### PR TITLE
Step1 - 지하철역 관리

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -17,6 +17,7 @@ repositories {
 dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-web'
 	implementation 'org.springframework.boot:spring-boot-starter-jdbc'
+	implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
 	implementation 'org.jgrapht:jgrapht-core:1.0.1'
 	implementation 'net.rakugakibox.spring.boot:logback-access-spring-boot-starter:2.7.1'
 	runtimeOnly 'com.h2database:h2'

--- a/src/main/java/atdd/AtddApplication.java
+++ b/src/main/java/atdd/AtddApplication.java
@@ -1,3 +1,24 @@
+/*
+ *
+ * AtddApplication
+ *
+ * 0.0.1
+ *
+ * Copyright 2020 irrationnelle <drakkarverenis@gmail.com>.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * */
 package atdd;
 
 import org.springframework.boot.SpringApplication;

--- a/src/main/java/atdd/station/Station.java
+++ b/src/main/java/atdd/station/Station.java
@@ -35,7 +35,8 @@ public class Station {
 
     protected Station() {}
 
-    public Station(String name) {
+    public Station(Long id, String name) {
+        this.id = id;
         this.name = name;
     }
 

--- a/src/main/java/atdd/station/Station.java
+++ b/src/main/java/atdd/station/Station.java
@@ -1,0 +1,35 @@
+/*
+ *
+ * Station
+ *
+ * 0.0.1
+ *
+ * Copyright 2020 irrationnelle <drakkarverenis@gmail.com>.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * */
+
+package atdd.station;
+
+public class Station {
+    private String name;
+
+    public Station(String name) {
+        this.name = name;
+    }
+
+    public String getName() {
+        return name;
+    }
+}

--- a/src/main/java/atdd/station/StationController.java
+++ b/src/main/java/atdd/station/StationController.java
@@ -56,4 +56,12 @@ public class StationController {
 
         return new ResponseEntity(station, HttpStatus.OK);
     }
+
+    @DeleteMapping("/stations/{id}")
+    public ResponseEntity deleteStation(@PathVariable String id) {
+        long castingId = Long.parseLong(id);
+        stationRepository.deleteById(castingId);
+
+        return ResponseEntity.ok().build();
+    }
 }

--- a/src/main/java/atdd/station/StationController.java
+++ b/src/main/java/atdd/station/StationController.java
@@ -27,6 +27,7 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
 import java.net.URI;
+import java.util.List;
 
 @RestController
 public class StationController {
@@ -36,9 +37,16 @@ public class StationController {
     @PostMapping("/stations")
     public ResponseEntity createStation(@RequestBody Station station) {
         Station savedStation = stationRepository.save(station);
-        String resultUri = String.format("/station/$d", savedStation.getId());
+        String resultUri = String.format("/stations/%d", savedStation.getId());
 
         return ResponseEntity.created(URI.create(resultUri)).build();
+    }
+
+    @GetMapping("/stations")
+    public ResponseEntity readStation() {
+        List<Station> stations = stationRepository.findAll();
+
+        return new ResponseEntity(stations, HttpStatus.OK);
     }
 
     @GetMapping("/stations/{id}")

--- a/src/main/java/atdd/station/StationController.java
+++ b/src/main/java/atdd/station/StationController.java
@@ -39,7 +39,7 @@ public class StationController {
         Station savedStation = stationRepository.save(station);
         String resultUri = String.format("/stations/%d", savedStation.getId());
 
-        return ResponseEntity.created(URI.create(resultUri)).build();
+        return ResponseEntity.created(URI.create(resultUri)).body(savedStation);
     }
 
     @GetMapping("/stations")

--- a/src/main/java/atdd/station/StationController.java
+++ b/src/main/java/atdd/station/StationController.java
@@ -1,3 +1,24 @@
+/*
+ *
+ * StationController
+ *
+ * 0.0.1
+ *
+ * Copyright 2020 irrationnelle <drakkarverenis@gmail.com>.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * */
 package atdd.station;
 
 import org.springframework.http.ResponseEntity;

--- a/src/main/java/atdd/station/StationController.java
+++ b/src/main/java/atdd/station/StationController.java
@@ -21,17 +21,24 @@
  * */
 package atdd.station;
 
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RestController;
 
 import java.net.URI;
 
 @RestController
 public class StationController {
+    @Autowired
+    private StationRepository stationRepository;
 
     @PostMapping("/stations")
-    public ResponseEntity createStation() {
-        return ResponseEntity.created(URI.create("/stations/1")).build();
+    public ResponseEntity createStation(@RequestBody Station station) {
+        Station savedStation = stationRepository.save(station);
+        String resultUri = String.format("/station/$d", savedStation.getId());
+
+        return ResponseEntity.created(URI.create(resultUri)).build();
     }
 }

--- a/src/main/java/atdd/station/StationController.java
+++ b/src/main/java/atdd/station/StationController.java
@@ -22,10 +22,9 @@
 package atdd.station;
 
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 import java.net.URI;
 
@@ -40,5 +39,13 @@ public class StationController {
         String resultUri = String.format("/station/$d", savedStation.getId());
 
         return ResponseEntity.created(URI.create(resultUri)).build();
+    }
+
+    @GetMapping("/stations/{id}")
+    public ResponseEntity readStation(@PathVariable String id) {
+        long castingId = Long.parseLong(id);
+        Station station = stationRepository.findById(castingId);
+
+        return new ResponseEntity(station, HttpStatus.OK);
     }
 }

--- a/src/main/java/atdd/station/StationRepository.java
+++ b/src/main/java/atdd/station/StationRepository.java
@@ -24,4 +24,5 @@ package atdd.station;
 import org.springframework.data.repository.CrudRepository;
 
 public interface StationRepository extends CrudRepository<Station, Long> {
+    Station findById(long id);
 }

--- a/src/main/java/atdd/station/StationRepository.java
+++ b/src/main/java/atdd/station/StationRepository.java
@@ -23,6 +23,10 @@ package atdd.station;
 
 import org.springframework.data.repository.CrudRepository;
 
+import java.util.List;
+
 public interface StationRepository extends CrudRepository<Station, Long> {
     Station findById(long id);
+
+    List<Station> findAll();
 }

--- a/src/main/java/atdd/station/StationRepository.java
+++ b/src/main/java/atdd/station/StationRepository.java
@@ -29,4 +29,6 @@ public interface StationRepository extends CrudRepository<Station, Long> {
     Station findById(long id);
 
     List<Station> findAll();
+
+    void deleteById(long id);
 }

--- a/src/main/java/atdd/station/StationRepository.java
+++ b/src/main/java/atdd/station/StationRepository.java
@@ -1,6 +1,6 @@
 /*
  *
- * Station
+ * StationRepository
  *
  * 0.0.1
  *
@@ -21,29 +21,7 @@
  * */
 package atdd.station;
 
-import javax.persistence.Entity;
-import javax.persistence.GeneratedValue;
-import javax.persistence.GenerationType;
-import javax.persistence.Id;
+import org.springframework.data.repository.CrudRepository;
 
-@Entity
-public class Station {
-    @Id
-    @GeneratedValue(strategy = GenerationType.AUTO)
-    private Long id;
-    private String name;
-
-    protected Station() {}
-
-    public Station(String name) {
-        this.name = name;
-    }
-
-    public String getName() {
-        return name;
-    }
-
-    public Long getId() {
-        return id;
-    }
+public interface StationRepository extends CrudRepository<Station, Long> {
 }

--- a/src/test/java/atdd/station/StationAcceptanceTest.java
+++ b/src/test/java/atdd/station/StationAcceptanceTest.java
@@ -93,8 +93,24 @@ public class StationAcceptanceTest {
                 .expectBody(Station.class)
                 .consumeWith(result -> {
                     Station station = result.getResponseBody();
-                    Assertions.assertThat(station.getName()).isEqualTo("강남역");
+                    Assertions.assertThat(station.getName())
+                              .isEqualTo("강남역");
                 });
+    }
+
+    @Test
+    public void testDeleteStation() {
+        testCreateStation();
+
+        String reqUri = String.format("%s/%d", prefixUri, targetStation.getId());
+
+        webTestClient.delete()
+                     .uri(reqUri)
+                     .exchange()
+                     .expectStatus()
+                     .isOk();
+
+        readRequestWebTestClient(reqUri).expectBody().isEmpty();
     }
 
     private WebTestClient.ResponseSpec readRequestWebTestClient(String uri) {

--- a/src/test/java/atdd/station/StationAcceptanceTest.java
+++ b/src/test/java/atdd/station/StationAcceptanceTest.java
@@ -39,6 +39,7 @@ public class StationAcceptanceTest {
     private static final Logger logger = LoggerFactory.getLogger(StationAcceptanceTest.class);
     private final Long id = new Long(1);
     private final Station targetStation = new Station(id, "강남역");
+    private final String prefixUri = "/stations";
 
     @Autowired
     private WebTestClient webTestClient;
@@ -46,9 +47,10 @@ public class StationAcceptanceTest {
     @Test
     public void testCreateStation() {
         String inputJson = String.format("{\"name\": \"%s\"}", targetStation.getName());
+        String reqUri = prefixUri;
 
         webTestClient.post()
-                     .uri("/stations")
+                     .uri(reqUri)
                      .contentType(MediaType.APPLICATION_JSON)
                      .body(Mono.just(inputJson), String.class)
                      .exchange()
@@ -60,7 +62,7 @@ public class StationAcceptanceTest {
     public void testReadStation() {
         testCreateStation();
 
-        String reqUri = "/stations/" + targetStation.getId();
+        String reqUri = String.format("%s/%d", prefixUri, targetStation.getId());
 
         webTestClient.get()
                      .uri(reqUri)

--- a/src/test/java/atdd/station/StationAcceptanceTest.java
+++ b/src/test/java/atdd/station/StationAcceptanceTest.java
@@ -1,3 +1,24 @@
+/*
+ *
+ * StationAcceptanceTest
+ *
+ * 0.0.1
+ *
+ * Copyright 2020 irrationnelle <drakkarverenis@gmail.com>.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * */
 package atdd.station;
 
 import org.junit.jupiter.api.Test;
@@ -16,15 +37,21 @@ import reactor.core.publisher.Mono;
 @AutoConfigureWebTestClient
 public class StationAcceptanceTest {
     private static final Logger logger = LoggerFactory.getLogger(StationAcceptanceTest.class);
+    private final Station targetStation = new Station("강남역");
 
     @Autowired
     private WebTestClient webTestClient;
 
     @Test
     public void test() {
-        String stationName = "강남역";
-        String inputJson = "{\"name\":\"" + stationName + "\"}";
+        String inputJson = String.format("{name: %s}", targetStation.getName());
 
-        webTestClient.post().uri("/stations").contentType(MediaType.APPLICATION_JSON).body(Mono.just(inputJson), String.class).exchange().expectStatus().isCreated();
+        webTestClient.post()
+                     .uri("/stations")
+                     .contentType(MediaType.APPLICATION_JSON)
+                     .body(Mono.just(inputJson), String.class)
+                     .exchange()
+                     .expectStatus()
+                     .isCreated();
     }
 }

--- a/src/test/java/atdd/station/StationAcceptanceTest.java
+++ b/src/test/java/atdd/station/StationAcceptanceTest.java
@@ -43,8 +43,8 @@ public class StationAcceptanceTest {
     private WebTestClient webTestClient;
 
     @Test
-    public void test() {
-        String inputJson = String.format("{name: %s}", targetStation.getName());
+    public void testCreateStation() {
+        String inputJson = String.format("{\"name\": \"%s\"}", targetStation.getName());
 
         webTestClient.post()
                      .uri("/stations")

--- a/src/test/java/atdd/station/StationAcceptanceTest.java
+++ b/src/test/java/atdd/station/StationAcceptanceTest.java
@@ -59,6 +59,21 @@ public class StationAcceptanceTest {
     }
 
     @Test
+    public void testReadStations() {
+        String reqUri = prefixUri;
+
+        webTestClient.get()
+                     .uri(reqUri)
+                     .accept(MediaType.APPLICATION_JSON)
+                     .exchange()
+                     .expectStatus()
+                     .isOk()
+                     .expectBodyList(Station.class)
+                     .hasSize(1)
+                     .contains(targetStation);
+    }
+
+    @Test
     public void testReadStation() {
         testCreateStation();
 

--- a/src/test/java/atdd/station/StationAcceptanceTest.java
+++ b/src/test/java/atdd/station/StationAcceptanceTest.java
@@ -21,7 +21,6 @@
  * */
 package atdd.station;
 
-import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.Test;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -38,7 +37,8 @@ import reactor.core.publisher.Mono;
 @AutoConfigureWebTestClient
 public class StationAcceptanceTest {
     private static final Logger logger = LoggerFactory.getLogger(StationAcceptanceTest.class);
-    private final Station targetStation = new Station("강남역");
+    private final Long id = new Long(1);
+    private final Station targetStation = new Station(id, "강남역");
 
     @Autowired
     private WebTestClient webTestClient;
@@ -58,16 +58,18 @@ public class StationAcceptanceTest {
 
     @Test
     public void testReadStation() {
+        testCreateStation();
+
+        String reqUri = "/stations/" + targetStation.getId();
+
         webTestClient.get()
-                     .uri("/stations/1")
+                     .uri(reqUri)
                      .accept(MediaType.APPLICATION_JSON)
                      .exchange()
                      .expectStatus()
                      .isOk()
-                     .expectBody(Station.class)
-                     .consumeWith(result -> {
-                         Assertions.assertThat(result)
-                                   .isEqualTo("강남역");
-                     });
+                     .expectBody()
+                     .jsonPath("$.name")
+                     .isEqualTo("강남역");
     }
 }

--- a/src/test/java/atdd/station/StationAcceptanceTest.java
+++ b/src/test/java/atdd/station/StationAcceptanceTest.java
@@ -88,9 +88,13 @@ public class StationAcceptanceTest {
         String reqUri = String.format("%s/%d", prefixUri, targetStation.getId());
 
         readRequestWebTestClient(reqUri)
-                .expectBody()
-                .jsonPath("$.name")
-                .isEqualTo("강남역");
+                .expectHeader()
+                .contentType(MediaType.APPLICATION_JSON)
+                .expectBody(Station.class)
+                .consumeWith(result -> {
+                    Station station = result.getResponseBody();
+                    Assertions.assertThat(station.getName()).isEqualTo("강남역");
+                });
     }
 
     private WebTestClient.ResponseSpec readRequestWebTestClient(String uri) {

--- a/src/test/java/atdd/station/StationAcceptanceTest.java
+++ b/src/test/java/atdd/station/StationAcceptanceTest.java
@@ -21,6 +21,7 @@
  * */
 package atdd.station;
 
+import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.Test;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -53,5 +54,20 @@ public class StationAcceptanceTest {
                      .exchange()
                      .expectStatus()
                      .isCreated();
+    }
+
+    @Test
+    public void testReadStation() {
+        webTestClient.get()
+                     .uri("/stations/1")
+                     .accept(MediaType.APPLICATION_JSON)
+                     .exchange()
+                     .expectStatus()
+                     .isOk()
+                     .expectBody(Station.class)
+                     .consumeWith(result -> {
+                         Assertions.assertThat(result)
+                                   .isEqualTo("강남역");
+                     });
     }
 }

--- a/src/test/java/atdd/station/StationAcceptanceTest.java
+++ b/src/test/java/atdd/station/StationAcceptanceTest.java
@@ -62,15 +62,10 @@ public class StationAcceptanceTest {
     public void testReadStations() {
         String reqUri = prefixUri;
 
-        webTestClient.get()
-                     .uri(reqUri)
-                     .accept(MediaType.APPLICATION_JSON)
-                     .exchange()
-                     .expectStatus()
-                     .isOk()
-                     .expectBodyList(Station.class)
-                     .hasSize(1)
-                     .contains(targetStation);
+        readRequestWebTestClient(reqUri)
+                .expectBodyList(Station.class)
+                .hasSize(1)
+                .contains(targetStation);
     }
 
     @Test
@@ -79,14 +74,18 @@ public class StationAcceptanceTest {
 
         String reqUri = String.format("%s/%d", prefixUri, targetStation.getId());
 
-        webTestClient.get()
-                     .uri(reqUri)
-                     .accept(MediaType.APPLICATION_JSON)
-                     .exchange()
-                     .expectStatus()
-                     .isOk()
-                     .expectBody()
-                     .jsonPath("$.name")
-                     .isEqualTo("강남역");
+        readRequestWebTestClient(reqUri)
+                .expectBody()
+                .jsonPath("$.name")
+                .isEqualTo("강남역");
+    }
+
+    private WebTestClient.ResponseSpec readRequestWebTestClient(String uri) {
+        return webTestClient.get()
+                            .uri(uri)
+                            .accept(MediaType.APPLICATION_JSON)
+                            .exchange()
+                            .expectStatus()
+                            .isOk();
     }
 }

--- a/src/test/java/atdd/station/StationAcceptanceTest.java
+++ b/src/test/java/atdd/station/StationAcceptanceTest.java
@@ -21,6 +21,7 @@
  * */
 package atdd.station;
 
+import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.Test;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -31,6 +32,8 @@ import org.springframework.http.MediaType;
 import org.springframework.test.annotation.DirtiesContext;
 import org.springframework.test.web.reactive.server.WebTestClient;
 import reactor.core.publisher.Mono;
+
+import java.util.List;
 
 @DirtiesContext(classMode = DirtiesContext.ClassMode.BEFORE_EACH_TEST_METHOD)
 @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
@@ -60,12 +63,22 @@ public class StationAcceptanceTest {
 
     @Test
     public void testReadStations() {
+        testCreateStation();
+
         String reqUri = prefixUri;
 
         readRequestWebTestClient(reqUri)
+                .expectHeader()
+                .contentType(MediaType.APPLICATION_JSON)
                 .expectBodyList(Station.class)
                 .hasSize(1)
-                .contains(targetStation);
+                .consumeWith(result -> {
+                    List<Station> stations = result.getResponseBody();
+                    Station station = stations.get(0);
+
+                    Assertions.assertThat(station.getName())
+                              .isEqualTo("강남역");
+                });
     }
 
     @Test


### PR DESCRIPTION
- 인수테스트는 실제 사용 시나리오를 따라가야 한다고 하셔서 given 조건에 있는 것을 mocking이 없이 하려니 앞서 만들었던 `testCreateStation` 를 다른 테스트에서 먼저 실행 시켜주어야 했었습니다. 테스트 코드가 다른 테스트에 의존성(?)을 가진다는 것이 조금 이상하게 느껴집니다.

- 또한 매 테스트마다  `testCreateStation` 를 실행하려 하니 `@Before` 어노테이션을 이용하려고 했습니다. 하지만 이 경우 `testCreateStation` 메소드에서는 `@Before` 어노테이션을 적용하면 안 되기 때문에, 관련 자료를 찾아보니 특정 테스트 메소드에만 어노테이션을 적용하는 방법보다는 각 테스트를 분리해야 할 신호라고 받아들이고 테스트를 분리하라고 합니다. 이 부분에 대해서도 궁금합니다.

- 자바 언어를 다루는 것이 정말 오랜만이고 비즈니스 로직은 처음 다뤄보는 것이라 그런지 테스트 코드가 기대대로 작동하지 않아서 다음과 같은 과정이 빈번합니다. 

    1. 테스트 작성
    2. 테스트 실패
    3. 테스트 통과를 위한 코드 작성
    4. 결과 직접 확인
    5. 테스트 코드의 수정 필요성을 느낌
    6. 테스트 코드 수정
    7. 테스트 통과

 그런데 테스트를 억지로 코드에 맞추는 느낌이라 어색하네요. 언어와 프레임워크에 적응하는 동안은 어쩔 수 없는 것인지 언어와 프레임워크의 명세를 공식 문서에서 꼼꼼히 살펴보고 최대한 5와 6의 과정을 줄여야 하는지 궁금합니다.
 