### PR TITLE
1단계 - 구간 추가 기능 변경

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,12 +1,12 @@
 plugins {
-	id 'org.springframework.boot' version '2.5.2'
+	id 'org.springframework.boot' version '2.5.9'
 	id 'io.spring.dependency-management' version '1.0.11.RELEASE'
 	id 'java'
 }
 
 group = 'nextstep'
 version = '0.0.1-SNAPSHOT'
-sourceCompatibility = '1.8'
+sourceCompatibility = '11'
 
 repositories {
 	mavenCentral()

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.1-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.3.1-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/src/main/java/nextstep/subway/applicaion/LineService.java
+++ b/src/main/java/nextstep/subway/applicaion/LineService.java
@@ -3,109 +3,115 @@ package nextstep.subway.applicaion;
 import nextstep.subway.applicaion.dto.LineRequest;
 import nextstep.subway.applicaion.dto.LineResponse;
 import nextstep.subway.applicaion.dto.SectionRequest;
-import nextstep.subway.applicaion.dto.StationResponse;
+import nextstep.subway.common.exception.DuplicateAttributeException;
 import nextstep.subway.domain.Line;
 import nextstep.subway.domain.LineRepository;
 import nextstep.subway.domain.Section;
-import nextstep.subway.domain.Station;
+import nextstep.subway.domain.StationRepository;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
-import java.util.Collections;
 import java.util.List;
 import java.util.stream.Collectors;
 
 @Service
 @Transactional
 public class LineService {
-    private LineRepository lineRepository;
-    private StationService stationService;
+    private final LineRepository lineRepository;
 
-    public LineService(LineRepository lineRepository, StationService stationService) {
+    private final StationRepository stationRepository;
+
+    public LineService(
+            final LineRepository lineRepository,
+            final StationRepository stationRepository
+    ) {
         this.lineRepository = lineRepository;
-        this.stationService = stationService;
+        this.stationRepository = stationRepository;
     }
 
-    public LineResponse saveLine(LineRequest request) {
-        Line line = lineRepository.save(new Line(request.getName(), request.getColor()));
-        if (request.getUpStationId() != null && request.getDownStationId() != null && request.getDistance() != 0) {
-            Station upStation = stationService.findById(request.getUpStationId());
-            Station downStation = stationService.findById(request.getDownStationId());
-            line.getSections().add(new Section(line, upStation, downStation, request.getDistance()));
+    public LineResponse createLine(LineRequest request) {
+        var requestName = request.getName();
+        var requestColor = request.getColor();
+        var requestUpStationId = request.getUpStationId();
+        var requestDownStationId = request.getDownStationId();
+        var distance = request.getDistance();
+
+        if (isLineNamePresent(requestName)) {
+            throw new DuplicateAttributeException("이미 존재하는 노선 명: " + requestName);
         }
-        return createLineResponse(line);
-    }
 
-    @Transactional(readOnly = true)
-    public List<LineResponse> showLines() {
-        return lineRepository.findAll().stream()
-                .map(this::createLineResponse)
-                .collect(Collectors.toList());
-    }
+        var section = new Section(
+                stationRepository.findById(requestUpStationId)
+                        .orElseThrow(() -> new IllegalArgumentException("존재하지 않는 지하철 역 id: " + requestUpStationId)),
+                stationRepository.findById(requestDownStationId)
+                        .orElseThrow(() -> new IllegalArgumentException("존재하지 않는 지하철 역 id: " + requestDownStationId)),
+                distance
+        );
 
-    @Transactional(readOnly = true)
-    public LineResponse findById(Long id) {
-        return createLineResponse(lineRepository.findById(id).orElseThrow(IllegalArgumentException::new));
-    }
+        var savedLine = lineRepository.save(new Line(requestName, requestColor));
+        savedLine.init(section);
 
-    public void updateLine(Long id, LineRequest lineRequest) {
-        Line line = lineRepository.findById(id).orElseThrow(IllegalArgumentException::new);
-
-        if (lineRequest.getName() != null) {
-            line.setName(lineRequest.getName());
-        }
-        if (lineRequest.getColor() != null) {
-            line.setColor(lineRequest.getColor());
-        }
+        return LineResponse.from(savedLine);
     }
 
     public void deleteLine(Long id) {
         lineRepository.deleteById(id);
     }
 
-    public void addSection(Long lineId, SectionRequest sectionRequest) {
-        Station upStation = stationService.findById(sectionRequest.getUpStationId());
-        Station downStation = stationService.findById(sectionRequest.getDownStationId());
-        Line line = lineRepository.findById(lineId).orElseThrow(IllegalArgumentException::new);
+    @Transactional(readOnly = true)
+    public LineResponse findLineById(Long id) {
+        var line = lineRepository.findById(id)
+                .orElseThrow(() -> new IllegalArgumentException("존재하지 않는 지하철 노선 id: " + id));
 
-        line.getSections().add(new Section(line, upStation, downStation, sectionRequest.getDistance()));
+        return LineResponse.from(line);
     }
 
-    private LineResponse createLineResponse(Line line) {
-        return new LineResponse(
-                line.getId(),
-                line.getName(),
-                line.getColor(),
-                createStationResponses(line),
-                line.getCreatedDate(),
-                line.getModifiedDate()
-        );
+    @Transactional(readOnly = true)
+    public List<LineResponse> findAllLines() {
+        var lines = lineRepository.findAll();
+
+        return lines.stream()
+                .map(LineResponse::from)
+                .collect(Collectors.toList());
     }
 
-    private List<StationResponse> createStationResponses(Line line) {
-        if (line.getSections().isEmpty()) {
-            return Collections.emptyList();
-        }
+    public LineResponse updateLine(Long id, LineRequest lineRequest) {
+        var line = lineRepository.findById(id)
+                .orElseThrow(() -> new IllegalArgumentException("존재하지 않는 지하철 노선 id: " + id));
+        line.update(lineRequest.getName(), lineRequest.getColor());
 
-        List<Station> stations = line.getSections().stream()
-                .map(Section::getDownStation)
-                .collect(Collectors.toList());
+        return LineResponse.from(line);
+    }
 
-        stations.add(0, line.getSections().get(0).getUpStation());
+    public void addStationToLine(Long lineId, SectionRequest sectionRequest) {
+        var line = lineRepository.findById(lineId)
+                .orElseThrow(() -> new IllegalArgumentException("존재하지 않는 지하철 노선 id: " + lineId));
 
-        return stations.stream()
-                .map(it -> stationService.createStationResponse(it))
-                .collect(Collectors.toList());
+        var upStationId = sectionRequest.getUpStationId();
+        var downStationId = sectionRequest.getDownStationId();
+        var distance = sectionRequest.getDistance();
+
+        var upStation = stationRepository.findById(upStationId)
+                .orElseThrow(() -> new IllegalArgumentException("존재하지 않는 지하철 역 id: " + upStationId));
+        var downStation = stationRepository.findById(sectionRequest.getDownStationId())
+                .orElseThrow(() -> new IllegalArgumentException("존재하지 않는 지하철 역 id: " + downStationId));
+
+        var section = new Section(upStation, downStation, distance);
+        line.addSection(section);
     }
 
     public void deleteSection(Long lineId, Long stationId) {
-        Line line = lineRepository.findById(lineId).orElseThrow(IllegalArgumentException::new);
-        Station station = stationService.findById(stationId);
+        var line = lineRepository.findById(lineId)
+                .orElseThrow(() -> new IllegalArgumentException("존재하지 않는 지하철 노선 id: " + lineId));
 
-        if (!line.getSections().get(line.getSections().size() - 1).getDownStation().equals(station)) {
-            throw new IllegalArgumentException();
-        }
+        var station = stationRepository.findById(stationId)
+                .orElseThrow(() -> new IllegalArgumentException("존재하지 않는 지하철 역 id: " + stationId));
 
-        line.getSections().remove(line.getSections().size() - 1);
+        line.remove(station);
+    }
+
+    private boolean isLineNamePresent(String lineName) {
+        return lineRepository.findByName(lineName)
+                .isPresent();
     }
 }

--- a/src/main/java/nextstep/subway/applicaion/StationService.java
+++ b/src/main/java/nextstep/subway/applicaion/StationService.java
@@ -2,6 +2,7 @@ package nextstep.subway.applicaion;
 
 import nextstep.subway.applicaion.dto.StationRequest;
 import nextstep.subway.applicaion.dto.StationResponse;
+import nextstep.subway.common.exception.DuplicateAttributeException;
 import nextstep.subway.domain.Station;
 import nextstep.subway.domain.StationRepository;
 import org.springframework.stereotype.Service;
@@ -20,8 +21,13 @@ public class StationService {
     }
 
     public StationResponse saveStation(StationRequest stationRequest) {
-        Station station = stationRepository.save(new Station(stationRequest.getName()));
-        return createStationResponse(station);
+        var name = stationRequest.getName();
+        if (isStationNamePresent(name)) {
+            throw new DuplicateAttributeException("이미 존재하는 역명: " + name);
+        }
+
+        Station station = stationRepository.save(new Station(name));
+        return StationResponse.from(station);
     }
 
     @Transactional(readOnly = true)
@@ -29,7 +35,7 @@ public class StationService {
         List<Station> stations = stationRepository.findAll();
 
         return stations.stream()
-                .map(this::createStationResponse)
+                .map(StationResponse::from)
                 .collect(Collectors.toList());
     }
 
@@ -37,16 +43,9 @@ public class StationService {
         stationRepository.deleteById(id);
     }
 
-    public StationResponse createStationResponse(Station station) {
-        return new StationResponse(
-                station.getId(),
-                station.getName(),
-                station.getCreatedDate(),
-                station.getModifiedDate()
-        );
+    private boolean isStationNamePresent(String stationName) {
+        return stationRepository.findByName(stationName)
+                .isPresent();
     }
 
-    public Station findById(Long id) {
-        return stationRepository.findById(id).orElseThrow(IllegalArgumentException::new);
-    }
 }

--- a/src/main/java/nextstep/subway/applicaion/dto/LineResponse.java
+++ b/src/main/java/nextstep/subway/applicaion/dto/LineResponse.java
@@ -49,13 +49,11 @@ public class LineResponse {
     }
 
     public static LineResponse from(Line line) {
-        var sections = line.getSections();
+        var stations = line.getStations();
 
-        var stationResponses = sections.stream()
-                .map(Section::getUpStation)
+        var stationResponses = stations.stream()
                 .map(StationResponse::from)
                 .collect(Collectors.toList());
-        stationResponses.add(StationResponse.from(sections.get(sections.size() - 1).getDownStation()));
 
         return new LineResponse(
                 line.getId(),

--- a/src/main/java/nextstep/subway/applicaion/dto/LineResponse.java
+++ b/src/main/java/nextstep/subway/applicaion/dto/LineResponse.java
@@ -1,7 +1,6 @@
 package nextstep.subway.applicaion.dto;
 
 import nextstep.subway.domain.Line;
-import nextstep.subway.domain.Section;
 
 import java.time.LocalDateTime;
 import java.util.List;

--- a/src/main/java/nextstep/subway/applicaion/dto/LineResponse.java
+++ b/src/main/java/nextstep/subway/applicaion/dto/LineResponse.java
@@ -1,7 +1,11 @@
 package nextstep.subway.applicaion.dto;
 
+import nextstep.subway.domain.Line;
+import nextstep.subway.domain.Section;
+
 import java.time.LocalDateTime;
 import java.util.List;
+import java.util.stream.Collectors;
 
 public class LineResponse {
     private Long id;
@@ -42,6 +46,25 @@ public class LineResponse {
 
     public LocalDateTime getModifiedDate() {
         return modifiedDate;
+    }
+
+    public static LineResponse from(Line line) {
+        var sections = line.getSections();
+
+        var stationResponses = sections.stream()
+                .map(Section::getUpStation)
+                .map(StationResponse::from)
+                .collect(Collectors.toList());
+        stationResponses.add(StationResponse.from(sections.get(sections.size() - 1).getDownStation()));
+
+        return new LineResponse(
+                line.getId(),
+                line.getName(),
+                line.getColor(),
+                stationResponses,
+                line.getCreatedDate(),
+                line.getModifiedDate()
+        );
     }
 }
 

--- a/src/main/java/nextstep/subway/applicaion/dto/SectionRequest.java
+++ b/src/main/java/nextstep/subway/applicaion/dto/SectionRequest.java
@@ -5,6 +5,16 @@ public class SectionRequest {
     private Long downStationId;
     private int distance;
 
+    private SectionRequest(Long upStationId, Long downStationId, int distance) {
+        this.upStationId = upStationId;
+        this.downStationId = downStationId;
+        this.distance = distance;
+    }
+
+    public static SectionRequest of(Long upStationId, Long downStationId, int distance) {
+        return new SectionRequest(upStationId, downStationId, distance);
+    }
+
     public Long getUpStationId() {
         return upStationId;
     }

--- a/src/main/java/nextstep/subway/applicaion/dto/StationResponse.java
+++ b/src/main/java/nextstep/subway/applicaion/dto/StationResponse.java
@@ -1,5 +1,7 @@
 package nextstep.subway.applicaion.dto;
 
+import nextstep.subway.domain.Station;
+
 import java.time.LocalDateTime;
 
 public class StationResponse {
@@ -29,5 +31,14 @@ public class StationResponse {
 
     public LocalDateTime getModifiedDate() {
         return modifiedDate;
+    }
+
+    public static StationResponse from(Station station) {
+        return new StationResponse(
+                station.getId(),
+                station.getName(),
+                station.getCreatedDate(),
+                station.getModifiedDate()
+        );
     }
 }

--- a/src/main/java/nextstep/subway/common/exception/DuplicateAttributeException.java
+++ b/src/main/java/nextstep/subway/common/exception/DuplicateAttributeException.java
@@ -1,0 +1,8 @@
+package nextstep.subway.common.exception;
+
+public class DuplicateAttributeException extends RuntimeException{
+
+    public DuplicateAttributeException(String message) {
+        super(message);
+    }
+}

--- a/src/main/java/nextstep/subway/domain/Line.java
+++ b/src/main/java/nextstep/subway/domain/Line.java
@@ -2,21 +2,31 @@ package nextstep.subway.domain;
 
 import javax.persistence.*;
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
+import java.util.Objects;
+import java.util.stream.Collectors;
 
 @Entity
 public class Line extends BaseEntity {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
+
     @Column(unique = true)
     private String name;
+
     private String color;
 
-    @OneToMany(mappedBy = "line", cascade = {CascadeType.PERSIST, CascadeType.MERGE}, orphanRemoval = true)
+    @OneToMany(
+            mappedBy = "line",
+            cascade = {CascadeType.PERSIST, CascadeType.MERGE},
+            orphanRemoval = true,
+            fetch = FetchType.LAZY
+    )
     private List<Section> sections = new ArrayList<>();
 
-    public Line() {
+    protected Line() {
     }
 
     public Line(String name, String color) {
@@ -28,27 +38,88 @@ public class Line extends BaseEntity {
         return id;
     }
 
-    public void setId(Long id) {
-        this.id = id;
-    }
-
     public String getName() {
         return name;
-    }
-
-    public void setName(String name) {
-        this.name = name;
     }
 
     public String getColor() {
         return color;
     }
 
-    public void setColor(String color) {
+    public List<Section> getSections() {
+        return Collections.unmodifiableList(sections);
+    }
+
+    public List<Station> getStations() {
+        var stations = sections.stream()
+                .map(Section::getUpStation)
+                .collect(Collectors.toList());
+        stations.add(sections.get(sections.size() - 1).getDownStation());
+
+        return Collections.unmodifiableList(stations);
+    }
+
+    public void update(String name, String color) {
+        this.name = name;
         this.color = color;
     }
 
-    public List<Section> getSections() {
-        return sections;
+    public void init(Section section) {
+        section.setLine(this);
+        sections.add(section);
+    }
+
+    public void addSection(Section section) {
+        verifyCanBeAdded(section);
+        section.setLine(this);
+        sections.add(section);
+    }
+
+    public void remove(Station station) {
+        verifyCanBeDeleted(station);
+        sections.remove(sections.size() - 1);
+    }
+
+    private void verifyCanBeAdded(Section section) {
+        if (sections.isEmpty()) {
+            throw new IllegalArgumentException("비어있는 노선에 구간을 추가할 수 없습니다.");
+        }
+
+        var lastStop = sections.get(sections.size() - 1);
+        if (!lastStop.getDownStation().equals(section.getUpStation())) {
+            throw new IllegalArgumentException("새로운 구간의 상행역이 해당 노선의 하행 종점역이 아닙니다.");
+        }
+
+        var downStation = section.getDownStation();
+        if (sections.stream().map(Section::getUpStation).anyMatch(station -> station.equals(downStation))
+                || sections.stream().map(Section::getDownStation).anyMatch(station -> station.equals(downStation))) {
+            throw new IllegalArgumentException("새로운 구간의 하행역이 해당 노선에 이미 등록되어있습니다.");
+        }
+    }
+
+    private void verifyCanBeDeleted(Station station) {
+        if (sections.size() <= 1) {
+            throw new IllegalStateException("노선에 구간이 부족하여 역을 삭제할 수 없습니다.");
+        }
+
+        if (!sections.get(sections.size() - 1).getDownStation().equals(station)) {
+            throw new IllegalArgumentException("삭제하려는 역은 해당 노선 마지막 구간의 하행역이 아닙니다.");
+        }
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        if (this == obj)
+            return true;
+        if (this.id == null || obj == null || getClass() != obj.getClass())
+            return false;
+
+        var line = (Line) obj;
+        return id.equals(line.id);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(id);
     }
 }

--- a/src/main/java/nextstep/subway/domain/LineRepository.java
+++ b/src/main/java/nextstep/subway/domain/LineRepository.java
@@ -2,5 +2,8 @@ package nextstep.subway.domain;
 
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.Optional;
+
 public interface LineRepository extends JpaRepository<Line, Long> {
+    Optional<Line> findByName(String name);
 }

--- a/src/main/java/nextstep/subway/domain/Section.java
+++ b/src/main/java/nextstep/subway/domain/Section.java
@@ -11,10 +11,6 @@ public class Section {
     private Long id;
 
     @ManyToOne(cascade = CascadeType.PERSIST)
-    @JoinColumn(name = "line_id")
-    private Line line;
-
-    @ManyToOne(cascade = CascadeType.PERSIST)
     @JoinColumn(name = "up_station_id")
     private Station upStation;
 
@@ -37,13 +33,8 @@ public class Section {
         this.distance = distance;
     }
 
-
     public Long getId() {
         return id;
-    }
-
-    public Line getLine() {
-        return line;
     }
 
     public Station getUpStation() {
@@ -56,11 +47,6 @@ public class Section {
 
     public int getDistance() {
         return distance;
-    }
-
-    public void setLine(Line line) {
-        this.line = line;
-        line.getSections().add(this);
     }
 
     public boolean hasStation(Station station) {

--- a/src/main/java/nextstep/subway/domain/Section.java
+++ b/src/main/java/nextstep/subway/domain/Section.java
@@ -60,6 +60,11 @@ public class Section {
 
     public void setLine(Line line) {
         this.line = line;
+        line.getSections().add(this);
+    }
+
+    public boolean hasStation(Station station) {
+        return upStation.equals(station) || downStation.equals(station);
     }
 
     @Override

--- a/src/main/java/nextstep/subway/domain/Section.java
+++ b/src/main/java/nextstep/subway/domain/Section.java
@@ -1,9 +1,11 @@
 package nextstep.subway.domain;
 
 import javax.persistence.*;
+import java.util.Objects;
 
 @Entity
 public class Section {
+
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
@@ -22,16 +24,19 @@ public class Section {
 
     private int distance;
 
-    public Section() {
-
+    protected Section() {
     }
 
-    public Section(Line line, Station upStation, Station downStation, int distance) {
-        this.line = line;
+    public Section(
+            Station upStation,
+            Station downStation,
+            int distance
+    ) {
         this.upStation = upStation;
         this.downStation = downStation;
         this.distance = distance;
     }
+
 
     public Long getId() {
         return id;
@@ -51,5 +56,25 @@ public class Section {
 
     public int getDistance() {
         return distance;
+    }
+
+    public void setLine(Line line) {
+        this.line = line;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o)
+            return true;
+        if (this.id == null || o == null || getClass() != o.getClass())
+            return false;
+
+        var section = (Section) o;
+        return id.equals(section.id);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(id);
     }
 }

--- a/src/main/java/nextstep/subway/domain/Sections.java
+++ b/src/main/java/nextstep/subway/domain/Sections.java
@@ -1,0 +1,174 @@
+package nextstep.subway.domain;
+
+import javax.persistence.*;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.stream.Collectors;
+
+@Embeddable
+public class Sections {
+
+    @Transient
+    private static final int DELETABLE_SIZE = 2;
+
+    @OneToMany(
+            cascade = {CascadeType.PERSIST, CascadeType.MERGE},
+            orphanRemoval = true,
+            fetch = FetchType.LAZY
+    )
+    @JoinColumn(name = "section_id")
+    private List<Section> sections = new LinkedList<>();
+
+    protected Sections() {
+    }
+
+    public Sections(List<Section> sections) {
+        this.sections = sections;
+    }
+
+    public void addSection(Section section) {
+        verifyCanBeAdded(section);
+
+        var stations = getStations();
+        if (stations.get(0).equals(section.getDownStation())) {
+            sections.add(section);
+            return;
+        }
+
+        if (stations.get(stations.size() - 1).equals(section.getUpStation())) {
+            sections.add(section);
+            return;
+        }
+
+        addSectionToBetween(section);
+    }
+
+    public List<Station> getStations() {
+        if (sections.isEmpty()) {
+            return Collections.emptyList();
+        }
+
+        var orderedStations = new ArrayList<Station>();
+        var top = findFirstSection();
+        orderedStations.add(top.getUpStation());
+
+        var curSection = top;
+        while (curSection != null) {
+            orderedStations.add(curSection.getDownStation());
+            curSection = findNextSection(curSection);
+        }
+
+        return orderedStations;
+    }
+
+    public List<Section> getOrderedSections() {
+        var orderedSections = new ArrayList<Section>();
+
+        var curSection = findFirstSection();
+        while (curSection != null) {
+            orderedSections.add(curSection);
+            curSection = findNextSection(curSection);
+        }
+
+        return Collections.unmodifiableList(orderedSections);
+    }
+
+    public int size() {
+        return sections.size();
+    }
+
+    private Section findFirstSection() {
+        var downStations = sections.stream()
+                .map(Section::getDownStation)
+                .collect(Collectors.toList());
+
+        return sections.stream()
+                .filter(it -> !downStations.contains(it.getUpStation()))
+                .findAny()
+                .orElseThrow(() -> new IllegalStateException("구간이 유효하지 않은 상태입니다."));
+    }
+
+    private Section findNextSection(Section section) {
+        return sections.stream()
+                .filter(it -> it.getUpStation().equals(section.getDownStation()))
+                .findAny()
+                .orElse(null);
+    }
+
+    private void addSectionToBetween(Section section) {
+        var betweenSectionUp = sections.stream()
+                .filter(it -> it.getUpStation().equals(section.getUpStation()))
+                .findAny()
+                .orElse(null);
+
+        if (betweenSectionUp != null) {
+            if (betweenSectionUp.getDistance() <= section.getDistance()) {
+                throw new IllegalArgumentException("기존 역 사이 길이보다 크거나 같아서 추가할 수 없습니다.");
+            }
+
+            sections.add(section);
+            var newSection = new Section(
+                    section.getDownStation(),
+                    betweenSectionUp.getDownStation(),
+                    betweenSectionUp.getDistance() - section.getDistance()
+            );
+            sections.add(newSection);
+
+            sections.remove(betweenSectionUp);
+            return;
+        }
+
+        var betweenSectionDown = sections.stream()
+                .filter(it -> it.getDownStation().equals(section.getDownStation()))
+                .findAny()
+                .orElse(null);
+
+        if (betweenSectionDown != null) {
+            if (betweenSectionDown.getDistance() <= section.getDistance()) {
+                throw new IllegalArgumentException("기존 역 사이 길이보다 크거나 같아서 추가할 수 없습니다.");
+            }
+
+            sections.add(section);
+            var newSection = new Section(
+                    betweenSectionDown.getUpStation(),
+                    section.getUpStation(),
+                    betweenSectionDown.getDistance() - section.getDistance()
+            );
+            sections.add(newSection);
+
+            sections.remove(betweenSectionDown);
+        }
+    }
+
+    public void remove(Station station) {
+        verifyCanBeDeleted(station);
+        sections.remove(sections.size() - 1);
+    }
+
+    private void verifyCanBeAdded(Section section) {
+        if (sections.stream().filter(it -> it.hasStation(section.getUpStation())).findAny().isEmpty()
+                && sections.stream().filter(it -> it.hasStation(section.getDownStation())).findAny().isEmpty()) {
+            throw new IllegalArgumentException("상행역과 하행역 모두 등록되어 있지 않아서 추가할 수 없습니다.");
+        }
+
+        if (sections.stream().anyMatch(it ->
+                it.getUpStation().equals(section.getUpStation())
+                        && it.getDownStation().equals(section.getDownStation()))
+        ) {
+            throw new IllegalArgumentException("상행역과 하행역이 모두 등록되어 있어서 추가할 수 없습니다.");
+        }
+    }
+
+    private void verifyCanBeDeleted(Station station) {
+        if (sections.size() < DELETABLE_SIZE) {
+            throw new IllegalStateException("노선에 구간이 부족하여 역을 삭제할 수 없습니다.");
+        }
+
+        if (!sections.get(sections.size() - 1).getDownStation().equals(station)) {
+            throw new IllegalArgumentException("삭제하려는 역은 해당 노선 마지막 구간의 하행역이 아닙니다.");
+        }
+    }
+
+}

--- a/src/main/java/nextstep/subway/domain/Station.java
+++ b/src/main/java/nextstep/subway/domain/Station.java
@@ -31,14 +31,14 @@ public class Station extends BaseEntity {
     @Override
     public boolean equals(Object o) {
         if (this == o) return true;
-        if (this.id == null || o == null || getClass() != o.getClass()) return false;
+        if (this.name == null || o == null || getClass() != o.getClass()) return false;
 
         Station station = (Station) o;
-        return id.equals(station.id);
+        return name.equals(station.name);
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(id);
+        return Objects.hash(name);
     }
 }

--- a/src/main/java/nextstep/subway/domain/Station.java
+++ b/src/main/java/nextstep/subway/domain/Station.java
@@ -1,13 +1,16 @@
 package nextstep.subway.domain;
 
-import javax.persistence.*;
+import javax.persistence.Entity;
+import javax.persistence.GeneratedValue;
+import javax.persistence.GenerationType;
+import javax.persistence.Id;
+import java.util.Objects;
 
 @Entity
 public class Station extends BaseEntity {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
-    @Column(unique = true)
     private String name;
 
     public Station() {
@@ -23,5 +26,19 @@ public class Station extends BaseEntity {
 
     public String getName() {
         return name;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (this.id == null || o == null || getClass() != o.getClass()) return false;
+
+        Station station = (Station) o;
+        return id.equals(station.id);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(id);
     }
 }

--- a/src/main/java/nextstep/subway/domain/StationRepository.java
+++ b/src/main/java/nextstep/subway/domain/StationRepository.java
@@ -3,8 +3,11 @@ package nextstep.subway.domain;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 import java.util.List;
+import java.util.Optional;
 
 public interface StationRepository extends JpaRepository<Station, Long> {
     @Override
     List<Station> findAll();
+
+    Optional<Station> findByName(String name);
 }

--- a/src/main/java/nextstep/subway/ui/ControllerExceptionHandler.java
+++ b/src/main/java/nextstep/subway/ui/ControllerExceptionHandler.java
@@ -25,4 +25,10 @@ public class ControllerExceptionHandler {
     public void handleDuplicateAttributeException(DuplicateAttributeException e) {
         logger.info(e.getMessage());
     }
+
+    @ExceptionHandler(IllegalArgumentException.class)
+    @ResponseStatus(HttpStatus.BAD_REQUEST)
+    public void handleIllegalArgumentException(IllegalArgumentException e) {
+        logger.info(e.getMessage());
+    }
 }

--- a/src/main/java/nextstep/subway/ui/ControllerExceptionHandler.java
+++ b/src/main/java/nextstep/subway/ui/ControllerExceptionHandler.java
@@ -1,14 +1,28 @@
 package nextstep.subway.ui;
 
+import nextstep.subway.common.exception.DuplicateAttributeException;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.dao.DataIntegrityViolationException;
+import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.ControllerAdvice;
 import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.ResponseStatus;
 
 @ControllerAdvice
 public class ControllerExceptionHandler {
+
+    private Logger logger = LoggerFactory.getLogger(this.getClass());
+
     @ExceptionHandler(DataIntegrityViolationException.class)
     public ResponseEntity<Void> handleIllegalArgsException(DataIntegrityViolationException e) {
         return ResponseEntity.badRequest().build();
+    }
+
+    @ExceptionHandler(DuplicateAttributeException.class)
+    @ResponseStatus(HttpStatus.CONFLICT)
+    public void handleDuplicateAttributeException(DuplicateAttributeException e) {
+        logger.info(e.getMessage());
     }
 }

--- a/src/main/java/nextstep/subway/ui/LineController.java
+++ b/src/main/java/nextstep/subway/ui/LineController.java
@@ -4,6 +4,7 @@ import nextstep.subway.applicaion.LineService;
 import nextstep.subway.applicaion.dto.LineRequest;
 import nextstep.subway.applicaion.dto.LineResponse;
 import nextstep.subway.applicaion.dto.SectionRequest;
+import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
@@ -21,26 +22,26 @@ public class LineController {
 
     @PostMapping
     public ResponseEntity<LineResponse> createLine(@RequestBody LineRequest lineRequest) {
-        LineResponse line = lineService.saveLine(lineRequest);
+        LineResponse line = lineService.createLine(lineRequest);
         return ResponseEntity.created(URI.create("/lines/" + line.getId())).body(line);
     }
 
     @GetMapping
     public ResponseEntity<List<LineResponse>> showLines() {
-        List<LineResponse> responses = lineService.showLines();
+        List<LineResponse> responses = lineService.findAllLines();
         return ResponseEntity.ok().body(responses);
     }
 
     @GetMapping("/{id}")
     public ResponseEntity<LineResponse> getLine(@PathVariable Long id) {
-        LineResponse lineResponse = lineService.findById(id);
+        LineResponse lineResponse = lineService.findLineById(id);
         return ResponseEntity.ok().body(lineResponse);
     }
 
     @PutMapping("/{id}")
-    public ResponseEntity<Void> updateLine(@PathVariable Long id, @RequestBody LineRequest lineRequest) {
-        lineService.updateLine(id, lineRequest);
-        return ResponseEntity.ok().build();
+    @ResponseStatus(HttpStatus.OK)
+    public LineResponse updateLine(@PathVariable Long id, @RequestBody LineRequest lineRequest) {
+        return lineService.updateLine(id, lineRequest);
     }
 
     @DeleteMapping("/{id}")
@@ -51,7 +52,7 @@ public class LineController {
 
     @PostMapping("/{lineId}/sections")
     public ResponseEntity<Void> addSection(@PathVariable Long lineId, @RequestBody SectionRequest sectionRequest) {
-        lineService.addSection(lineId, sectionRequest);
+        lineService.addStationToLine(lineId, sectionRequest);
         return ResponseEntity.ok().build();
     }
 

--- a/src/main/java/nextstep/subway/ui/LineController.java
+++ b/src/main/java/nextstep/subway/ui/LineController.java
@@ -52,7 +52,7 @@ public class LineController {
 
     @PostMapping("/{lineId}/sections")
     public ResponseEntity<Void> addSection(@PathVariable Long lineId, @RequestBody SectionRequest sectionRequest) {
-        lineService.addStationToLine(lineId, sectionRequest);
+        lineService.addSection(lineId, sectionRequest);
         return ResponseEntity.ok().build();
     }
 

--- a/src/test/java/nextstep/subway/acceptance/LineSectionAcceptanceTest.java
+++ b/src/test/java/nextstep/subway/acceptance/LineSectionAcceptanceTest.java
@@ -4,19 +4,57 @@ import nextstep.subway.fixture.SectionFixture;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
+import static nextstep.subway.acceptance.LineSteps.노선_생성_요청;
 import static nextstep.subway.acceptance.LineSteps.신분당선_생성_완료;
 import static nextstep.subway.acceptance.SectionSteps.*;
 import static nextstep.subway.acceptance.StationSteps.역_생성_요청;
+import static nextstep.subway.fixture.LineFixture.신분당선;
 import static nextstep.subway.fixture.StationFixture.*;
 
 @DisplayName("지하철 구간 관리 기능")
 class LineSectionAcceptanceTest extends AcceptanceTest {
 
+    @DisplayName("역 사이에 새로운 역을 등록")
+    @Test
+    void addSectionBetweenSection() {
+        // given
+        역_생성_요청(신논현역);
+        역_생성_요청(양재역);
+        var 노선_생성_응답 = 노선_생성_요청(신분당선);
+
+        역_생성_요청(강남역);
+
+        // when
+        var lineUri = 노선_생성_응답.header("Location");
+        var 구간_등록_응답 = 구간_등록_요청(lineUri, SectionFixture.of(3L, 2L, 5));
+
+        // then
+        구간_등록_성공(구간_등록_응답);
+    }
+
+    @DisplayName("새로운 역을 상행 종점으로 등록")
+    @Test
+    void addSectionToTop() {
+        // given
+        역_생성_요청(강남역);
+        역_생성_요청(양재역);
+        var 노선_생성_응답 = 노선_생성_요청(신분당선);
+
+        역_생성_요청(신논현역);
+
+        // when
+        var lineUri = 노선_생성_응답.header("Location");
+        var 구간_등록_응답 = 구간_등록_요청(lineUri, SectionFixture.of(3L, 1L, 5));
+
+        // then
+        구간_등록_성공(구간_등록_응답);
+    }
+
     /**
      * When 지하철 노선에 새로운 구간 추가를 요청 하면
      * Then 노선에 새로운 구간이 추가된다
      */
-    @DisplayName("지하철 노선에 구간을 등록")
+    @DisplayName("새로운 역을 하행 종점으로 등록")
     @Test
     void addLineSection() {
         // given

--- a/src/test/java/nextstep/subway/acceptance/LineSectionAcceptanceTest.java
+++ b/src/test/java/nextstep/subway/acceptance/LineSectionAcceptanceTest.java
@@ -4,8 +4,7 @@ import nextstep.subway.fixture.SectionFixture;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
-import static nextstep.subway.acceptance.LineSteps.노선_생성_요청;
-import static nextstep.subway.acceptance.LineSteps.신분당선_생성_완료;
+import static nextstep.subway.acceptance.LineSteps.*;
 import static nextstep.subway.acceptance.SectionSteps.*;
 import static nextstep.subway.acceptance.StationSteps.역_생성_요청;
 import static nextstep.subway.fixture.LineFixture.신분당선;
@@ -95,4 +94,38 @@ class LineSectionAcceptanceTest extends AcceptanceTest {
         구간_삭제_성공(구간_삭제_응답);
     }
 
+
+    @DisplayName("역 사이에 새로운 역을 생성")
+    @Test
+    void addSectionBetween() {
+        // given
+        var 노선_생성_응답 = 이호선_생성_완료();
+
+        역_생성_요청(강남역);
+
+        // when
+        var lineUri = 노선_생성_응답.header("Location");
+        var 구간1 = SectionFixture.of(3L, 2L, 4);
+        var 구간_등록_응답 = 구간_등록_요청(lineUri, 구간1);
+
+        // then
+        구간_등록_성공(구간_등록_응답);
+    }
+
+    @DisplayName("역 사이에 기존 구간보다 더 긴 구간을 추가")
+    @Test
+    void addSectionBetweenLong() {
+        // given
+        var 노선_생성_응답 = 이호선_생성_완료();
+
+        역_생성_요청(강남역);
+
+        // when
+        var lineUri = 노선_생성_응답.header("Location");
+        var 구간1 = SectionFixture.of(3L, 2L, 11);
+        var 구간_등록_응답 = 구간_등록_요청(lineUri, 구간1);
+
+        // then
+        구간_생성_예외(구간_등록_응답);
+    }
 }

--- a/src/test/java/nextstep/subway/acceptance/LineSectionAcceptanceTest.java
+++ b/src/test/java/nextstep/subway/acceptance/LineSectionAcceptanceTest.java
@@ -1,39 +1,16 @@
 package nextstep.subway.acceptance;
 
-import io.restassured.response.ExtractableResponse;
-import io.restassured.response.Response;
-import org.junit.jupiter.api.BeforeEach;
+import nextstep.subway.fixture.SectionFixture;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
-import org.springframework.http.HttpStatus;
 
-import java.util.HashMap;
-import java.util.Map;
-
-import static nextstep.subway.acceptance.LineSteps.*;
-import static nextstep.subway.acceptance.StationSteps.지하철역_생성_요청;
-import static org.assertj.core.api.Assertions.assertThat;
+import static nextstep.subway.acceptance.LineSteps.신분당선_생성_완료;
+import static nextstep.subway.acceptance.SectionSteps.*;
+import static nextstep.subway.acceptance.StationSteps.역_생성_요청;
+import static nextstep.subway.fixture.StationFixture.*;
 
 @DisplayName("지하철 구간 관리 기능")
 class LineSectionAcceptanceTest extends AcceptanceTest {
-    private Long 신분당선;
-
-    private Long 강남역;
-    private Long 양재역;
-
-    /**
-     * Given 지하철역과 노선 생성을 요청 하고
-     */
-    @BeforeEach
-    public void setUp() {
-        super.setUp();
-
-        강남역 = 지하철역_생성_요청("강남역").jsonPath().getLong("id");
-        양재역 = 지하철역_생성_요청("양재역").jsonPath().getLong("id");
-
-        Map<String, String> lineCreateParams = createLineCreateParams(강남역, 양재역);
-        신분당선 = 지하철_노선_생성_요청(lineCreateParams).jsonPath().getLong("id");
-    }
 
     /**
      * When 지하철 노선에 새로운 구간 추가를 요청 하면
@@ -42,14 +19,18 @@ class LineSectionAcceptanceTest extends AcceptanceTest {
     @DisplayName("지하철 노선에 구간을 등록")
     @Test
     void addLineSection() {
+        // given
+        역_생성_요청(역삼역);
+
+        var 노선_생성_응답 = 신분당선_생성_완료();
+
         // when
-        Long 정자역 = 지하철역_생성_요청("정자역").jsonPath().getLong("id");
-        지하철_노선에_지하철_구간_생성_요청(신분당선, createSectionCreateParams(양재역, 정자역));
+        var lineUri = 노선_생성_응답.header("Location");
+        var 구간1 = SectionFixture.of(2L, 3L, 10);
+        var 구간_등록_응답 = 구간_등록_요청(lineUri, 구간1);
 
         // then
-        ExtractableResponse<Response> response = 지하철_노선_조회_요청(신분당선);
-        assertThat(response.statusCode()).isEqualTo(HttpStatus.OK.value());
-        assertThat(response.jsonPath().getList("stations.id", Long.class)).containsExactly(강남역, 양재역, 정자역);
+        구간_등록_성공(구간_등록_응답);
     }
 
     /**
@@ -61,34 +42,19 @@ class LineSectionAcceptanceTest extends AcceptanceTest {
     @Test
     void removeLineSection() {
         // given
-        Long 정자역 = 지하철역_생성_요청("정자역").jsonPath().getLong("id");
-        지하철_노선에_지하철_구간_생성_요청(신분당선, createSectionCreateParams(양재역, 정자역));
+        역_생성_요청(역삼역);
+
+        var 노선_생성_응답 = 신분당선_생성_완료();
+        var 구간1 = SectionFixture.of(2L, 3L, 10);
+
+        var lineUri = 노선_생성_응답.header("Location");
+        구간_등록_요청(lineUri, 구간1);
 
         // when
-        지하철_노선에_지하철_구간_제거_요청(신분당선, 정자역);
+        var 구간_삭제_응답 = 구간_삭제_요청(lineUri, 3L);
 
         // then
-        ExtractableResponse<Response> response = 지하철_노선_조회_요청(신분당선);
-        assertThat(response.statusCode()).isEqualTo(HttpStatus.OK.value());
-        assertThat(response.jsonPath().getList("stations.id", Long.class)).containsExactly(강남역, 양재역);
+        구간_삭제_성공(구간_삭제_응답);
     }
 
-    private Map<String, String> createLineCreateParams(Long upStationId, Long downStationId) {
-        Map<String, String> lineCreateParams;
-        lineCreateParams = new HashMap<>();
-        lineCreateParams.put("name", "신분당선");
-        lineCreateParams.put("color", "bg-red-600");
-        lineCreateParams.put("upStationId", upStationId + "");
-        lineCreateParams.put("downStationId", downStationId + "");
-        lineCreateParams.put("distance", 10 + "");
-        return lineCreateParams;
-    }
-
-    private Map<String, String> createSectionCreateParams(Long upStationId, Long downStationId) {
-        Map<String, String> params = new HashMap<>();
-        params.put("upStationId", upStationId + "");
-        params.put("downStationId", downStationId + "");
-        params.put("distance", 6 + "");
-        return params;
-    }
 }

--- a/src/test/java/nextstep/subway/acceptance/LineSectionAcceptanceTest.java
+++ b/src/test/java/nextstep/subway/acceptance/LineSectionAcceptanceTest.java
@@ -21,11 +21,13 @@ class LineSectionAcceptanceTest extends AcceptanceTest {
         역_생성_요청(양재역);
         var 노선_생성_응답 = 노선_생성_요청(신분당선);
 
-        역_생성_요청(강남역);
+        var 역_생성_응답 = 역_생성_요청(강남역);
 
         // when
         var lineUri = 노선_생성_응답.header("Location");
-        var 구간_등록_응답 = 구간_등록_요청(lineUri, SectionFixture.of(3L, 2L, 5));
+        var 하행_종점역_ID = 노선_생성_응답.jsonPath().getList("stations.id", Long.class).get(1);
+        long 새로운역_ID = 역_생성_응답.jsonPath().getLong("id");
+        var 구간_등록_응답 = 구간_등록_요청(lineUri, SectionFixture.of(새로운역_ID, 하행_종점역_ID, 5));
 
         // then
         구간_등록_성공(구간_등록_응답);
@@ -39,11 +41,13 @@ class LineSectionAcceptanceTest extends AcceptanceTest {
         역_생성_요청(양재역);
         var 노선_생성_응답 = 노선_생성_요청(신분당선);
 
-        역_생성_요청(신논현역);
+        var 역_생성_응답 = 역_생성_요청(신논현역);
 
         // when
         var lineUri = 노선_생성_응답.header("Location");
-        var 구간_등록_응답 = 구간_등록_요청(lineUri, SectionFixture.of(3L, 1L, 5));
+        var 상행_종점역_ID = 노선_생성_응답.jsonPath().getList("stations.id", Long.class).get(0);
+        var 새로운역_ID = 역_생성_응답.jsonPath().getLong("id");
+        var 구간_등록_응답 = 구간_등록_요청(lineUri, SectionFixture.of(새로운역_ID, 상행_종점역_ID, 5));
 
         // then
         구간_등록_성공(구간_등록_응답);
@@ -57,13 +61,15 @@ class LineSectionAcceptanceTest extends AcceptanceTest {
     @Test
     void addLineSection() {
         // given
-        역_생성_요청(역삼역);
-
         var 노선_생성_응답 = 신분당선_생성_완료();
+        var 역_생성_응답 = 역_생성_요청(역삼역);
 
         // when
         var lineUri = 노선_생성_응답.header("Location");
-        var 구간1 = SectionFixture.of(2L, 3L, 10);
+        var 하행_종점역_ID = 노선_생성_응답.jsonPath().getList("stations.id", Long.class).get(1);
+        var 새로운역_ID = 역_생성_응답.jsonPath().getLong("id");
+
+        var 구간1 = SectionFixture.of(하행_종점역_ID, 새로운역_ID, 10);
         var 구간_등록_응답 = 구간_등록_요청(lineUri, 구간1);
 
         // then
@@ -79,16 +85,19 @@ class LineSectionAcceptanceTest extends AcceptanceTest {
     @Test
     void removeLineSection() {
         // given
-        역_생성_요청(역삼역);
-
         var 노선_생성_응답 = 신분당선_생성_완료();
-        var 구간1 = SectionFixture.of(2L, 3L, 10);
+
+        var 역_생성_응답 = 역_생성_요청(역삼역);
+        var 하행_종점역_ID = 노선_생성_응답.jsonPath().getList("stations.id", Long.class).get(1);
+        var 새로운역_ID = 역_생성_응답.jsonPath().getLong("id");
+
+        var 구간1 = SectionFixture.of(하행_종점역_ID, 새로운역_ID, 10);
 
         var lineUri = 노선_생성_응답.header("Location");
         구간_등록_요청(lineUri, 구간1);
 
         // when
-        var 구간_삭제_응답 = 구간_삭제_요청(lineUri, 3L);
+        var 구간_삭제_응답 = 구간_삭제_요청(lineUri, 새로운역_ID);
 
         // then
         구간_삭제_성공(구간_삭제_응답);
@@ -101,11 +110,14 @@ class LineSectionAcceptanceTest extends AcceptanceTest {
         // given
         var 노선_생성_응답 = 이호선_생성_완료();
 
-        역_생성_요청(강남역);
+        var 역_생성_응답 = 역_생성_요청(강남역);
 
         // when
         var lineUri = 노선_생성_응답.header("Location");
-        var 구간1 = SectionFixture.of(3L, 2L, 4);
+        var 하행_종점역_ID = 노선_생성_응답.jsonPath().getList("stations.id", Long.class).get(1);
+        var 새로운역_ID = 역_생성_응답.jsonPath().getLong("id");
+
+        var 구간1 = SectionFixture.of(새로운역_ID, 하행_종점역_ID, 4);
         var 구간_등록_응답 = 구간_등록_요청(lineUri, 구간1);
 
         // then
@@ -118,11 +130,14 @@ class LineSectionAcceptanceTest extends AcceptanceTest {
         // given
         var 노선_생성_응답 = 이호선_생성_완료();
 
-        역_생성_요청(강남역);
+        var 역_생성_응답 = 역_생성_요청(강남역);
 
         // when
         var lineUri = 노선_생성_응답.header("Location");
-        var 구간1 = SectionFixture.of(3L, 2L, 11);
+        var 하행_종점역_ID = 노선_생성_응답.jsonPath().getList("stations.id", Long.class).get(1);
+        var 새로운역_ID = 역_생성_응답.jsonPath().getLong("id");
+
+        var 구간1 = SectionFixture.of(새로운역_ID, 하행_종점역_ID, 11);
         var 구간_등록_응답 = 구간_등록_요청(lineUri, 구간1);
 
         // then

--- a/src/test/java/nextstep/subway/acceptance/LineSteps.java
+++ b/src/test/java/nextstep/subway/acceptance/LineSteps.java
@@ -74,6 +74,16 @@ public class LineSteps {
         return LineSteps.노선_생성_요청(params);
     }
 
+    public static ExtractableResponse<Response> 이호선_생성_완료() {
+        var station1 = StationFixture.서초역;
+        var station2 = StationFixture.방배역;
+        역_생성_요청(station1);
+        역_생성_요청(station2);
+
+        var params = LineFixture.이호선;
+        return LineSteps.노선_생성_요청(params);
+    }
+
 
     public static void 노선_생성_완료(ExtractableResponse<Response> response) {
         assertThat(response.statusCode()).isEqualTo(HttpStatus.CREATED.value());

--- a/src/test/java/nextstep/subway/acceptance/LineSteps.java
+++ b/src/test/java/nextstep/subway/acceptance/LineSteps.java
@@ -1,67 +1,114 @@
 package nextstep.subway.acceptance;
 
 import io.restassured.RestAssured;
+import io.restassured.http.ContentType;
 import io.restassured.response.ExtractableResponse;
 import io.restassured.response.Response;
-import org.springframework.http.MediaType;
+import nextstep.subway.fixture.LineFixture;
+import nextstep.subway.fixture.StationFixture;
+import org.springframework.http.HttpStatus;
 
-import java.util.HashMap;
+import java.util.Arrays;
 import java.util.Map;
 
+import static nextstep.subway.acceptance.StationSteps.역_생성_요청;
+import static org.assertj.core.api.Assertions.assertThat;
+
 public class LineSteps {
-    public static ExtractableResponse<Response> 지하철_노선_생성_요청(String name, String color) {
-        Map<String, String> params = new HashMap<>();
-        params.put("name", name);
-        params.put("color", color);
-        return RestAssured
-                .given().log().all()
-                .body(params)
-                .contentType(MediaType.APPLICATION_JSON_VALUE)
-                .when().post("/lines")
-                .then().log().all().extract();
-    }
 
-    public static ExtractableResponse<Response> 지하철_노선_목록_조회_요청() {
-        return RestAssured
-                .given().log().all()
-                .when().get("/lines")
-                .then().log().all().extract();
-    }
+    private static final String PATH = "/lines";
 
-    public static ExtractableResponse<Response> 지하철_노선_조회_요청(ExtractableResponse<Response> createResponse) {
-        return RestAssured
-                .given().log().all()
-                .when().get(createResponse.header("location"))
-                .then().log().all().extract();
-    }
-
-    public static ExtractableResponse<Response> 지하철_노선_조회_요청(Long id) {
-        return RestAssured
-                .given().log().all()
-                .when().get("/lines/{id}", id)
-                .then().log().all().extract();
-    }
-
-    public static ExtractableResponse<Response> 지하철_노선_생성_요청(Map<String, String> params) {
-        return RestAssured
-                .given().log().all()
-                .body(params)
-                .contentType(MediaType.APPLICATION_JSON_VALUE)
-                .when().post("/lines")
-                .then().log().all().extract();
-    }
-
-    public static ExtractableResponse<Response> 지하철_노선에_지하철_구간_생성_요청(Long lineId, Map<String, String> params) {
+    public static ExtractableResponse<Response> 노선_생성_요청(Map<String, Object> params) {
         return RestAssured.given().log().all()
-                .contentType(MediaType.APPLICATION_JSON_VALUE)
                 .body(params)
-                .when().post("/lines/{lineId}/sections", lineId)
-                .then().log().all().extract();
+                .contentType(ContentType.JSON)
+                .when()
+                .post(PATH)
+                .then().log().all()
+                .extract();
     }
 
-    public static ExtractableResponse<Response> 지하철_노선에_지하철_구간_제거_요청(Long lineId, Long stationId) {
+    public static ExtractableResponse<Response> 노선_조회_요청(String uri) {
         return RestAssured.given().log().all()
-                .when().delete("/lines/{lineId}/sections?stationId={stationId}", lineId, stationId)
-                .then().log().all().extract();
+                .accept(ContentType.JSON)
+                .when()
+                .get(uri)
+                .then().log().all()
+                .extract();
+    }
+
+    public static ExtractableResponse<Response> 노선_목록_조회_요청() {
+        return RestAssured.given().log().all()
+                .accept(ContentType.JSON)
+                .when()
+                .get(PATH)
+                .then().log().all()
+                .extract();
+    }
+
+    public static ExtractableResponse<Response> 노선_수정_요청(String uri, Map<String, Object> params) {
+        return RestAssured.given().log().all()
+                .contentType(ContentType.JSON)
+                .body(params)
+                .when()
+                .put(uri)
+                .then().log().all()
+                .extract();
+    }
+
+    public static ExtractableResponse<Response> 노선_삭제_요청(String uri) {
+        return RestAssured.given().log().all()
+                .contentType(ContentType.JSON)
+                .delete(uri)
+                .then().log().all()
+                .extract();
+    }
+
+    public static ExtractableResponse<Response> 신분당선_생성_완료() {
+        var station1 = StationFixture.신논현역;
+        var station2 = StationFixture.강남역;
+        역_생성_요청(station1);
+        역_생성_요청(station2);
+
+        var params = LineFixture.신분당선;
+        return LineSteps.노선_생성_요청(params);
+    }
+
+
+    public static void 노선_생성_완료(ExtractableResponse<Response> response) {
+        assertThat(response.statusCode()).isEqualTo(HttpStatus.CREATED.value());
+        assertThat(response.header("Location")).isNotBlank();
+    }
+
+    public static void 노선_목록_조회_완료(ExtractableResponse<Response> response, Map<String, Object>... paramsArgs) {
+        assertThat(response.statusCode()).isEqualTo(HttpStatus.OK.value());
+        var lineNames = response.jsonPath().getList("name");
+        assertThat(lineNames).contains(Arrays.stream(paramsArgs).map(m -> m.get("name")).toArray());
+    }
+
+    public static void 노선_조회_완료(
+            ExtractableResponse<Response> response,
+            Map<String, Object> params,
+            Map<String, String>... stationFixtures
+    ) {
+        assertThat(response.statusCode()).isEqualTo(HttpStatus.OK.value());
+        var lineName = response.jsonPath().getString("name");
+        var stations = response.jsonPath().getList("stations.name");
+        assertThat(lineName).isEqualTo(params.get("name"));
+        assertThat(stations).containsExactlyInAnyOrder(Arrays.stream(stationFixtures).map(m -> m.get("name")).toArray());
+    }
+
+    public static void 노선_수정_완료(ExtractableResponse<Response> response, Map<String, Object> modifyParams) {
+        assertThat(response.statusCode()).isEqualTo(HttpStatus.OK.value());
+        var lineName = response.jsonPath().getString("name");
+        assertThat(lineName).isEqualTo(modifyParams.get("name"));
+    }
+
+    public static void 노선_삭제_완료(ExtractableResponse<Response> response) {
+        assertThat(response.statusCode()).isEqualTo(HttpStatus.NO_CONTENT.value());
+    }
+
+    public static void 중복된_노선_생성_예외(ExtractableResponse<Response> response) {
+        assertThat(response.statusCode()).isEqualTo(HttpStatus.CONFLICT.value());
     }
 }

--- a/src/test/java/nextstep/subway/acceptance/SectionSteps.java
+++ b/src/test/java/nextstep/subway/acceptance/SectionSteps.java
@@ -1,0 +1,43 @@
+package nextstep.subway.acceptance;
+
+import io.restassured.RestAssured;
+import io.restassured.http.ContentType;
+import io.restassured.response.ExtractableResponse;
+import io.restassured.response.Response;
+import org.springframework.http.HttpStatus;
+
+import java.util.Map;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class SectionSteps {
+
+    private static final String PATH = "/sections";
+
+    public static ExtractableResponse<Response> 구간_등록_요청(String lineUri, Map<String, Object> params) {
+        return RestAssured.given().log().all()
+                .body(params)
+                .contentType(ContentType.JSON)
+                .when()
+                .post(lineUri + PATH)
+                .then().log().all()
+                .extract();
+    }
+
+    public static ExtractableResponse<Response> 구간_삭제_요청(String lineUri, Long stationId) {
+        return RestAssured.given().log().all()
+                .contentType(ContentType.JSON)
+                .when()
+                .delete(lineUri + PATH + "?stationId=" + stationId)
+                .then().log().all()
+                .extract();
+    }
+
+    public static void 구간_등록_성공(ExtractableResponse<Response> response) {
+        assertThat(response.statusCode()).isEqualTo(HttpStatus.OK.value());
+    }
+
+    public static void 구간_삭제_성공(ExtractableResponse<Response> response) {
+        assertThat(response.statusCode()).isEqualTo(HttpStatus.OK.value());
+    }
+}

--- a/src/test/java/nextstep/subway/acceptance/SectionSteps.java
+++ b/src/test/java/nextstep/subway/acceptance/SectionSteps.java
@@ -40,4 +40,8 @@ public class SectionSteps {
     public static void 구간_삭제_성공(ExtractableResponse<Response> response) {
         assertThat(response.statusCode()).isEqualTo(HttpStatus.OK.value());
     }
+
+    public static void 구간_생성_예외(ExtractableResponse<Response> response){
+        assertThat(response.statusCode()).isEqualTo(HttpStatus.BAD_REQUEST.value());
+    }
 }

--- a/src/test/java/nextstep/subway/acceptance/StationAcceptanceTest.java
+++ b/src/test/java/nextstep/subway/acceptance/StationAcceptanceTest.java
@@ -1,16 +1,11 @@
 package nextstep.subway.acceptance;
 
-import io.restassured.RestAssured;
-import io.restassured.response.ExtractableResponse;
-import io.restassured.response.Response;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
-import org.springframework.http.HttpStatus;
 
-import java.util.List;
-
-import static nextstep.subway.acceptance.StationSteps.지하철역_생성_요청;
-import static org.assertj.core.api.Assertions.assertThat;
+import static nextstep.subway.acceptance.StationSteps.*;
+import static nextstep.subway.fixture.StationFixture.강남역;
+import static nextstep.subway.fixture.StationFixture.역삼역;
 
 @DisplayName("지하철역 관리 기능")
 class StationAcceptanceTest extends AcceptanceTest {
@@ -21,12 +16,14 @@ class StationAcceptanceTest extends AcceptanceTest {
     @DisplayName("지하철역 생성")
     @Test
     void createStation() {
+        // given
+        var 역1 = 강남역;
+
         // when
-        ExtractableResponse<Response> response = 지하철역_생성_요청("강남역");
+        var 역_생성_응답 = 역_생성_요청(역1);
 
         // then
-        assertThat(response.statusCode()).isEqualTo(HttpStatus.CREATED.value());
-        assertThat(response.header("Location")).isNotBlank();
+        역_생성_완료(역_생성_응답);
     }
 
     /**
@@ -38,20 +35,17 @@ class StationAcceptanceTest extends AcceptanceTest {
     @DisplayName("지하철역 목록 조회")
     @Test
     void getStations() {
-        // given
-        지하철역_생성_요청("강남역");
-        지하철역_생성_요청("역삼역");
+        /// given
+        var 역1 = 강남역;
+        역_생성_요청(역1);
+
+        var 역2 = 역삼역;
+        역_생성_요청(역2);
 
         // when
-        ExtractableResponse<Response> response = RestAssured.given().log().all()
-                .when()
-                .get("/stations")
-                .then().log().all()
-                .extract();
+        var 역_목록_조회_응답 = 역_목록_조회_요청();
 
-        assertThat(response.statusCode()).isEqualTo(HttpStatus.OK.value());
-        List<String> stationNames = response.jsonPath().getList("name");
-        assertThat(stationNames).contains("강남역", "역삼역");
+        역_목록_조회_완료(역_목록_조회_응답, 역1, 역2);
     }
 
     /**
@@ -63,18 +57,14 @@ class StationAcceptanceTest extends AcceptanceTest {
     @Test
     void deleteStation() {
         // given
-        ExtractableResponse<Response> createResponse = 지하철역_생성_요청("강남역");
+        var 역_생성_응답 = 역_생성_요청(강남역);
 
         // when
-        String uri = createResponse.header("Location");
-        ExtractableResponse<Response> response = RestAssured.given().log().all()
-                .when()
-                .delete(uri)
-                .then().log().all()
-                .extract();
+        String uri = 역_생성_응답.header("Location");
+        var 역_삭제_응답 = 역_삭제_요청(uri);
 
         // then
-        assertThat(response.statusCode()).isEqualTo(HttpStatus.NO_CONTENT.value());
+        역_삭제_완료(역_삭제_응답);
     }
 
     /**
@@ -86,12 +76,13 @@ class StationAcceptanceTest extends AcceptanceTest {
     @Test
     void duplicateName() {
         // given
-        지하철역_생성_요청("강남역");
+        var 역1 = 강남역;
+        역_생성_요청(역1);
 
         // when
-        ExtractableResponse<Response> createResponse = 지하철역_생성_요청("강남역");
+        var 역_생성_응답 = 역_생성_요청(역1);
 
         // then
-        assertThat(createResponse.statusCode()).isEqualTo(HttpStatus.BAD_REQUEST.value());
+        중복된_역_생성_예외(역_생성_응답);
     }
 }

--- a/src/test/java/nextstep/subway/acceptance/StationSteps.java
+++ b/src/test/java/nextstep/subway/acceptance/StationSteps.java
@@ -1,23 +1,63 @@
 package nextstep.subway.acceptance;
 
 import io.restassured.RestAssured;
+import io.restassured.http.ContentType;
 import io.restassured.response.ExtractableResponse;
 import io.restassured.response.Response;
-import org.springframework.http.MediaType;
+import org.springframework.http.HttpStatus;
 
-import java.util.HashMap;
+import java.util.Arrays;
+import java.util.List;
 import java.util.Map;
 
+import static org.assertj.core.api.Assertions.assertThat;
+
 public class StationSteps {
-    public static ExtractableResponse<Response> 지하철역_생성_요청(String name) {
-        Map<String, String> params = new HashMap<>();
-        params.put("name", name);
+    private static final String PATH = "/stations";
+
+    public static ExtractableResponse<Response> 역_생성_요청(Map<String, String> params) {
         return RestAssured.given().log().all()
                 .body(params)
-                .contentType(MediaType.APPLICATION_JSON_VALUE)
+                .contentType(ContentType.JSON)
                 .when()
-                .post("/stations")
+                .post(PATH)
                 .then().log().all()
                 .extract();
+    }
+
+    public static ExtractableResponse<Response> 역_목록_조회_요청() {
+        return RestAssured.given().log().all()
+                .accept(ContentType.JSON)
+                .when()
+                .get(PATH)
+                .then().log().all()
+                .extract();
+    }
+
+    public static ExtractableResponse<Response> 역_삭제_요청(String uri) {
+        return RestAssured.given().log().all()
+                .contentType(ContentType.JSON)
+                .delete(uri)
+                .then().log().all()
+                .extract();
+    }
+
+    public static void 역_생성_완료(ExtractableResponse<Response> response) {
+        assertThat(response.statusCode()).isEqualTo(HttpStatus.CREATED.value());
+        assertThat(response.header("Location")).isNotBlank();
+    }
+
+    public static void 역_목록_조회_완료(ExtractableResponse<Response> response, Map<String, String>... paramsArgs) {
+        assertThat(response.statusCode()).isEqualTo(HttpStatus.OK.value());
+        List<String> stationNames = response.jsonPath().getList("name");
+        assertThat(stationNames).contains(Arrays.stream(paramsArgs).map(m -> m.get("name")).toArray(String[]::new));
+    }
+
+    public static void 역_삭제_완료(ExtractableResponse<Response> response) {
+        assertThat(response.statusCode()).isEqualTo(HttpStatus.NO_CONTENT.value());
+    }
+
+    public static void 중복된_역_생성_예외(ExtractableResponse<Response> response){
+        assertThat(response.statusCode()).isEqualTo(HttpStatus.CONFLICT.value());
     }
 }

--- a/src/test/java/nextstep/subway/fixture/LineFixture.java
+++ b/src/test/java/nextstep/subway/fixture/LineFixture.java
@@ -1,0 +1,21 @@
+package nextstep.subway.fixture;
+
+import java.util.Map;
+
+public class LineFixture {
+
+    public static final Map<String, Object> 신분당선 = Map.of(
+            "name", "신분당선",
+            "color", "bg-red-600",
+            "upStationId", 1L,
+            "downStationId", 2L,
+            "distance", 10
+    );
+    public static final Map<String, Object> 이호선 = Map.of(
+            "name", "이호선",
+            "color", "bg-green-600",
+            "upStationId", 2L,
+            "downStationId", 3L,
+            "distance", 10
+    );
+}

--- a/src/test/java/nextstep/subway/fixture/LineFixture.java
+++ b/src/test/java/nextstep/subway/fixture/LineFixture.java
@@ -14,8 +14,8 @@ public class LineFixture {
     public static final Map<String, Object> 이호선 = Map.of(
             "name", "이호선",
             "color", "bg-green-600",
-            "upStationId", 2L,
-            "downStationId", 3L,
+            "upStationId", 1L,
+            "downStationId", 2L,
             "distance", 10
     );
 }

--- a/src/test/java/nextstep/subway/fixture/SectionFixture.java
+++ b/src/test/java/nextstep/subway/fixture/SectionFixture.java
@@ -1,0 +1,15 @@
+package nextstep.subway.fixture;
+
+import java.util.Map;
+
+public class SectionFixture {
+
+    public static Map<String, Object> of(Long upStationId, Long downStationId, int distance) {
+        return Map.of(
+                "downStationId", downStationId,
+                "upStationId", upStationId,
+                "distance", distance
+        );
+    }
+
+}

--- a/src/test/java/nextstep/subway/fixture/StationFixture.java
+++ b/src/test/java/nextstep/subway/fixture/StationFixture.java
@@ -1,0 +1,29 @@
+package nextstep.subway.fixture;
+
+import java.util.Map;
+
+public class StationFixture {
+
+    public static final Map<String, String> 신논현역 = Map.of(
+            "name", "신논현역"
+    );
+    public static final Map<String, String> 강남역 = Map.of(
+            "name", "강남역"
+    );
+    public static final Map<String, String> 역삼역 = Map.of(
+            "name", "역삼역"
+    );
+    public static final Map<String, String> 서초역 = Map.of(
+            "name", "서초역"
+    );
+    public static final Map<String, String> 방배역 = Map.of(
+            "name", "방배역"
+    );
+    public static final Map<String, String> 양재역 = Map.of(
+            "name", "양재역"
+    );
+    public static final Map<String, String> 선릉역 = Map.of(
+            "name", "선릉역"
+    );
+
+}

--- a/src/test/java/nextstep/subway/unit/LineServiceMockTest.java
+++ b/src/test/java/nextstep/subway/unit/LineServiceMockTest.java
@@ -23,30 +23,34 @@ public class LineServiceMockTest {
     @Mock
     private StationService stationService;
 
+    /**
+     * 리팩토링을 진행하면서 목을 사용하다보니 구현에 강하게 결합된 테스트여서 깨짐.
+     * 기존에는 LineService 가 StationService 에 의존하고 있었는데, StationRepository 를 의존하도록 변경하였습니다.
+     */
     @Test
     void addSection() {
         // given
         // lineRepository, stationService stub 설정을 통해 초기값 셋팅
-        var upStationId = 1L;
-        var downStationId = 2L;
-        var upStation = new Station("신논현역");
-        var downStation = new Station("강남역");
-        var distance = 10;
-        var lineId = 1L;
-        var line = new Line("신분당선", "bg-red-600");
-
-        when(lineRepository.findById(lineId)).thenReturn(Optional.of(line));
-        when(stationService.findById(upStationId)).thenReturn(upStation);
-        when(stationService.findById(downStationId)).thenReturn(downStation);
+//        var upStationId = 1L;
+//        var downStationId = 2L;
+//        var upStation = new Station("신논현역");
+//        var downStation = new Station("강남역");
+//        var distance = 10;
+//        var lineId = 1L;
+//        var line = new Line("신분당선", "bg-red-600");
+//
+//        when(lineRepository.findById(lineId)).thenReturn(Optional.of(line));
+//        when(stationService.findById(upStationId)).thenReturn(upStation);
+//        when(stationService.findById(downStationId)).thenReturn(downStation);
 
         // when
         // lineService.addSection 호출
-        var sut = new LineService(lineRepository, stationService);
-        sut.addSection(lineId, SectionRequest.of(upStationId, downStationId, distance));
+//        var sut = new LineService(lineRepository, stationService);
+//        sut.addStationToLine(lineId, SectionRequest.of(upStationId, downStationId, distance));
 
         // then
         // line.findLineById 메서드를 통해 검증
-        var lineResponse = sut.findById(lineId);
-        assertThat(lineResponse.getStations().size()).isEqualTo(2);
+//        var lineResponse = sut.findById(lineId);
+//        assertThat(lineResponse.getStations().size()).isEqualTo(2);
     }
 }

--- a/src/test/java/nextstep/subway/unit/LineServiceMockTest.java
+++ b/src/test/java/nextstep/subway/unit/LineServiceMockTest.java
@@ -1,11 +1,11 @@
 package nextstep.subway.unit;
 
 import nextstep.subway.applicaion.LineService;
-import nextstep.subway.applicaion.StationService;
 import nextstep.subway.applicaion.dto.SectionRequest;
 import nextstep.subway.domain.Line;
 import nextstep.subway.domain.LineRepository;
 import nextstep.subway.domain.Station;
+import nextstep.subway.domain.StationRepository;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
@@ -21,7 +21,7 @@ public class LineServiceMockTest {
     @Mock
     private LineRepository lineRepository;
     @Mock
-    private StationService stationService;
+    private StationRepository stationRepository;
 
     /**
      * 리팩토링을 진행하면서 목을 사용하다보니 구현에 강하게 결합된 테스트여서 깨짐.
@@ -31,26 +31,27 @@ public class LineServiceMockTest {
     void addSection() {
         // given
         // lineRepository, stationService stub 설정을 통해 초기값 셋팅
-//        var upStationId = 1L;
-//        var downStationId = 2L;
-//        var upStation = new Station("신논현역");
-//        var downStation = new Station("강남역");
-//        var distance = 10;
-//        var lineId = 1L;
-//        var line = new Line("신분당선", "bg-red-600");
-//
-//        when(lineRepository.findById(lineId)).thenReturn(Optional.of(line));
-//        when(stationService.findById(upStationId)).thenReturn(upStation);
-//        when(stationService.findById(downStationId)).thenReturn(downStation);
+        var upStationId = 1L;
+        var downStationId = 2L;
+        var upStation = new Station("신논현역");
+        var downStation = new Station("강남역");
+        var distance = 10;
+        var lineId = 1L;
+        var line = new Line("신분당선", "bg-red-600", upStation, downStation, distance);
+
+        var newStationId = 3L;
+        when(lineRepository.findById(lineId)).thenReturn(Optional.of(line));
+        when(stationRepository.findById(downStationId)).thenReturn(Optional.of(downStation));
+        when(stationRepository.findById(newStationId)).thenReturn(Optional.of(new Station("양재역")));
 
         // when
         // lineService.addSection 호출
-//        var sut = new LineService(lineRepository, stationService);
-//        sut.addStationToLine(lineId, SectionRequest.of(upStationId, downStationId, distance));
+        var sut = new LineService(lineRepository, stationRepository);
+        sut.addSection(lineId, SectionRequest.of(downStationId, newStationId, distance));
 
         // then
         // line.findLineById 메서드를 통해 검증
-//        var lineResponse = sut.findById(lineId);
-//        assertThat(lineResponse.getStations().size()).isEqualTo(2);
+        var lineResponse = sut.findLineById(lineId);
+        assertThat(lineResponse.getStations().size()).isEqualTo(3);
     }
 }

--- a/src/test/java/nextstep/subway/unit/LineServiceMockTest.java
+++ b/src/test/java/nextstep/subway/unit/LineServiceMockTest.java
@@ -1,11 +1,20 @@
 package nextstep.subway.unit;
 
+import nextstep.subway.applicaion.LineService;
 import nextstep.subway.applicaion.StationService;
+import nextstep.subway.applicaion.dto.SectionRequest;
+import nextstep.subway.domain.Line;
 import nextstep.subway.domain.LineRepository;
+import nextstep.subway.domain.Station;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.when;
 
 @ExtendWith(MockitoExtension.class)
 public class LineServiceMockTest {
@@ -18,11 +27,26 @@ public class LineServiceMockTest {
     void addSection() {
         // given
         // lineRepository, stationService stub 설정을 통해 초기값 셋팅
+        var upStationId = 1L;
+        var downStationId = 2L;
+        var upStation = new Station("신논현역");
+        var downStation = new Station("강남역");
+        var distance = 10;
+        var lineId = 1L;
+        var line = new Line("신분당선", "bg-red-600");
+
+        when(lineRepository.findById(lineId)).thenReturn(Optional.of(line));
+        when(stationService.findById(upStationId)).thenReturn(upStation);
+        when(stationService.findById(downStationId)).thenReturn(downStation);
 
         // when
         // lineService.addSection 호출
+        var sut = new LineService(lineRepository, stationService);
+        sut.addSection(lineId, SectionRequest.of(upStationId, downStationId, distance));
 
         // then
         // line.findLineById 메서드를 통해 검증
+        var lineResponse = sut.findById(lineId);
+        assertThat(lineResponse.getStations().size()).isEqualTo(2);
     }
 }

--- a/src/test/java/nextstep/subway/unit/LineServiceTest.java
+++ b/src/test/java/nextstep/subway/unit/LineServiceTest.java
@@ -2,10 +2,7 @@ package nextstep.subway.unit;
 
 import nextstep.subway.applicaion.LineService;
 import nextstep.subway.applicaion.dto.SectionRequest;
-import nextstep.subway.domain.Line;
-import nextstep.subway.domain.LineRepository;
-import nextstep.subway.domain.Station;
-import nextstep.subway.domain.StationRepository;
+import nextstep.subway.domain.*;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
@@ -31,13 +28,16 @@ public class LineServiceTest {
         var upStation = stationRepository.save(new Station("신논현역"));
         var downStation = stationRepository.save(new Station("강남역"));
         var line = lineRepository.save(new Line("신분당선", "bg-red-600"));
+        line.init(new Section(upStation, downStation, 10));
+        var station = stationRepository.save(new Station("양재역"));
 
         // when
         // lineService.addSection 호출
-        lineService.addSection(line.getId(), SectionRequest.of(upStation.getId(), downStation.getId(), 10));
+        var sectionRequest = SectionRequest.of(2L, 3L, 10);
+        lineService.addStationToLine(line.getId(), sectionRequest);
 
         // then
         // line.getSections 메서드를 통해 검증
-        assertThat(line.getSections().size()).isEqualTo(1);
+        assertThat(line.getSections().size()).isEqualTo(2);
     }
 }

--- a/src/test/java/nextstep/subway/unit/LineServiceTest.java
+++ b/src/test/java/nextstep/subway/unit/LineServiceTest.java
@@ -1,12 +1,17 @@
 package nextstep.subway.unit;
 
 import nextstep.subway.applicaion.LineService;
+import nextstep.subway.applicaion.dto.SectionRequest;
+import nextstep.subway.domain.Line;
 import nextstep.subway.domain.LineRepository;
+import nextstep.subway.domain.Station;
 import nextstep.subway.domain.StationRepository;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.transaction.annotation.Transactional;
+
+import static org.assertj.core.api.Assertions.assertThat;
 
 @SpringBootTest
 @Transactional
@@ -23,11 +28,16 @@ public class LineServiceTest {
     void addSection() {
         // given
         // stationRepository와 lineRepository를 활용하여 초기값 셋팅
+        var upStation = stationRepository.save(new Station("신논현역"));
+        var downStation = stationRepository.save(new Station("강남역"));
+        var line = lineRepository.save(new Line("신분당선", "bg-red-600"));
 
         // when
         // lineService.addSection 호출
+        lineService.addSection(line.getId(), SectionRequest.of(upStation.getId(), downStation.getId(), 10));
 
         // then
         // line.getSections 메서드를 통해 검증
+        assertThat(line.getSections().size()).isEqualTo(1);
     }
 }

--- a/src/test/java/nextstep/subway/unit/LineServiceTest.java
+++ b/src/test/java/nextstep/subway/unit/LineServiceTest.java
@@ -27,14 +27,13 @@ public class LineServiceTest {
         // stationRepository와 lineRepository를 활용하여 초기값 셋팅
         var upStation = stationRepository.save(new Station("신논현역"));
         var downStation = stationRepository.save(new Station("강남역"));
-        var line = lineRepository.save(new Line("신분당선", "bg-red-600"));
-        line.init(new Section(upStation, downStation, 10));
+        var line = lineRepository.save(new Line("신분당선", "bg-red-600", upStation, downStation, 10));
         var station = stationRepository.save(new Station("양재역"));
 
         // when
         // lineService.addSection 호출
         var sectionRequest = SectionRequest.of(2L, 3L, 10);
-        lineService.addStationToLine(line.getId(), sectionRequest);
+        lineService.addSection(line.getId(), sectionRequest);
 
         // then
         // line.getSections 메서드를 통해 검증

--- a/src/test/java/nextstep/subway/unit/LineTest.java
+++ b/src/test/java/nextstep/subway/unit/LineTest.java
@@ -7,6 +7,7 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 class LineTest {
     @DisplayName("구간 목록 마지막에 새로운 구간을 추가할 경우")
@@ -67,4 +68,91 @@ class LineTest {
         // then
         assertThat(line.getStations()).doesNotContain(station3);
     }
+
+    @DisplayName("구간 목록 처음에 새로운 구간을 추가할 경우")
+    @Test
+    void addSectionToTop() {
+        // given
+        var station1 = new Station("강남역");
+        var station2 = new Station("양재역");
+
+        var line = new Line("신분당선", "bg-red-600");
+        var section = new Section(station1, station2, 10);
+        line.init(section);
+
+        // when
+        var station = new Station("신논현역");
+        line.addSection(new Section(station, station1, 11));
+
+        // then
+        assertThat(line.getStations()).containsExactlyInAnyOrder(station1, station2, station);
+    }
+
+    @DisplayName("구간의 중간에 새로운 구간을 추가할 경우")
+    @Test
+    void addSectionToBetween() {
+        // given
+        var station1 = new Station("신논현역");
+        var station2 = new Station("양재역");
+
+        var line = new Line("신분당선", "bg-red-600");
+        var section = new Section(station1, station2, 10);
+        line.init(section);
+
+        // when
+        var station = new Station("강남역");
+        line.addSection(new Section(station1, station, 6));
+
+        // then
+        assertThat(line.getStations()).containsExactlyInAnyOrder(station1, station2, station);
+    }
+
+    @DisplayName("기존 구간의 중간에 추가할 때 더 긴 구간을 추가하면 예외 발생")
+    @Test
+    void addSectionToBetweenLong() {
+        // given
+        var station1 = new Station("신논현역");
+        var station2 = new Station("양재역");
+
+        var line = new Line("신분당선", "bg-red-600");
+        var section = new Section(station1, station2, 10);
+        line.init(section);
+
+        // when, then
+        var station = new Station("강남역");
+        assertThrows(RuntimeException.class, () -> line.addSection(new Section(station1, station, 11)));
+    }
+
+    @DisplayName("추가하는 구간의 상행,하행 역 모두 현재 노선에 존재하지 않으면 예외 발생")
+    @Test
+    void addSectionWithoutStationsExist() {
+        // given
+        var station1 = new Station("신논현역");
+        var station2 = new Station("양재역");
+
+        var line = new Line("신분당선", "bg-red-600");
+        var section = new Section(station1, station2, 10);
+        line.init(section);
+
+        // when, then
+        var station3 = new Station("강남역");
+        var station4 = new Station("신사역");
+        assertThrows(RuntimeException.class, () -> line.addSection(new Section(station4, station3, 9)));
+    }
+
+    @DisplayName("추가하는 구간의 상행,하행 역 모두 현재 노선에 존재하면 예외 발생")
+    @Test
+    void addSectionWithStationsExist() {
+        // given
+        var station1 = new Station("신논현역");
+        var station2 = new Station("양재역");
+
+        var line = new Line("신분당선", "bg-red-600");
+        var section = new Section(station1, station2, 10);
+        line.init(section);
+
+        // when, then
+        assertThrows(RuntimeException.class, () -> line.addSection(new Section(station1, station2, 9)));
+    }
+
 }

--- a/src/test/java/nextstep/subway/unit/LineTest.java
+++ b/src/test/java/nextstep/subway/unit/LineTest.java
@@ -1,21 +1,70 @@
 package nextstep.subway.unit;
 
+import nextstep.subway.domain.Line;
+import nextstep.subway.domain.Section;
+import nextstep.subway.domain.Station;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
 
 class LineTest {
     @DisplayName("구간 목록 마지막에 새로운 구간을 추가할 경우")
     @Test
     void addSection() {
+        // given
+        var line = new Line("신분당선", "bg-red-600");
+        var station1 = new Station("신논현역");
+        var station2 = new Station("강남역");
+
+        var section1 = new Section(station1, station2, 10);
+        line.init(section1);
+
+        // when
+        var station = new Station("양재역");
+        var section = new Section(station2, station, 11);
+        line.addSection(section);
+
+        // then
+        assertThat(line.getSections().size()).isEqualTo(2);
     }
 
     @DisplayName("노선에 속해있는 역 목록 조회")
     @Test
     void getStations() {
+        // given
+        var station1 = new Station("신논현역");
+        var station2 = new Station("강남역");
+
+        var line = new Line("신분당선", "bg-red-600");
+        var section = new Section(station1, station2, 10);
+        line.init(section);
+
+        // when
+        var stationList = line.getStations();
+
+        // then
+        assertThat(stationList).containsExactlyInAnyOrder(station1, station2);
     }
 
     @DisplayName("구간이 목록에서 마지막 역 삭제")
     @Test
     void removeSection() {
+        // given
+        var station1 = new Station("신논현역");
+        var station2 = new Station("강남역");
+
+        var line = new Line("신분당선", "bg-red-600");
+        var section = new Section(station1, station2, 10);
+        line.init(section);
+
+        var station3 = new Station("양재역");
+        line.addSection(new Section(station2, station3, 10));
+
+        // when
+        line.remove(station3);
+
+        // then
+        assertThat(line.getStations()).doesNotContain(station3);
     }
 }

--- a/src/test/java/nextstep/subway/unit/LineTest.java
+++ b/src/test/java/nextstep/subway/unit/LineTest.java
@@ -1,12 +1,12 @@
 package nextstep.subway.unit;
 
 import nextstep.subway.domain.Line;
-import nextstep.subway.domain.Section;
 import nextstep.subway.domain.Station;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertAll;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
 class LineTest {
@@ -14,20 +14,23 @@ class LineTest {
     @Test
     void addSection() {
         // given
-        var line = new Line("신분당선", "bg-red-600");
         var station1 = new Station("신논현역");
         var station2 = new Station("강남역");
 
-        var section1 = new Section(station1, station2, 10);
-        line.init(section1);
+        var line = new Line("신분당선", "bg-red-600", station1, station2, 10);
 
         // when
         var station = new Station("양재역");
-        var section = new Section(station2, station, 11);
-        line.addSection(section);
+        line.addSection(station2, station, 11);
 
         // then
-        assertThat(line.getSections().size()).isEqualTo(2);
+        var sections = line.getSections();
+        var stations = line.getStations();
+        assertAll(
+                () -> assertThat(sections.size()).isEqualTo(2),
+                () -> assertThat(stations.get(stations.size() - 1)).isEqualTo(station)
+        );
+
     }
 
     @DisplayName("노선에 속해있는 역 목록 조회")
@@ -37,9 +40,7 @@ class LineTest {
         var station1 = new Station("신논현역");
         var station2 = new Station("강남역");
 
-        var line = new Line("신분당선", "bg-red-600");
-        var section = new Section(station1, station2, 10);
-        line.init(section);
+        var line = new Line("신분당선", "bg-red-600", station1, station2, 10);
 
         // when
         var stationList = line.getStations();
@@ -55,15 +56,13 @@ class LineTest {
         var station1 = new Station("신논현역");
         var station2 = new Station("강남역");
 
-        var line = new Line("신분당선", "bg-red-600");
-        var section = new Section(station1, station2, 10);
-        line.init(section);
+        var line = new Line("신분당선", "bg-red-600", station1, station2, 10);
 
         var station3 = new Station("양재역");
-        line.addSection(new Section(station2, station3, 10));
+        line.addSection(station2, station3, 10);
 
         // when
-        line.remove(station3);
+        line.removeSection(station3);
 
         // then
         assertThat(line.getStations()).doesNotContain(station3);
@@ -76,13 +75,11 @@ class LineTest {
         var station1 = new Station("강남역");
         var station2 = new Station("양재역");
 
-        var line = new Line("신분당선", "bg-red-600");
-        var section = new Section(station1, station2, 10);
-        line.init(section);
+        var line = new Line("신분당선", "bg-red-600", station1, station2, 10);
 
         // when
         var station = new Station("신논현역");
-        line.addSection(new Section(station, station1, 11));
+        line.addSection(station, station1, 11);
 
         // then
         assertThat(line.getStations()).containsExactlyInAnyOrder(station1, station2, station);
@@ -95,16 +92,18 @@ class LineTest {
         var station1 = new Station("신논현역");
         var station2 = new Station("양재역");
 
-        var line = new Line("신분당선", "bg-red-600");
-        var section = new Section(station1, station2, 10);
-        line.init(section);
+        var line = new Line("신분당선", "bg-red-600", station1, station2, 10);
 
         // when
         var station = new Station("강남역");
-        line.addSection(new Section(station1, station, 6));
+        line.addSection(station1, station, 6);
 
         // then
-        assertThat(line.getStations()).containsExactlyInAnyOrder(station1, station2, station);
+        var orderedSections = line.getSections().getOrderedSections();
+        assertAll(
+                () -> assertThat(line.getStations()).containsExactlyInAnyOrder(station1, station2, station),
+                () -> assertThat(orderedSections.get(orderedSections.size() - 1).getDistance()).isEqualTo(4)
+        );
     }
 
     @DisplayName("기존 구간의 중간에 추가할 때 더 긴 구간을 추가하면 예외 발생")
@@ -114,13 +113,11 @@ class LineTest {
         var station1 = new Station("신논현역");
         var station2 = new Station("양재역");
 
-        var line = new Line("신분당선", "bg-red-600");
-        var section = new Section(station1, station2, 10);
-        line.init(section);
+        var line = new Line("신분당선", "bg-red-600", station1, station2, 10);
 
         // when, then
         var station = new Station("강남역");
-        assertThrows(RuntimeException.class, () -> line.addSection(new Section(station1, station, 11)));
+        assertThrows(RuntimeException.class, () -> line.addSection(station1, station, 11));
     }
 
     @DisplayName("추가하는 구간의 상행,하행 역 모두 현재 노선에 존재하지 않으면 예외 발생")
@@ -130,14 +127,12 @@ class LineTest {
         var station1 = new Station("신논현역");
         var station2 = new Station("양재역");
 
-        var line = new Line("신분당선", "bg-red-600");
-        var section = new Section(station1, station2, 10);
-        line.init(section);
+        var line = new Line("신분당선", "bg-red-600", station1, station2, 10);
 
         // when, then
         var station3 = new Station("강남역");
         var station4 = new Station("신사역");
-        assertThrows(RuntimeException.class, () -> line.addSection(new Section(station4, station3, 9)));
+        assertThrows(RuntimeException.class, () -> line.addSection(station4, station3, 9));
     }
 
     @DisplayName("추가하는 구간의 상행,하행 역 모두 현재 노선에 존재하면 예외 발생")
@@ -147,12 +142,10 @@ class LineTest {
         var station1 = new Station("신논현역");
         var station2 = new Station("양재역");
 
-        var line = new Line("신분당선", "bg-red-600");
-        var section = new Section(station1, station2, 10);
-        line.init(section);
+        var line = new Line("신분당선", "bg-red-600", station1, station2, 10);
 
         // when, then
-        assertThrows(RuntimeException.class, () -> line.addSection(new Section(station1, station2, 9)));
+        assertThrows(RuntimeException.class, () -> line.addSection(station1, station2, 9));
     }
 
 }


### PR DESCRIPTION
안녕하세요~ 준우님😀
설 연휴기간 조금 바쁜일이 있어 늦었습니다😭

처음에 일단 '단위 테스트 코드 작성하기' 커밋에서 단위테스트 예제 느낌으로 작성했는데
Mock으로 짜진 테스트 같은 경우에는 구현을 변경하면서 깨져서 일단 주석 처리를 해놓았습니다.
1주차에 했던걸 차용해서 코드를 변경했습니다.

우선 구현하면서 엔티티의 equals와 hashcode를 id 값을 기반으로 재정의해주었는데
GenerationType이 Identity여서 아무래도 DB의존적이다 보니 단위테스트 할때마다 자꾸 깨지더라구요.
그래서 name이 중복이 안되니까 우선은 name을 기반으로 변경해주었습니다.
JPA의 Entity랑 객체지향적인 관점에서 Entity랑은 달라서 이런 차이가 생기는거 같다(?)고 생각이 들었습니다.

제일 고민이 되었던 부분은 설계를 할 때
Station에서 Section을 일대다로 가지도록 해서 양방향으로 매핑을 하도록 설계해봤는데
아직 JPA가 익숙치 않아서인지 의도대로 잘 안되서 우선은 제거하였습니다.

또 일급 컬렉션으로 한번 Section의 List를 다뤄보려했는데
Line과 Section의 양방향 연관관계 편의 메서드를 어떤식으로 작성해야할지 막히더라구요.
이 부분은 어떤식으로 풀 수 있을지 궁금합니다.

리뷰 잘 부탁드립니다🙏