### PR TITLE
Step2

### DIFF
--- a/src/main/java/atdd/edge/domain/Edge.java
+++ b/src/main/java/atdd/edge/domain/Edge.java
@@ -1,0 +1,39 @@
+package atdd.edge.domain;
+
+import atdd.line.domain.Line;
+import atdd.station.domain.Station;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import javax.persistence.*;
+
+import static javax.persistence.FetchType.LAZY;
+
+@Getter
+@NoArgsConstructor
+@Entity
+public class Edge {
+
+	@Id
+	@GeneratedValue
+	@Column(name = "EDGE_ID")
+	private Long id;
+
+	@ManyToOne(fetch = LAZY)
+	@JoinColumn(name = "LINE_ID")
+	private Line line;
+
+	@Column(name = "ELAPSED_TIME")
+	private int elapsedTime;
+
+	@Column(name = "DISTANCE")
+	private int distance;
+
+	@OneToOne(fetch = LAZY)
+	@JoinColumn(name = "SOURCE_STATION_ID")
+	private Station sourceStation;
+
+	@OneToOne(fetch = LAZY)
+	@JoinColumn(name = "TARGET_STATION_ID")
+	private Station targetStation;
+}

--- a/src/main/java/atdd/edge/domain/Edge.java
+++ b/src/main/java/atdd/edge/domain/Edge.java
@@ -2,6 +2,7 @@ package atdd.edge.domain;
 
 import atdd.line.domain.Line;
 import atdd.station.domain.Station;
+import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
@@ -24,10 +25,10 @@ public class Edge {
 	private Line line;
 
 	@Column(name = "ELAPSED_TIME")
-	private int elapsedTime;
+	private double elapsedTime;	// 소요시간(분)
 
 	@Column(name = "DISTANCE")
-	private int distance;
+	private double distance;		// 거리(km)
 
 	@OneToOne(fetch = LAZY)
 	@JoinColumn(name = "SOURCE_STATION_ID")
@@ -36,4 +37,22 @@ public class Edge {
 	@OneToOne(fetch = LAZY)
 	@JoinColumn(name = "TARGET_STATION_ID")
 	private Station targetStation;
+
+	@Builder
+	public Edge(final Line line, double elapsedTime, double distance, Station sourceStation, Station targetStation) {
+		this.line = line;
+		this.elapsedTime = elapsedTime;
+		this.distance = distance;
+		this.sourceStation = sourceStation;
+		this.targetStation = targetStation;
+	}
+
+	public void applyStations(Station sourceStation, Station targetStation) {
+		this.sourceStation = sourceStation;
+		this.targetStation = targetStation;
+	}
+
+	public void applyLine(final Line line) {
+		this.line = line;
+	}
 }

--- a/src/main/java/atdd/edge/domain/EdgeRepository.java
+++ b/src/main/java/atdd/edge/domain/EdgeRepository.java
@@ -1,0 +1,10 @@
+package atdd.edge.domain;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.List;
+
+public interface EdgeRepository extends JpaRepository<Edge, Long> {
+
+	List<Edge> findAllByLine(Long id);
+}

--- a/src/main/java/atdd/line/controller/LineController.java
+++ b/src/main/java/atdd/line/controller/LineController.java
@@ -1,0 +1,47 @@
+package atdd.line.controller;
+
+import atdd.line.domain.Line;
+import atdd.line.dto.CreateLineAndStationsRequest;
+import atdd.line.dto.CreateLineRequest;
+import atdd.line.dto.FindLineResponse;
+import atdd.line.service.LineService;
+import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+import java.net.URI;
+import java.util.List;
+
+@RestController
+public class LineController {
+
+	private LineService lineService;
+
+	public LineController(final LineService lineService) {
+		this.lineService = lineService;
+	}
+
+	@PostMapping("/lines")
+	public ResponseEntity<Line> createLine(@RequestBody CreateLineRequest request) {
+		Line line = lineService.save(request);
+		return ResponseEntity.created(URI.create("/lines" + line.getId()))
+			.contentType(MediaType.APPLICATION_JSON)
+			.body(line);
+	}
+
+	@PostMapping("/line-stations")
+	public ResponseEntity<Line> createLineAndStations(@RequestBody CreateLineAndStationsRequest request) {
+		Line line = lineService.saveLineAndStations(request);
+		return ResponseEntity.ok(line);
+	}
+
+	@GetMapping("/lines")
+	public ResponseEntity<List<Line>> findAll() {
+		return ResponseEntity.ok(lineService.findAll());
+	}
+
+	@GetMapping("/line")
+	public ResponseEntity<FindLineResponse> findByName(@RequestParam("name") String name) {
+		return ResponseEntity.ok(lineService.findByName(name));
+	}
+}

--- a/src/main/java/atdd/line/domain/Line.java
+++ b/src/main/java/atdd/line/domain/Line.java
@@ -1,0 +1,32 @@
+package atdd.line.domain;
+
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import javax.persistence.Column;
+import javax.persistence.Entity;
+import javax.persistence.GeneratedValue;
+import javax.persistence.Id;
+
+@Getter
+@NoArgsConstructor
+@Entity
+public class Line {
+
+	@Id
+	@GeneratedValue
+	@Column(name = "LINE_ID")
+	private Long id;
+
+	@Column(name = "NAME")
+	private String name;
+
+	@Column(name = "START_TIME")
+	private String startTime;
+
+	@Column(name = "END_TIME")
+	private String endTime;
+
+	@Column(name = "INTERVAL_TIME")
+	private String intervalTime;
+}

--- a/src/main/java/atdd/line/domain/Line.java
+++ b/src/main/java/atdd/line/domain/Line.java
@@ -1,5 +1,6 @@
 package atdd.line.domain;
 
+import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
@@ -29,4 +30,12 @@ public class Line {
 
 	@Column(name = "INTERVAL_TIME")
 	private String intervalTime;
+
+	@Builder
+	public Line(final String name, final String startTime, final String endTime, final String intervalTime) {
+		this.name = name;
+		this.startTime = startTime;
+		this.endTime = endTime;
+		this.intervalTime = intervalTime;
+	}
 }

--- a/src/main/java/atdd/line/domain/LineRepository.java
+++ b/src/main/java/atdd/line/domain/LineRepository.java
@@ -1,0 +1,10 @@
+package atdd.line.domain;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.Optional;
+
+public interface LineRepository extends JpaRepository<Line, Long> {
+
+	Optional<Line> findByName(String name);
+}

--- a/src/main/java/atdd/line/dto/CreateEdgeRequest.java
+++ b/src/main/java/atdd/line/dto/CreateEdgeRequest.java
@@ -1,0 +1,28 @@
+package atdd.line.dto;
+
+import atdd.edge.domain.Edge;
+import atdd.station.domain.Station;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+public class CreateEdgeRequest {
+
+	private double elapsedTime;
+	private double distance;
+
+	@Builder
+	public CreateEdgeRequest(final double elapsedTime, final double distance) {
+		this.elapsedTime = elapsedTime;
+		this.distance = distance;
+	}
+
+	public Edge toEntity(final Station sourceStation, final Station targetStation) {
+		return Edge.builder()
+			.elapsedTime(elapsedTime)
+			.distance(distance)
+			.sourceStation(sourceStation)
+			.targetStation(targetStation)
+			.build();
+	}
+}

--- a/src/main/java/atdd/line/dto/CreateEdgesAndStationsRequest.java
+++ b/src/main/java/atdd/line/dto/CreateEdgesAndStationsRequest.java
@@ -1,0 +1,22 @@
+package atdd.line.dto;
+
+import atdd.station.dto.CreateStationRequest;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+public class CreateEdgesAndStationsRequest {
+
+	private CreateEdgeRequest edge;
+	private CreateStationRequest sourceStation;
+	private CreateStationRequest targetStation;
+
+	@Builder
+	public CreateEdgesAndStationsRequest(final CreateEdgeRequest edge,
+										 final CreateStationRequest sourceStation,
+										 final CreateStationRequest targetStation) {
+		this.edge = edge;
+		this.sourceStation = sourceStation;
+		this.targetStation = targetStation;
+	}
+}

--- a/src/main/java/atdd/line/dto/CreateLineAndStationsRequest.java
+++ b/src/main/java/atdd/line/dto/CreateLineAndStationsRequest.java
@@ -1,0 +1,23 @@
+package atdd.line.dto;
+
+import atdd.line.domain.Line;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.util.List;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
+public class CreateLineAndStationsRequest {
+
+	private Line line;
+	private List<CreateEdgesAndStationsRequest> edgesAndStations;
+
+	@Builder
+	public CreateLineAndStationsRequest(final Line line, final List<CreateEdgesAndStationsRequest> edgesAndStations) {
+		this.line = line;
+		this.edgesAndStations = edgesAndStations;
+	}
+}

--- a/src/main/java/atdd/line/dto/CreateLineRequest.java
+++ b/src/main/java/atdd/line/dto/CreateLineRequest.java
@@ -1,0 +1,31 @@
+package atdd.line.dto;
+
+import atdd.line.domain.Line;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+public class CreateLineRequest {
+
+	private String name;
+	private String startTime;
+	private String endTime;
+	private String intervalTime;
+
+	@Builder
+	public CreateLineRequest(final String name, final String startTime, final String endTime, final String intervalTime) {
+		this.name = name;
+		this.startTime = startTime;
+		this.endTime = endTime;
+		this.intervalTime = intervalTime;
+	}
+
+	public Line toEntity() {
+		return Line.builder()
+			.name(name)
+			.startTime(startTime)
+			.endTime(endTime)
+			.intervalTime(intervalTime)
+			.build();
+	}
+}

--- a/src/main/java/atdd/line/dto/FindLineResponse.java
+++ b/src/main/java/atdd/line/dto/FindLineResponse.java
@@ -1,0 +1,29 @@
+package atdd.line.dto;
+
+import atdd.line.domain.Line;
+import atdd.station.domain.Station;
+import lombok.Builder;
+import lombok.Getter;
+
+import java.util.List;
+
+@Getter
+public class FindLineResponse {
+
+	private Long id;
+	private String name;
+	private String startTime;
+	private String endTime;
+	private String intervalTime;
+	private List<Station> stations;
+
+	@Builder
+	public FindLineResponse(final Line line, final List<Station> stations) {
+		this.id = line.getId();
+		this.name = line.getName();
+		this.startTime = line.getStartTime();
+		this.endTime = line.getEndTime();
+		this.intervalTime = line.getIntervalTime();
+		this.stations = stations;
+	}
+}

--- a/src/main/java/atdd/line/service/LineService.java
+++ b/src/main/java/atdd/line/service/LineService.java
@@ -1,0 +1,19 @@
+package atdd.line.service;
+
+import atdd.line.domain.Line;
+import atdd.line.dto.CreateLineAndStationsRequest;
+import atdd.line.dto.CreateLineRequest;
+import atdd.line.dto.FindLineResponse;
+
+import java.util.List;
+
+public interface LineService {
+
+	Line save(CreateLineRequest request);
+
+	Line saveLineAndStations(CreateLineAndStationsRequest request);
+
+	List<Line> findAll();
+
+	FindLineResponse findByName(String name);
+}

--- a/src/main/java/atdd/line/service/LineServiceImpl.java
+++ b/src/main/java/atdd/line/service/LineServiceImpl.java
@@ -1,0 +1,98 @@
+package atdd.line.service;
+
+import atdd.edge.domain.Edge;
+import atdd.edge.domain.EdgeRepository;
+import atdd.line.domain.Line;
+import atdd.line.domain.LineRepository;
+import atdd.line.dto.CreateEdgesAndStationsRequest;
+import atdd.line.dto.CreateLineAndStationsRequest;
+import atdd.line.dto.CreateLineRequest;
+import atdd.line.dto.FindLineResponse;
+import atdd.station.domain.Station;
+import atdd.station.domain.StationRepository;
+import atdd.station.dto.CreateStationRequest;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import javax.persistence.EntityNotFoundException;
+import java.util.ArrayList;
+import java.util.List;
+
+@Service
+public class LineServiceImpl implements LineService {
+
+	private LineRepository lineRepository;
+	private StationRepository stationRepository;
+	private EdgeRepository edgeRepository;
+
+	public LineServiceImpl(final LineRepository lineRepository, final StationRepository stationRepository,
+						   final EdgeRepository edgeRepository) {
+		this.lineRepository = lineRepository;
+		this.stationRepository = stationRepository;
+		this.edgeRepository = edgeRepository;
+	}
+
+	@Override
+	@Transactional
+	public Line save(CreateLineRequest request) {
+		return lineRepository.save(request.toEntity());
+	}
+
+	@Override
+	@Transactional
+	public Line saveLineAndStations(final CreateLineAndStationsRequest request) {
+		Line line = request.getLine();
+		List<CreateEdgesAndStationsRequest> edgesAndStationsRequests = request.getEdgesAndStations();
+		for (CreateEdgesAndStationsRequest edgesAndStations : edgesAndStationsRequests) {
+			CreateStationRequest sourceStationRequest = edgesAndStations.getSourceStation();
+			CreateStationRequest targetStationRequest = edgesAndStations.getTargetStation();
+
+			Station sourceStation = stationRepository.save(sourceStationRequest.toEntity());
+			Station targetStation = stationRepository.save(targetStationRequest.toEntity());
+			Edge edge = edgesAndStations.getEdge().toEntity(sourceStation, targetStation);
+			edge.applyStations(sourceStation, targetStation);
+			edge.applyLine(line);
+			edgeRepository.save(edge);
+		}
+		return lineRepository.save(line);
+	}
+
+	@Override
+	@Transactional(readOnly = true)
+	public List<Line> findAll() {
+		return lineRepository.findAll();
+	}
+
+	@Override
+	@Transactional(readOnly = true)
+	public FindLineResponse findByName(String name) {
+		Line line = lineRepository.findByName(name)
+			.orElseThrow(() -> new EntityNotFoundException("해당 노선이 없습니다."));
+		List<Edge> edges = edgeRepository.findAllByLine(line.getId());
+		List<Station> stations = getStationsUsing(edges);
+		return FindLineResponse.builder()
+			.line(line)
+			.stations(stations)
+			.build();
+	}
+
+	private List<Station> getStationsUsing(final List<Edge> edges) {
+		List<Station> stations = new ArrayList<>();
+		for (Edge edge : edges) {
+			Station sourceStation = edge.getSourceStation();
+			Station targetStation = edge.getTargetStation();
+			addToListOnlyIfNotExists(stations, sourceStation, targetStation);
+		}
+		return stations;
+	}
+
+	private void addToListOnlyIfNotExists(final List<Station> stations,
+										  final Station sourceStation, final Station targetStation) {
+		if (!stations.contains(sourceStation)) {
+			stations.add(sourceStation);
+		}
+		if (!stations.contains(targetStation)) {
+			stations.add(targetStation);
+		}
+	}
+}

--- a/src/main/java/atdd/station/CustomRestExceptionHandler.java
+++ b/src/main/java/atdd/station/CustomRestExceptionHandler.java
@@ -1,5 +1,6 @@
 package atdd.station;
 
+import atdd.station.domain.Station;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.ExceptionHandler;
@@ -11,6 +12,6 @@ public class CustomRestExceptionHandler extends ResponseEntityExceptionHandler {
 
 	@ExceptionHandler(IllegalArgumentException.class)
 	public ResponseEntity<Station> handleIllegalArgumentException() {
-		return new ResponseEntity<>(null, HttpStatus.NOT_FOUND);
+		return new ResponseEntity<>(null, HttpStatus.NO_CONTENT);
 	}
 }

--- a/src/main/java/atdd/station/StationRepository.java
+++ b/src/main/java/atdd/station/StationRepository.java
@@ -1,8 +1,6 @@
 package atdd.station;
 
 import org.springframework.data.jpa.repository.JpaRepository;
-import org.springframework.data.jpa.repository.Query;
-import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
 import java.util.Optional;
@@ -10,6 +8,5 @@ import java.util.Optional;
 @Repository
 public interface StationRepository extends JpaRepository<Station, Long> {
 
-	@Query("select s from Station s where s.name = :name")
-	Optional<Station> findByName(@Param("name") String name);
+	Optional<Station> findByName(String name);
 }

--- a/src/main/java/atdd/station/controller/StationController.java
+++ b/src/main/java/atdd/station/controller/StationController.java
@@ -1,5 +1,8 @@
-package atdd.station;
+package atdd.station.controller;
 
+import atdd.station.domain.Station;
+import atdd.station.domain.StationRepository;
+import atdd.station.dto.CreateStationRequest;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;

--- a/src/main/java/atdd/station/domain/Station.java
+++ b/src/main/java/atdd/station/domain/Station.java
@@ -4,6 +4,7 @@ import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
+import javax.persistence.Column;
 import javax.persistence.Entity;
 import javax.persistence.GeneratedValue;
 import javax.persistence.Id;
@@ -15,8 +16,10 @@ public class Station {
 
 	@Id
 	@GeneratedValue
+	@Column(name = "STATION_ID")
 	private Long id;
 
+	@Column(name = "NAME")
 	private String name;
 
 	@Builder

--- a/src/main/java/atdd/station/domain/Station.java
+++ b/src/main/java/atdd/station/domain/Station.java
@@ -1,4 +1,4 @@
-package atdd.station;
+package atdd.station.domain;
 
 import lombok.Builder;
 import lombok.Getter;

--- a/src/main/java/atdd/station/domain/StationRepository.java
+++ b/src/main/java/atdd/station/domain/StationRepository.java
@@ -1,4 +1,4 @@
-package atdd.station;
+package atdd.station.domain;
 
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;

--- a/src/main/java/atdd/station/dto/CreateStationRequest.java
+++ b/src/main/java/atdd/station/dto/CreateStationRequest.java
@@ -1,5 +1,6 @@
-package atdd.station;
+package atdd.station.dto;
 
+import atdd.station.domain.Station;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;

--- a/src/main/java/atdd/station/dto/CreateStationRequest.java
+++ b/src/main/java/atdd/station/dto/CreateStationRequest.java
@@ -1,12 +1,13 @@
 package atdd.station.dto;
 
 import atdd.station.domain.Station;
+import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 @Getter
-@NoArgsConstructor
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
 public class CreateStationRequest {
 
 	private String name;

--- a/src/main/java/atdd/station/dto/StationResponse.java
+++ b/src/main/java/atdd/station/dto/StationResponse.java
@@ -1,0 +1,16 @@
+package atdd.station.dto;
+
+import atdd.station.domain.Station;
+import lombok.Getter;
+
+@Getter
+public class StationResponse {
+
+	private Long id;
+	private String name;
+
+	public StationResponse(Station entity) {
+		this.id = entity.getId();
+		this.name = entity.getName();
+	}
+}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -4,3 +4,15 @@ spring:
     url: jdbc:h2:mem:testdb
     username: sa
     password: password
+
+  jpa:
+    hibernate:
+      ddl-auto: create
+    properties:
+      hibernate:
+#        show_sql: true
+        format_sql: true
+
+logging.level:
+  org.hibernate.SQL: debug
+  org.hibernate.type: trace

--- a/src/test/java/atdd/edge/EdgeAcceptanceTest.java
+++ b/src/test/java/atdd/edge/EdgeAcceptanceTest.java
@@ -1,0 +1,22 @@
+package atdd.edge;
+
+import org.junit.jupiter.api.DisplayName;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.reactive.AutoConfigureWebTestClient;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.annotation.DirtiesContext;
+import org.springframework.test.web.reactive.server.WebTestClient;
+
+@DisplayName("지하철 노선에 지하철 구간을 추가/제거")
+@AutoConfigureWebTestClient
+@DirtiesContext(classMode = DirtiesContext.ClassMode.BEFORE_EACH_TEST_METHOD)
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
+public class EdgeAcceptanceTest {
+	private static final Logger logger = LoggerFactory.getLogger(EdgeAcceptanceTest.class);
+
+	@Autowired
+	private WebTestClient webTestClient;
+
+}

--- a/src/test/java/atdd/line/LineAcceptanceTest.java
+++ b/src/test/java/atdd/line/LineAcceptanceTest.java
@@ -1,0 +1,22 @@
+package atdd.line;
+
+import org.junit.jupiter.api.DisplayName;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.reactive.AutoConfigureWebTestClient;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.annotation.DirtiesContext;
+import org.springframework.test.web.reactive.server.WebTestClient;
+
+@DisplayName("지하철 노선 관리")
+@DirtiesContext(classMode = DirtiesContext.ClassMode.BEFORE_EACH_TEST_METHOD)
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
+@AutoConfigureWebTestClient
+public class LineAcceptanceTest {
+	private static final Logger logger = LoggerFactory.getLogger(LineAcceptanceTest.class);
+
+	@Autowired
+	private WebTestClient webTestClient;
+
+}

--- a/src/test/java/atdd/line/LineAcceptanceTest.java
+++ b/src/test/java/atdd/line/LineAcceptanceTest.java
@@ -1,22 +1,203 @@
 package atdd.line;
 
+import atdd.line.domain.Line;
+import atdd.line.dto.CreateEdgeRequest;
+import atdd.line.dto.CreateEdgesAndStationsRequest;
+import atdd.line.dto.CreateLineAndStationsRequest;
+import atdd.line.dto.CreateLineRequest;
+import atdd.station.dto.CreateStationRequest;
 import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.reactive.AutoConfigureWebTestClient;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.http.MediaType;
 import org.springframework.test.annotation.DirtiesContext;
+import org.springframework.test.web.reactive.server.EntityExchangeResult;
 import org.springframework.test.web.reactive.server.WebTestClient;
+import reactor.core.publisher.Mono;
+
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
 
 @DisplayName("지하철 노선 관리")
+@AutoConfigureWebTestClient
 @DirtiesContext(classMode = DirtiesContext.ClassMode.BEFORE_EACH_TEST_METHOD)
 @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
-@AutoConfigureWebTestClient
 public class LineAcceptanceTest {
 	private static final Logger logger = LoggerFactory.getLogger(LineAcceptanceTest.class);
 
 	@Autowired
 	private WebTestClient webTestClient;
 
+	@DisplayName("지하철 노선 등록")
+	@Test
+	void createLine() {
+		// given
+		CreateLineRequest request = CreateLineRequest.builder()
+			.name("2호선")
+			.startTime("05:00")
+			.endTime("23:50")
+			.intervalTime("10")
+			.build();
+
+		// when (관리자는 "2호선" 지하철 노선 등록을 요청한다.)
+		// then ("2호선" 지하철 노선이 등록 되었다.)
+		webTestClient.post().uri("/lines")
+			.contentType(MediaType.APPLICATION_JSON)
+			.accept(MediaType.APPLICATION_JSON)
+			.body(Mono.just(request), CreateLineAndStationsRequest.class)
+			.exchange()
+			.expectStatus().isCreated()
+			.expectHeader().contentType(MediaType.APPLICATION_JSON)
+			.expectHeader().exists("Location")
+			.expectBody()
+			.jsonPath("$.name").isEqualTo("2호선")
+			.jsonPath("$.startTime").isEqualTo("05:00")
+			.jsonPath("$.endTime").isEqualTo("23:50")
+			.jsonPath("$.intervalTime").isEqualTo("10");
+	}
+
+	@DisplayName("지하철 노선 목록 조회")
+	@Test
+	void findAllLines() {
+		// given ("2호선" 지하철 노선이 등록되어 있다.)
+		createLineStub();
+
+		// when (사용자는 지하철 노선의 목록 조회를 요청한다.)
+		EntityExchangeResult<List<Line>> result = webTestClient.get().uri("/lines")
+			.accept(MediaType.APPLICATION_JSON)
+			.exchange()
+			.expectStatus().isOk()
+			.expectHeader().contentType(MediaType.APPLICATION_JSON)
+			.expectBodyList(Line.class)
+			.returnResult();
+
+		// then (지하철 노선의 목록을 응답받는다.)
+		assertThat(result.getResponseBody()).flatExtracting(Line::getName)
+			.contains("2호선");
+	}
+
+	@DisplayName("지하철 노선 정보 조회")
+	@Test
+	void findLine() {
+		// given ("2호선" 지하철 노선이 등록되어 있다.)
+		Line line = CreateLineRequest.builder()
+			.name("2호선")
+			.startTime("05:00")
+			.endTime("23:50")
+			.intervalTime("10")
+			.build().toEntity();
+		CreateLineAndStationsRequest createLineAndStationsRequest = CreateLineAndStationsRequest.builder()
+			.line(line)
+			.edgesAndStations(createEdgesAndStationsRequests())
+			.build();
+		webTestClient.post().uri("/line-stations")
+			.contentType(MediaType.APPLICATION_JSON)
+			.accept(MediaType.APPLICATION_JSON)
+			.body(Mono.just(createLineAndStationsRequest), CreateLineAndStationsRequest.class)
+			.exchange();
+
+		// when (사용자는 "2호선" 지하철 노선의 정보 조회를 요청한다.)
+		// then ("2호선" 지하철 노선의 정보를 응답받는다.)
+		webTestClient.get().uri(uriBuilder -> uriBuilder
+			.path("/line")
+			.queryParam("name", "2호선")
+			.build())
+			.accept(MediaType.APPLICATION_JSON)
+			.exchange()
+			.expectStatus().isOk()
+			.expectHeader().contentType(MediaType.APPLICATION_JSON)
+			.expectBody()
+			.jsonPath("$.name").isEqualTo("2호선")
+			.jsonPath("$.startTime").isEqualTo("05:00")
+			.jsonPath("$.endTime").isEqualTo("23:50")
+			.jsonPath("$.intervalTime").isEqualTo("10")
+			.jsonPath("$.stations").isNotEmpty();
+	}
+
+	@DisplayName("지하철 노선 삭제")
+	@Test
+	void deleteLine() {
+		// given ("2호선" 지하철 노선이 등록되어 있다.)
+
+		// when (관리자는 "2호선" 지하철 노선 삭제를 요청한다.)
+
+		// then ("2호선" 지하철 노선이 삭제되었다.)
+	}
+
+	private void createLineStub() {
+		CreateLineRequest request = CreateLineRequest.builder()
+			.name("2호선")
+			.startTime("05:00")
+			.endTime("23:50")
+			.intervalTime("10")
+			.build();
+		webTestClient.post().uri("/lines")
+			.contentType(MediaType.APPLICATION_JSON)
+			.accept(MediaType.APPLICATION_JSON)
+			.body(Mono.just(request), CreateLineAndStationsRequest.class)
+			.exchange();
+	}
+
+	// TODO: 별도 클래스로 분리, static 변수화
+	private List<CreateEdgesAndStationsRequest> createEdgesAndStationsRequests() {
+		return List.of(
+			CreateEdgesAndStationsRequest.builder()
+				.edge(CreateEdgeRequest.builder()
+					.elapsedTime(2.0)
+					.distance(1.2)
+					.build()
+				)
+				.sourceStation(CreateStationRequest.builder()
+					.name("교대역")
+					.build())
+				.targetStation(CreateStationRequest.builder()
+					.name("강남역")
+					.build())
+				.build(),
+			CreateEdgesAndStationsRequest.builder()
+				.edge(CreateEdgeRequest.builder()
+					.elapsedTime(1.5)
+					.distance(0.8)
+					.build()
+				)
+				.sourceStation(CreateStationRequest.builder()
+					.name("강남역")
+					.build())
+				.targetStation(CreateStationRequest.builder()
+					.name("역삼역")
+					.build())
+				.build(),
+			CreateEdgesAndStationsRequest.builder()
+				.edge(CreateEdgeRequest.builder()
+					.elapsedTime(2.0)
+					.distance(1.2)
+					.build()
+				)
+				.sourceStation(CreateStationRequest.builder()
+					.name("역삼역")
+					.build())
+				.targetStation(CreateStationRequest.builder()
+					.name("선릉역")
+					.build())
+				.build(),
+			CreateEdgesAndStationsRequest.builder()
+				.edge(CreateEdgeRequest.builder()
+					.elapsedTime(2.0)
+					.distance(1.3)
+					.build()
+				)
+				.sourceStation(CreateStationRequest.builder()
+					.name("선릉역")
+					.build())
+				.targetStation(CreateStationRequest.builder()
+					.name("삼성역")
+					.build())
+				.build()
+		);
+	}
 }

--- a/src/test/java/atdd/station/StationAcceptanceTest.java
+++ b/src/test/java/atdd/station/StationAcceptanceTest.java
@@ -1,5 +1,7 @@
 package atdd.station;
 
+import atdd.station.domain.Station;
+import atdd.station.dto.CreateStationRequest;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.slf4j.Logger;

--- a/src/test/java/atdd/station/StationAcceptanceTest.java
+++ b/src/test/java/atdd/station/StationAcceptanceTest.java
@@ -1,5 +1,6 @@
 package atdd.station;
 
+import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -16,6 +17,7 @@ import java.util.List;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
+@DisplayName("지하철역 관리")
 @DirtiesContext(classMode = DirtiesContext.ClassMode.BEFORE_EACH_TEST_METHOD)
 @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
 @AutoConfigureWebTestClient
@@ -25,6 +27,7 @@ public class StationAcceptanceTest {
     @Autowired
     private WebTestClient webTestClient;
 
+    @DisplayName("1개의 지하철역을 등록")
     @Test
     void createStation() {
         // given
@@ -45,6 +48,7 @@ public class StationAcceptanceTest {
             .jsonPath("$.name").isEqualTo(request.getName());
     }
 
+    @DisplayName("모든 지하철역 목록을 조회")
     @Test
     void findAllStations() {
         // given
@@ -71,6 +75,7 @@ public class StationAcceptanceTest {
             .contains("강남역");
     }
 
+    @DisplayName("특정 지하철역의 정보를 조회")
     @Test
     void findStationByName() {
         // given
@@ -97,6 +102,7 @@ public class StationAcceptanceTest {
                 .jsonPath("$.name").isEqualTo(request.getName());
     }
 
+    @DisplayName("특정 지하철역을 삭제")
     @Test
     void deleteStationByName() {
         // given


### PR DESCRIPTION
안녕하세요, step2 중간 리뷰 요청드립니다. 아직 2단계 구현이 완료되지 않은 상태라, 사실 리뷰라기보다는 도움을 요청드리려고 합니다.  
지하철 노선 정보 조회 API를 구현하다가 막혔습니다. JPA에 익숙하지 않지만 그래도 시도해보고 있는데 시행착오가 많네요ㅠ
 
- "지하철 노선 목록 조회"를 호출하면 결국 `stations`가 응답결과에 포함되어야 하기 때문에, given 단계에서 먼저 관련 정보를 저장하는 API를 호출하는데요. 다음의 데이터를 body를 담아서 등록을 요청합니다.
```json
{
  "line": {
    "name": "2호선",
    "startTime": "05:00",
    "endTime": "23:50",
    "intervalTime": "10"
  },
  "edgesAndStations": [
    {
      "edge": {
        "elapsedTime": "2.0",
        "distance":  "1.2"
      },
      "sourceStation": {
        "name": "교대역"
      },
      "targetStation": {
        "name": "강남역"
      }
    },
    {
      "edge": {
        "elapsedTime": "1.5",
        "distance":  "0.8"
      },
      "sourceStation": {
        "name": "강남역"
      },
      "targetStation": {
        "name": "역삼역"
      }
    },
    {
      "edge": {
        "elapsedTime": "2.0",
        "distance":  "1.2"
      },
      "sourceStation": {
        "name": "역삼역"
      },
      "targetStation": {
        "name": "선릉역"
      }
    },
    ...
  ]
}
```
  - 문제는, 이름이 같은 station이 각각 여러번 저장됩니다. 여러가지 시도를 해봤는데 잘 되지 않아서.. 혹시 해결책이 무엇일까요...?
  - 요청 body를 `"stations": ["교대역", "강남역", "역삼역", "선릉역", "삼성역"], "lines": [{...}, {...}, ...]` 이런 식으로 할까 하다가, 위의 형태가 더 확실할 것 같아서 저렇게 정했습니다.
- 그리고 entity 객체들의 기본적인 설정이나 매핑에는 문제가 없는 상태일까요...?