### PR TITLE
2단계 - 구간 제거 기능 변경

### DIFF
--- a/src/main/java/nextstep/subway/line/application/LineService.java
+++ b/src/main/java/nextstep/subway/line/application/LineService.java
@@ -74,7 +74,7 @@ public class LineService {
 
     public void removeSection(Long lineId, Long stationId) {
         Line line = findLineById(lineId);
-        line.removeSection(line, stationId);
+        line.removeSection(stationId);
     }
 
     public LineResponse createLineResponse(Line line) {

--- a/src/main/java/nextstep/subway/line/domain/Line.java
+++ b/src/main/java/nextstep/subway/line/domain/Line.java
@@ -57,8 +57,8 @@ public class Line extends BaseEntity {
         sections.addSection(section);
     }
 
-    public void removeSection(Line line, Long stationId) {
-        sections.removeSection(line, stationId);
+    public void removeSection(Long stationId) {
+        sections.removeSection(stationId);
     }
 
     public List<Station> getStations(){

--- a/src/main/java/nextstep/subway/line/domain/Section.java
+++ b/src/main/java/nextstep/subway/line/domain/Section.java
@@ -73,6 +73,11 @@ public class Section {
         this.distance = distance - newSectionDistance;
     }
 
+    public void union(Section lastSection) {
+        this.downStation = lastSection.getDownStation();
+        this.distance += lastSection.getDistance();
+    }
+
     @Override
     public boolean equals(Object o) {
         if (this == o) return true;

--- a/src/main/java/nextstep/subway/line/domain/Sections.java
+++ b/src/main/java/nextstep/subway/line/domain/Sections.java
@@ -23,7 +23,7 @@ public class Sections {
 
     public void addSection(Section section) {
         validateContainsAllStations(section);
-        swapStation(section);
+        insertBetweenStation(section);
         sections.add(section);
     }
 
@@ -34,7 +34,7 @@ public class Sections {
         }
     }
 
-    private void swapStation(Section section) {
+    private void insertBetweenStation(Section section) {
         if (sections.size() == 0 || isStartStationAndEndAddable(getStations(), section)) {
             return;
         }

--- a/src/main/java/nextstep/subway/line/domain/Sections.java
+++ b/src/main/java/nextstep/subway/line/domain/Sections.java
@@ -11,6 +11,7 @@ import javax.persistence.Embeddable;
 
 import javax.persistence.OneToMany;
 import java.util.*;
+import java.util.stream.Collectors;
 
 @Embeddable
 public class Sections {
@@ -82,12 +83,7 @@ public class Sections {
 
     public void removeSection(Long stationId) {
         validateRemoveSection();
-
-        boolean isCenter = isCenterStation(stationId);
-        if(isCenter) {
-            Section lastSection = sections.get(sections.size() -1);
-            sections.get(0).union(lastSection);
-        }
+        unionIfStartOrEndStation(stationId);
 
         Section section = sections.stream()
                 .filter(it -> it.getDownStation().getId() == stationId || it.getUpStation().getId() == stationId)
@@ -96,7 +92,18 @@ public class Sections {
         sections.remove(section);
     }
 
-    private boolean isCenterStation(Long stationId) {
+    private void unionIfStartOrEndStation(Long stationId) {
+        if(isNotStartOrEndStation(stationId)) {
+            List<Section> result = sections.stream()
+                    .filter(section -> section.getDownStation().getId() == stationId || section.getUpStation().getId() == stationId)
+                    .collect(Collectors.toList());
+
+            sections.stream().filter(it -> it.equals(result.get(0)))
+                    .forEach(it -> it.union(result.get(result.size() - 1)));
+        }
+    }
+
+    private boolean isNotStartOrEndStation(Long stationId) {
        return  sections.stream().anyMatch(it -> it.getDownStation().getId() == stationId) &&
                sections.stream().anyMatch(it -> it.getUpStation().getId() == stationId);
     }

--- a/src/main/java/nextstep/subway/line/domain/Sections.java
+++ b/src/main/java/nextstep/subway/line/domain/Sections.java
@@ -1,6 +1,7 @@
 package nextstep.subway.line.domain;
 
 import nextstep.subway.line.domain.exception.AlreadyExistStation;
+import nextstep.subway.line.domain.exception.CannotRemoveStation;
 import nextstep.subway.line.domain.exception.InvalidDistanceException;
 import nextstep.subway.line.domain.exception.NotExistedStation;
 import nextstep.subway.station.domain.Station;
@@ -79,20 +80,23 @@ public class Sections {
      return section.containsStation(targetSection.getUpStation()) || section.containsStation(targetSection.getDownStation());
     }
 
-    public void removeSection(Line line, Long stationId) {
-        if (line.getSections().size() <= 1) {
-            throw new RuntimeException();
-        }
-
-        boolean isNotValidUpStation = getStations().get(getStations().size() - 1).getId() != stationId;
-        if (isNotValidUpStation) {
-            throw new RuntimeException("하행 종점역만 삭제가 가능합니다.");
-        }
-
+    public void removeSection(Long stationId) {
+        validateRemoveSection(stationId);
         sections.stream()
                 .filter(it -> it.getDownStation().getId() == stationId)
                 .findFirst()
-                .ifPresent(it -> sections.remove(it));
+                .ifPresent(it -> sections.remove(it))
+        ;
+    }
+
+    private void validateRemoveSection(Long stationId) {
+        if (sections.size() <= 1) {
+            throw new CannotRemoveStation("노선에 등록된 구간이 1개 이하일때는 삭제할 수 없습니다.");
+        }
+
+        if(!getStations().stream().anyMatch(it -> it.getId() == stationId)){
+            throw new CannotRemoveStation("노선에 해당되는 역이 없습니다.");
+        }
     }
 
     public List<Station> getStations() {

--- a/src/main/java/nextstep/subway/line/domain/Sections.java
+++ b/src/main/java/nextstep/subway/line/domain/Sections.java
@@ -81,21 +81,29 @@ public class Sections {
     }
 
     public void removeSection(Long stationId) {
-        validateRemoveSection(stationId);
-        sections.stream()
-                .filter(it -> it.getDownStation().getId() == stationId)
-                .findFirst()
-                .ifPresent(it -> sections.remove(it))
-        ;
-    }
+        validateRemoveSection();
 
-    private void validateRemoveSection(Long stationId) {
-        if (sections.size() <= 1) {
-            throw new CannotRemoveStation("노선에 등록된 구간이 1개 이하일때는 삭제할 수 없습니다.");
+        boolean isCenter = isCenterStation(stationId);
+        if(isCenter) {
+            Section lastSection = sections.get(sections.size() -1);
+            sections.get(0).union(lastSection);
         }
 
-        if(!getStations().stream().anyMatch(it -> it.getId() == stationId)){
-            throw new CannotRemoveStation("노선에 해당되는 역이 없습니다.");
+        Section section = sections.stream()
+                .filter(it -> it.getDownStation().getId() == stationId || it.getUpStation().getId() == stationId)
+                .findFirst()
+                .orElseThrow(() -> new CannotRemoveStation("노선에 해당되는 역이 없습니다."));
+        sections.remove(section);
+    }
+
+    private boolean isCenterStation(Long stationId) {
+       return  sections.stream().anyMatch(it -> it.getDownStation().getId() == stationId) &&
+               sections.stream().anyMatch(it -> it.getUpStation().getId() == stationId);
+    }
+
+    private void validateRemoveSection() {
+        if (sections.size() <= 1) {
+            throw new CannotRemoveStation("노선에 등록된 구간이 1개 이하일때는 삭제할 수 없습니다.");
         }
     }
 

--- a/src/main/java/nextstep/subway/line/domain/exception/CannotRemoveStation.java
+++ b/src/main/java/nextstep/subway/line/domain/exception/CannotRemoveStation.java
@@ -1,0 +1,8 @@
+package nextstep.subway.line.domain.exception;
+
+public class CannotRemoveStation extends DomainBusinessException {
+
+    public CannotRemoveStation(String message){
+        super(message);
+    }
+}

--- a/src/main/java/nextstep/subway/line/ui/LineController.java
+++ b/src/main/java/nextstep/subway/line/ui/LineController.java
@@ -68,6 +68,6 @@ public class LineController {
 
     @ExceptionHandler(DomainBusinessException.class)
     public ResponseEntity handleDomainBusinessException(DomainBusinessException e) {
-        return ResponseEntity.badRequest().build();
+        return ResponseEntity.badRequest().body(e.getMessage());
     }
 }

--- a/src/main/java/nextstep/subway/station/domain/Station.java
+++ b/src/main/java/nextstep/subway/station/domain/Station.java
@@ -20,6 +20,11 @@ public class Station extends BaseEntity {
         this.name = name;
     }
 
+    public Station(Long id, String name) {
+        this.id = id;
+        this.name = name;
+    }
+
     public Long getId() {
         return id;
     }

--- a/src/test/java/nextstep/subway/line/acceptance/LineSectionAcceptanceTest.java
+++ b/src/test/java/nextstep/subway/line/acceptance/LineSectionAcceptanceTest.java
@@ -123,12 +123,20 @@ public class LineSectionAcceptanceTest extends AcceptanceTest {
         지하철_노선에_지하철역_순서_정렬됨(response, Arrays.asList(강남역, 정자역));
     }
 
-    @DisplayName("등록되지 않는 노선을 제거한다.")
+    @DisplayName("등록되지 않는 지하철역 제거한다.")
     @Test
     void removeLineSectionNotExistStation(){
+        //Given
+        지하철_노선에_지하철역_등록_요청(신분당선, 양재역, 정자역, 3);
+
+        //When
+        ExtractableResponse<Response> response = 지하철_노선에_지하철역_제외_요청(신분당선, 광교역);
+
+        // then
+        지하철_노선에_지하철역_제외_실패됨(response);
     }
 
-    @DisplayName("지하철 노선에 등록된 지하철역을 제외한다.")
+    @DisplayName("등록된 하행 종점역을 제거한다.")
     @Test
     void removeLineSection() {
         // given
@@ -179,6 +187,6 @@ public class LineSectionAcceptanceTest extends AcceptanceTest {
     }
 
     public static void 지하철_노선에_지하철역_제외_실패됨(ExtractableResponse<Response> response) {
-        assertThat(response.statusCode()).isEqualTo(HttpStatus.INTERNAL_SERVER_ERROR.value());
+        assertThat(response.statusCode()).isEqualTo(HttpStatus.BAD_REQUEST.value());
     }
 }

--- a/src/test/java/nextstep/subway/line/acceptance/LineSectionAcceptanceTest.java
+++ b/src/test/java/nextstep/subway/line/acceptance/LineSectionAcceptanceTest.java
@@ -107,7 +107,7 @@ public class LineSectionAcceptanceTest extends AcceptanceTest {
     }
 
 
-    @DisplayName("변경된 요구사항 : 지하철 노선에 등록된 지하철을 제외한다.")
+    @DisplayName("역과 역사이의 등록된 지하철역을 제외한다.")
     @Test
     void removeLineSection_NewVersion(){
         //Given

--- a/src/test/java/nextstep/subway/line/acceptance/LineSectionAcceptanceTest.java
+++ b/src/test/java/nextstep/subway/line/acceptance/LineSectionAcceptanceTest.java
@@ -10,17 +10,14 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;
-import org.springframework.http.HttpStatus;
 
 import java.util.Arrays;
 import java.util.HashMap;
-import java.util.List;
 import java.util.Map;
-import java.util.stream.Collectors;
 
 import static nextstep.subway.line.acceptance.LineSteps.*;
+import static nextstep.subway.line.acceptance.LineVerifier.*;
 import static nextstep.subway.station.StationSteps.지하철역_등록되어_있음;
-import static org.assertj.core.api.Assertions.assertThat;
 
 @DisplayName("지하철 노선에 역 등록 관련 기능")
 public class LineSectionAcceptanceTest extends AcceptanceTest {
@@ -161,32 +158,4 @@ public class LineSectionAcceptanceTest extends AcceptanceTest {
         지하철_노선에_지하철역_제외_실패됨(removeResponse);
     }
 
-    public static void 지하철_노선에_지하철역_등록됨(ExtractableResponse<Response> response) {
-        assertThat(response.statusCode()).isEqualTo(HttpStatus.OK.value());
-    }
-
-    public static void 지하철_노선에_지하철역_등록_실패됨(ExtractableResponse<Response> response) {
-        assertThat(response.statusCode()).isEqualTo(HttpStatus.BAD_REQUEST.value());
-    }
-
-    public static void 지하철_노선에_지하철역_순서_정렬됨(ExtractableResponse<Response> response, List<StationResponse> expectedStations) {
-        LineResponse line = response.as(LineResponse.class);
-        List<Long> stationIds = line.getStations().stream()
-                .map(it -> it.getId())
-                .collect(Collectors.toList());
-
-        List<Long> expectedStationIds = expectedStations.stream()
-                .map(it -> it.getId())
-                .collect(Collectors.toList());
-
-        assertThat(stationIds).containsExactlyElementsOf(expectedStationIds);
-    }
-
-    public static void 지하철_노선에_지하철역_제외됨(ExtractableResponse<Response> response) {
-        assertThat(response.statusCode()).isEqualTo(HttpStatus.OK.value());
-    }
-
-    public static void 지하철_노선에_지하철역_제외_실패됨(ExtractableResponse<Response> response) {
-        assertThat(response.statusCode()).isEqualTo(HttpStatus.BAD_REQUEST.value());
-    }
 }

--- a/src/test/java/nextstep/subway/line/acceptance/LineVerifier.java
+++ b/src/test/java/nextstep/subway/line/acceptance/LineVerifier.java
@@ -1,0 +1,44 @@
+package nextstep.subway.line.acceptance;
+
+import io.restassured.response.ExtractableResponse;
+import io.restassured.response.Response;
+import nextstep.subway.line.dto.LineResponse;
+import nextstep.subway.station.dto.StationResponse;
+import org.springframework.http.HttpStatus;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class LineVerifier {
+
+    public static void 지하철_노선에_지하철역_등록됨(ExtractableResponse<Response> response) {
+        assertThat(response.statusCode()).isEqualTo(HttpStatus.OK.value());
+    }
+
+    public static void 지하철_노선에_지하철역_등록_실패됨(ExtractableResponse<Response> response) {
+        assertThat(response.statusCode()).isEqualTo(HttpStatus.BAD_REQUEST.value());
+    }
+
+    public static void 지하철_노선에_지하철역_순서_정렬됨(ExtractableResponse<Response> response, List<StationResponse> expectedStations) {
+        LineResponse line = response.as(LineResponse.class);
+        List<Long> stationIds = line.getStations().stream()
+                .map(it -> it.getId())
+                .collect(Collectors.toList());
+
+        List<Long> expectedStationIds = expectedStations.stream()
+                .map(it -> it.getId())
+                .collect(Collectors.toList());
+
+        assertThat(stationIds).containsExactlyElementsOf(expectedStationIds);
+    }
+
+    public static void 지하철_노선에_지하철역_제외됨(ExtractableResponse<Response> response) {
+        assertThat(response.statusCode()).isEqualTo(HttpStatus.OK.value());
+    }
+
+    public static void 지하철_노선에_지하철역_제외_실패됨(ExtractableResponse<Response> response) {
+        assertThat(response.statusCode()).isEqualTo(HttpStatus.BAD_REQUEST.value());
+    }
+}

--- a/src/test/java/nextstep/subway/line/domain/SectionsTest.java
+++ b/src/test/java/nextstep/subway/line/domain/SectionsTest.java
@@ -196,6 +196,31 @@ public class SectionsTest {
 
     /**
      * 기존 : 영등포역 --10--> 신길역 --7--> 대방역
+     * 신규 : 영등포역 --17--> 대방역
+     */
+    @DisplayName("구간이 두개 이상일 경우, 가운역을 제거한다.")
+    @ParameterizedTest
+    @CsvSource(value = {"10:7", "15:3"}, delimiter = ':')
+    public void removeBetweenStation(int distance1, int distance2) {
+        //Given
+        Sections sections = new Sections();
+        sections.addSection(new Section(line, 영등포역, 신길역, distance1));
+        sections.addSection(new Section(line, 신길역, 대방역, distance2));
+
+        //When
+        sections.removeSection(신길역.getId());
+
+        //Then
+        assertAll(
+                () -> assertThat(sections.getStations()).hasSize(2),
+                () -> assertThat(sections.getSections()).hasSize(1),
+                () -> assertThat(sections.countTotalDistance()).isEqualTo(distance1 + distance2),
+                () -> assertThat(sections.getStations()).containsExactlyElementsOf(Arrays.asList(영등포역, 대방역))
+        );
+    }
+
+    /**
+     * 기존 : 영등포역 --10--> 신길역 --7--> 대방역
      * 신규 : 영등포역 --10--> 신길역
      */
     @DisplayName("구간이 두개 이상일 경우, 하행 종점역을 제거한다.")

--- a/src/test/java/nextstep/subway/line/domain/SectionsTest.java
+++ b/src/test/java/nextstep/subway/line/domain/SectionsTest.java
@@ -1,6 +1,7 @@
 package nextstep.subway.line.domain;
 
 import nextstep.subway.line.domain.exception.AlreadyExistStation;
+import nextstep.subway.line.domain.exception.CannotRemoveStation;
 import nextstep.subway.line.domain.exception.InvalidDistanceException;
 import nextstep.subway.line.domain.exception.NotExistedStation;
 import nextstep.subway.station.domain.Station;
@@ -11,6 +12,7 @@ import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.CsvSource;
 import org.junit.jupiter.params.provider.MethodSource;
+import org.junit.jupiter.params.provider.ValueSource;
 
 import java.util.Arrays;
 import java.util.List;
@@ -29,13 +31,13 @@ public class SectionsTest {
     private Station 영등포역;
 
     @BeforeEach
-    public void setUp(){
+    public void setUp() {
         line = new Line("1호선", "blue");
 
-        영등포역 = new Station("영등포역");
-        신길역 = new Station("신길역");
-        대방역 = new Station("대방역");
-        노량진역 = new Station("노량진");
+        영등포역 = new Station(1L, "영등포역");
+        신길역 = new Station(2L, "신길역");
+        대방역 = new Station(3L, "대방역");
+        노량진역 = new Station(4L, "노량진");
 
     }
 
@@ -92,10 +94,10 @@ public class SectionsTest {
      * 기존 : 영등포역 ---> 대방역
      * 신규 : 영등포역 ---> 신길역 ---> 대방역
      */
-    @DisplayName("역 사이에 새로운 역을 등록한다. 새롭게 등록된 하행역은 기존의 하행역의 상행역이 된다." )
+    @DisplayName("역 사이에 새로운 역을 등록한다. 새롭게 등록된 하행역은 기존의 하행역의 상행역이 된다.")
     @ParameterizedTest
     @MethodSource("provideSections")
-    public void addSection_case3(Section section1, int distance, Section section2){
+    public void addSection_case3(Section section1, int distance, Section section2) {
         //Given
         Sections newSections = new Sections();
         newSections.addSection(section1);
@@ -104,7 +106,7 @@ public class SectionsTest {
         newSections.addSection(section2);
 
         //Then
-        List<Station> stations =newSections.getStations();
+        List<Station> stations = newSections.getStations();
         assertAll(
                 () -> assertThat(stations.size()).isEqualTo(3),
                 () -> assertThat(stations).containsExactlyElementsOf(Arrays.asList(영등포역, 신길역, 대방역)),
@@ -112,10 +114,11 @@ public class SectionsTest {
                 () -> assertThat(newSections.countTotalDistance()).isEqualTo(distance)
         );
     }
+
     private static Stream<Arguments> provideSections() {
         return Stream.of(
                 Arguments.of(new Section(new Line("1호선", "blue"), new Station("영등포역"), new Station("대방역"), 8), 8,
-                             new Section(new Line("1호선", "blue"), new Station("영등포역"), new Station("신길역"), 2))
+                        new Section(new Line("1호선", "blue"), new Station("영등포역"), new Station("신길역"), 2))
         );
     }
 
@@ -126,7 +129,7 @@ public class SectionsTest {
      */
     @DisplayName("역 사이에 새로운 역을 등록한다. 새로운 하행역은 기존 하행역과 동일하다.")
     @Test
-    public void addSection_case4(){
+    public void addSection_case4() {
         //Given
         int section1Distance = 10;
         Sections newSections = new Sections();
@@ -147,8 +150,8 @@ public class SectionsTest {
 
     @DisplayName("역 사이에 새로운 역을 등록한다. 새로 등록되는 구간이 기존 등록된 구간보다 크거나 같을 경우 예외처리 ")
     @ParameterizedTest
-    @CsvSource(value = {"5:5","5:6","5:8"}, delimiter = ':')
-    public void addSection_case3_exception(int distance1, int distance2){
+    @CsvSource(value = {"5:5", "5:6", "5:8"}, delimiter = ':')
+    public void addSection_case3_exception(int distance1, int distance2) {
         assertThatThrownBy(() -> {
 
             Sections newSections = new Sections();
@@ -163,7 +166,7 @@ public class SectionsTest {
 
     @DisplayName("상행역과 하행역 둘 중하나도 포함되어있지 않을 경우 예외처리")
     @Test
-    public void addSectionNotExistedStations(){
+    public void addSectionNotExistedStations() {
         assertThatThrownBy(() -> {
 
             Sections newSections = new Sections();
@@ -179,7 +182,7 @@ public class SectionsTest {
 
     @DisplayName("상행역과 하행역이 이미 노선에 모두 등록되어 있을 경우 예외처리")
     @Test
-    public void alreadyExistStation(){
+    public void alreadyExistStation() {
         assertThatThrownBy(() -> {
 
             Sections newSections = new Sections();
@@ -188,6 +191,56 @@ public class SectionsTest {
             newSections.addSection(section2);
 
         }).isInstanceOf(AlreadyExistStation.class);
+    }
+
+
+    /**
+     * 기존 : 영등포역 --10--> 신길역 --7--> 대방역
+     * 신규 : 영등포역 --10--> 신길역
+     */
+    @DisplayName("구간이 두개 이상일 경우, 하행 종점역을 제거한다.")
+    @ParameterizedTest
+    @CsvSource(value = {"10:7", "15:3"}, delimiter = ':')
+    public void removeLastStation(int distance1, int distance2) {
+        //Given
+        Sections sections = new Sections();
+        sections.addSection(new Section(line, 영등포역, 신길역, distance1));
+        sections.addSection(new Section(line, 신길역, 대방역, distance2));
+
+        //When
+        sections.removeSection(대방역.getId());
+
+        //Then
+        assertAll(
+                () -> assertThat(sections.getStations()).hasSize(2),
+                () -> assertThat(sections.getSections()).hasSize(1),
+                () -> assertThat(sections.countTotalDistance()).isEqualTo(distance1),
+                () -> assertThat(sections.getStations()).containsExactlyElementsOf(Arrays.asList(영등포역, 신길역))
+        );
+    }
+
+
+    @DisplayName("구간이 하나인 경우 제거 할 수 없다")
+    @Test
+    public void cannotRemoveJustLineHasSection() {
+        assertThatThrownBy(() -> {
+            Sections sections = new Sections();
+            sections.addSection(new Section(line, 영등포역, 신길역, 10));
+            sections.removeSection(영등포역.getId());
+        }).isInstanceOf(CannotRemoveStation.class);
+
+    }
+
+    @DisplayName("노선에 등록되지 않은 역을 삭제할 경우 예외처리")
+    @Test
+    public void cannotRemoveNotExistStationTry(){
+        assertThatThrownBy(() ->{
+            Sections sections = new Sections();
+            sections.addSection(new Section(line, 영등포역, 신길역, 10));
+            sections.addSection(new Section(line, 신길역, 대방역, 5));
+            sections.removeSection(10L);
+
+        }).isInstanceOf(CannotRemoveStation.class);
     }
 
 }

--- a/src/test/java/nextstep/subway/line/domain/support/SectionsDomainBuilder.java
+++ b/src/test/java/nextstep/subway/line/domain/support/SectionsDomainBuilder.java
@@ -1,0 +1,20 @@
+package nextstep.subway.line.domain.support;
+
+import nextstep.subway.line.domain.Line;
+import nextstep.subway.line.domain.Section;
+import nextstep.subway.line.domain.Sections;
+import nextstep.subway.station.domain.Station;
+
+import java.util.List;
+
+public class SectionsDomainBuilder {
+
+    public static Sections build(List<Integer> distances, Station ...stations){
+        Sections sections = new Sections();
+        for(int i = 0; i < stations.length - 1 ; i++){
+            sections.addSection(new Section(new Line("1호선", "블루"), stations[i], stations[i+1], distances.get(i)));
+        }
+        return sections;
+    }
+
+}


### PR DESCRIPTION
안녕하세요. 리뷰어님 :)
2단계 구간 제거 기능 요청드려요

- [x] 하행종점역 제거 
- [x] 구간이 하나인 노선에 역을 삭제할 경우 예외
- [x] 노선에 등록되지 않은 역을 삭제할 경우 예외
- [x] 역과 역 사이 제거

미션진행 중 URI와 관련하여 문의사항 드립니다.

지하철 노선 구간의 리소스 uri 두가지가 어떤 차이가 있을까요 ?
1.  /lines/{lineId}/sections?stationId={stationId}
2. /lines/{lineId}/sections/{stationId}
평소에는 2번의 경우로 많이 썼었는데, 이번에 미션을 진행하면서 보니깐 쿼리스트링 형태로 표현이 되어있더라구요. 특별한 차이가 있는지 궁금합니다 

2단계도 리뷰 잘 부탁드리겠습니다. 
항상 세심한 리뷰 감사합니다 :) 