### PR TITLE
2단계 - 지하철 구간 추가 리팩터링

### DIFF
--- a/src/main/java/nextstep/subway/applicaion/dto/LineRequest.java
+++ b/src/main/java/nextstep/subway/applicaion/dto/LineRequest.java
@@ -1,11 +1,13 @@
 package nextstep.subway.applicaion.dto;
 
 public class LineRequest {
-    private final String name;
-    private final String color;
-    private final Long upStationId;
-    private final Long downStationId;
-    private final int distance;
+    private String name;
+    private String color;
+    private Long upStationId;
+    private Long downStationId;
+    private int distance;
+
+    private LineRequest() {}
 
     public LineRequest(String name, String color, Long upStationId, Long downStationId,
             int distance) {

--- a/src/main/java/nextstep/subway/applicaion/dto/LineResponse.java
+++ b/src/main/java/nextstep/subway/applicaion/dto/LineResponse.java
@@ -1,9 +1,11 @@
 package nextstep.subway.applicaion.dto;
 
 import java.util.List;
-import lombok.Data;
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
 
-@Data
+@Getter
+@EqualsAndHashCode
 public class LineResponse {
     private Long id;
     private String name;

--- a/src/main/java/nextstep/subway/applicaion/dto/SectionRequest.java
+++ b/src/main/java/nextstep/subway/applicaion/dto/SectionRequest.java
@@ -1,9 +1,12 @@
 package nextstep.subway.applicaion.dto;
 
 public class SectionRequest {
-    private final Long upStationId;
-    private final Long downStationId;
-    private final int distance;
+    private Long upStationId;
+    private Long downStationId;
+    private int distance;
+
+    private SectionRequest() {
+    }
 
     public SectionRequest(Long upStationId, Long downStationId, int distance) {
         this.upStationId = upStationId;

--- a/src/main/java/nextstep/subway/applicaion/dto/SectionRequest.java
+++ b/src/main/java/nextstep/subway/applicaion/dto/SectionRequest.java
@@ -3,7 +3,7 @@ package nextstep.subway.applicaion.dto;
 public class SectionRequest {
     private Long upStationId;
     private Long downStationId;
-    private int distance;
+    private Integer distance;
 
     private SectionRequest() {
     }

--- a/src/main/java/nextstep/subway/applicaion/dto/StationResponse.java
+++ b/src/main/java/nextstep/subway/applicaion/dto/StationResponse.java
@@ -1,11 +1,16 @@
 package nextstep.subway.applicaion.dto;
 
-import lombok.Data;
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
 
-@Data
+@Getter
+@EqualsAndHashCode
 public class StationResponse {
     private Long id;
     private String name;
+
+    private StationResponse() {
+    }
 
     public StationResponse(Long id, String name) {
         this.id = id;

--- a/src/main/java/nextstep/subway/domain/Section.java
+++ b/src/main/java/nextstep/subway/domain/Section.java
@@ -1,6 +1,7 @@
 package nextstep.subway.domain;
 
 import javax.persistence.*;
+import nextstep.subway.domain.exception.NotValidSectionDistanceException;
 
 @Entity
 public class Section {
@@ -51,7 +52,7 @@ public class Section {
 
     public void setNewUpStation(Station station, int distance) {
         if (distance < 1) {
-            throw new IllegalArgumentException();
+            throw new NotValidSectionDistanceException();
         }
 
         this.upStation = station;
@@ -60,7 +61,7 @@ public class Section {
 
     public void setNewDownStation(Station station, int distance) {
         if (distance < 1) {
-            throw new IllegalArgumentException();
+            throw new NotValidSectionDistanceException();
         }
 
         this.downStation = station;

--- a/src/main/java/nextstep/subway/domain/Section.java
+++ b/src/main/java/nextstep/subway/domain/Section.java
@@ -37,14 +37,6 @@ public class Section {
         this.distance = distance;
     }
 
-    public Long getId() {
-        return id;
-    }
-
-    public Line getLine() {
-        return line;
-    }
-
     public Station getUpStation() {
         return upStation;
     }

--- a/src/main/java/nextstep/subway/domain/Section.java
+++ b/src/main/java/nextstep/subway/domain/Section.java
@@ -33,6 +33,10 @@ public class Section {
         this.distance = distance;
     }
 
+    public void setUpStation(Station upStation) {
+        this.upStation = upStation;
+    }
+
     public Long getId() {
         return id;
     }

--- a/src/main/java/nextstep/subway/domain/Section.java
+++ b/src/main/java/nextstep/subway/domain/Section.java
@@ -37,6 +37,10 @@ public class Section {
         this.upStation = upStation;
     }
 
+    public void setDownStation(Station downStation) {
+        this.downStation = downStation;
+    }
+
     public Long getId() {
         return id;
     }

--- a/src/main/java/nextstep/subway/domain/Section.java
+++ b/src/main/java/nextstep/subway/domain/Section.java
@@ -41,6 +41,10 @@ public class Section {
         this.downStation = downStation;
     }
 
+    public void setDistance(int distance) {
+        this.distance = distance;
+    }
+
     public Long getId() {
         return id;
     }

--- a/src/main/java/nextstep/subway/domain/Section.java
+++ b/src/main/java/nextstep/subway/domain/Section.java
@@ -33,14 +33,6 @@ public class Section {
         this.distance = distance;
     }
 
-    public void setUpStation(Station upStation) {
-        this.upStation = upStation;
-    }
-
-    public void setDownStation(Station downStation) {
-        this.downStation = downStation;
-    }
-
     public void setDistance(int distance) {
         this.distance = distance;
     }
@@ -63,5 +55,23 @@ public class Section {
 
     public int getDistance() {
         return distance;
+    }
+
+    public void setNewUpStation(Station station, int distance) {
+        if (distance < 1) {
+            throw new IllegalArgumentException();
+        }
+
+        this.upStation = station;
+        this.distance = distance;
+    }
+
+    public void setNewDownStation(Station station, int distance) {
+        if (distance < 1) {
+            throw new IllegalArgumentException();
+        }
+
+        this.downStation = station;
+        this.distance = distance;
     }
 }

--- a/src/main/java/nextstep/subway/domain/Sections.java
+++ b/src/main/java/nextstep/subway/domain/Sections.java
@@ -21,26 +21,15 @@ public class Sections {
 
         if (isExistStation(upStation) && isNotLastStation(upStation)) {
             var section = getSectionByUpStation(upStation);
-            section.setUpStation(downStation);
-            var newDistance = section.getDistance() - distance;
-            if (newDistance < 1) {
-                throw new IllegalArgumentException();
-            }
-            section.setDistance(newDistance);
+            section.setNewUpStation(downStation, section.getDistance() - distance);
         }
 
         if (isExistStation(downStation) && isNotFirstStation(downStation)) {
             var section = getSectionByDownStation(downStation);
-            section.setDownStation(upStation);
-            var newDistance = section.getDistance() - distance;
-            if (newDistance < 1) {
-                throw new IllegalArgumentException();
-            }
-            section.setDistance(newDistance);
+            section.setNewDownStation(upStation, section.getDistance() - distance);
         }
 
-        var newSection = new Section(line, upStation, downStation, distance);
-        sectionList.add(newSection);
+        sectionList.add(new Section(line, upStation, downStation, distance));
     }
 
     public void removeByStation(Station downStation) {

--- a/src/main/java/nextstep/subway/domain/Sections.java
+++ b/src/main/java/nextstep/subway/domain/Sections.java
@@ -3,7 +3,7 @@ package nextstep.subway.domain;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
-import java.util.stream.Collectors;
+import java.util.Optional;
 import javax.persistence.CascadeType;
 import javax.persistence.Embeddable;
 import javax.persistence.OneToMany;
@@ -15,6 +15,10 @@ public class Sections {
     private List<Section> sectionList = new ArrayList<>();
 
     public void add(Line line, Station upStation, Station downStation, int distance) {
+        if (isExistStation(upStation) && isExistStation(downStation)) {
+            throw new IllegalArgumentException();
+        }
+
         var section = new Section(line, upStation, downStation, distance);
         sectionList.add(section);
     }
@@ -31,11 +35,15 @@ public class Sections {
             return Collections.emptyList();
         }
 
-        var stations = sectionList.stream()
-                .map(Section::getDownStation)
-                .collect(Collectors.toList());
+        var stations = new ArrayList<Station>();
+        var firstSection = getFirstSection();
+        stations.add(firstSection.getUpStation());
 
-        stations.add(0, sectionList.get(0).getUpStation());
+        var currentSection = Optional.of(firstSection);
+        while (currentSection.isPresent()) {
+            stations.add(currentSection.get().getDownStation());
+            currentSection = getNextSection(currentSection.get());
+        }
 
         return stations;
     }
@@ -44,4 +52,35 @@ public class Sections {
         return !sectionList.get(sectionList.size() - 1).getDownStation().equals(downStation);
     }
 
+    private Section getFirstSection() {
+        if (sectionList.isEmpty()) {
+            throw new IllegalStateException();
+        }
+
+        var currSection = sectionList.get(0);
+        var prevSection = getPrevSection(currSection);
+
+        while (prevSection.isPresent()) {
+            currSection = prevSection.get();
+            prevSection = getPrevSection(currSection);
+        }
+
+        return currSection;
+    }
+
+    private Optional<Section> getPrevSection(Section section) {
+        return sectionList.stream()
+                .filter(s -> section.getUpStation().equals(s.getDownStation()))
+                .findFirst();
+    }
+
+    private Optional<Section> getNextSection(Section section) {
+        return sectionList.stream()
+                .filter(s -> section.getDownStation().equals(s.getUpStation()))
+                .findFirst();
+    }
+
+    private boolean isExistStation(Station station) {
+        return getStations().contains(station);
+    }
 }

--- a/src/main/java/nextstep/subway/domain/Sections.java
+++ b/src/main/java/nextstep/subway/domain/Sections.java
@@ -83,28 +83,28 @@ public class Sections {
         return currSection;
     }
 
-    private Optional<Section> getPrevSection(Section section) {
+    private Optional<Section> getPrevSection(Section currentSection) {
         return sectionList.stream()
-                .filter(s -> section.getUpStation().equals(s.getDownStation()))
+                .filter(section -> currentSection.getUpStation().equals(section.getDownStation()))
                 .findFirst();
     }
 
-    private Optional<Section> getNextSection(Section section) {
+    private Optional<Section> getNextSection(Section currentSection) {
         return sectionList.stream()
-                .filter(s -> section.getDownStation().equals(s.getUpStation()))
+                .filter(section -> currentSection.getDownStation().equals(section.getUpStation()))
                 .findFirst();
     }
 
     private Section getSectionByUpStation(Station upStation) {
         return sectionList.stream()
-                .filter(s -> upStation.equals(s.getUpStation()))
+                .filter(section -> upStation.equals(section.getUpStation()))
                 .findFirst()
                 .orElseThrow(IllegalArgumentException::new);
     }
 
     private Section getSectionByDownStation(Station downStation) {
         return sectionList.stream()
-                .filter(s -> downStation.equals(s.getDownStation()))
+                .filter(section -> downStation.equals(section.getDownStation()))
                 .findFirst()
                 .orElseThrow(IllegalArgumentException::new);
     }

--- a/src/main/java/nextstep/subway/domain/Sections.java
+++ b/src/main/java/nextstep/subway/domain/Sections.java
@@ -19,8 +19,13 @@ public class Sections {
             throw new IllegalArgumentException();
         }
 
-        var section = new Section(line, upStation, downStation, distance);
-        sectionList.add(section);
+        var section = getSectionByUpStation(upStation);
+        if (isExistStation(upStation) && section.isPresent()) {
+            section.get().setUpStation(downStation);
+        }
+
+        var newSection = new Section(line, upStation, downStation, distance);
+        sectionList.add(newSection);
     }
 
     public void removeByStation(Station downStation) {
@@ -77,6 +82,12 @@ public class Sections {
     private Optional<Section> getNextSection(Section section) {
         return sectionList.stream()
                 .filter(s -> section.getDownStation().equals(s.getUpStation()))
+                .findFirst();
+    }
+
+    private Optional<Section> getSectionByUpStation(Station upStation) {
+        return sectionList.stream()
+                .filter(s -> upStation.equals(s.getUpStation()))
                 .findFirst();
     }
 

--- a/src/main/java/nextstep/subway/domain/Sections.java
+++ b/src/main/java/nextstep/subway/domain/Sections.java
@@ -39,6 +39,22 @@ public class Sections {
         sectionList.remove(sectionList.size() - 1);
     }
 
+    public List<Section> getOrderedSections() {
+        if (sectionList.isEmpty()) {
+            return Collections.emptyList();
+        }
+
+        var orderedSections = new ArrayList<Section>();
+        var currentSection = Optional.of(getFirstSection());
+
+        while (currentSection.isPresent()) {
+            orderedSections.add(currentSection.get());
+            currentSection = getNextSection(currentSection.get());
+        }
+
+        return orderedSections;
+    }
+
     public List<Station> getStations() {
         if (sectionList.isEmpty()) {
             return Collections.emptyList();

--- a/src/main/java/nextstep/subway/domain/Sections.java
+++ b/src/main/java/nextstep/subway/domain/Sections.java
@@ -60,15 +60,10 @@ public class Sections {
             return Collections.emptyList();
         }
 
+        var sections = getOrderedSections();
         var stations = new ArrayList<Station>();
-        var firstSection = getFirstSection();
-        stations.add(firstSection.getUpStation());
-
-        var currentSection = Optional.of(firstSection);
-        while (currentSection.isPresent()) {
-            stations.add(currentSection.get().getDownStation());
-            currentSection = getNextSection(currentSection.get());
-        }
+        stations.add(sections.get(0).getUpStation());
+        sections.forEach(section -> stations.add(section.getDownStation()));
 
         return stations;
     }

--- a/src/main/java/nextstep/subway/domain/Sections.java
+++ b/src/main/java/nextstep/subway/domain/Sections.java
@@ -20,10 +20,9 @@ public class Sections {
     }
 
     public void removeByStation(Station downStation) {
-        if (!sectionList.get(sectionList.size() - 1).getDownStation().equals(downStation)) {
+        if (isNotLastStation(downStation)) {
             throw new IllegalArgumentException();
         }
-
         sectionList.remove(sectionList.size() - 1);
     }
 
@@ -39,6 +38,10 @@ public class Sections {
         stations.add(0, sectionList.get(0).getUpStation());
 
         return stations;
+    }
+
+    private boolean isNotLastStation(Station downStation) {
+        return !sectionList.get(sectionList.size() - 1).getDownStation().equals(downStation);
     }
 
 }

--- a/src/main/java/nextstep/subway/domain/Sections.java
+++ b/src/main/java/nextstep/subway/domain/Sections.java
@@ -20,11 +20,23 @@ public class Sections {
         }
 
         if (isExistStation(upStation) && isNotLastStation(upStation)) {
-            getSectionByUpStation(upStation).setUpStation(downStation);
+            var section = getSectionByUpStation(upStation);
+            section.setUpStation(downStation);
+            var newDistance = section.getDistance() - distance;
+            if (newDistance < 1) {
+                throw new IllegalArgumentException();
+            }
+            section.setDistance(newDistance);
         }
 
         if (isExistStation(downStation) && isNotFirstStation(downStation)) {
-            getSectionByDownStation(downStation).setDownStation(upStation);
+            var section = getSectionByDownStation(downStation);
+            section.setDownStation(upStation);
+            var newDistance = section.getDistance() - distance;
+            if (newDistance < 1) {
+                throw new IllegalArgumentException();
+            }
+            section.setDistance(newDistance);
         }
 
         var newSection = new Section(line, upStation, downStation, distance);

--- a/src/main/java/nextstep/subway/domain/Sections.java
+++ b/src/main/java/nextstep/subway/domain/Sections.java
@@ -69,13 +69,14 @@ public class Sections {
     }
 
     private boolean isNotLastStation(Station station) {
-        var stations = getStations();
-        return !stations.get(stations.size() - 1).equals(station);
+        var sections = getOrderedSections();
+        var lastStation = sections.get(sections.size() - 1).getDownStation();
+        return !lastStation.equals(station);
     }
 
     private boolean isNotFirstStation(Station station) {
-        var stations = getStations();
-        return !stations.get(0).equals(station);
+        var firstStation = getFirstSection().getUpStation();
+        return !firstStation.equals(station);
     }
 
     private Section getFirstSection() {

--- a/src/main/java/nextstep/subway/domain/Sections.java
+++ b/src/main/java/nextstep/subway/domain/Sections.java
@@ -15,7 +15,7 @@ public class Sections {
     private List<Section> sectionList = new ArrayList<>();
 
     public void add(Line line, Station upStation, Station downStation, int distance) {
-        if (isExistStation(upStation) && isExistStation(downStation)) {
+        if (isNotValidStations(upStation, downStation)) {
             throw new IllegalArgumentException();
         }
 
@@ -106,6 +106,13 @@ public class Sections {
                 .filter(s -> downStation.equals(s.getDownStation()))
                 .findFirst()
                 .orElseThrow(IllegalArgumentException::new);
+    }
+
+    private boolean isNotValidStations(Station upStation, Station downStation) {
+        return !sectionList.isEmpty() && (
+                (isExistStation(upStation) && isExistStation(downStation)) ||
+                (!isExistStation(upStation) && !isExistStation(downStation))
+        );
     }
 
     private boolean isExistStation(Station station) {

--- a/src/main/java/nextstep/subway/domain/Sections.java
+++ b/src/main/java/nextstep/subway/domain/Sections.java
@@ -23,6 +23,10 @@ public class Sections {
             getSectionByUpStation(upStation).setUpStation(downStation);
         }
 
+        if (isExistStation(downStation) && isNotFirstStation(downStation)) {
+            getSectionByDownStation(downStation).setDownStation(upStation);
+        }
+
         var newSection = new Section(line, upStation, downStation, distance);
         sectionList.add(newSection);
     }
@@ -52,8 +56,14 @@ public class Sections {
         return stations;
     }
 
-    private boolean isNotLastStation(Station downStation) {
-        return !sectionList.get(sectionList.size() - 1).getDownStation().equals(downStation);
+    private boolean isNotLastStation(Station station) {
+        var stations = getStations();
+        return !stations.get(stations.size() - 1).equals(station);
+    }
+
+    private boolean isNotFirstStation(Station station) {
+        var stations = getStations();
+        return !stations.get(0).equals(station);
     }
 
     private Section getFirstSection() {
@@ -87,6 +97,13 @@ public class Sections {
     private Section getSectionByUpStation(Station upStation) {
         return sectionList.stream()
                 .filter(s -> upStation.equals(s.getUpStation()))
+                .findFirst()
+                .orElseThrow(IllegalArgumentException::new);
+    }
+
+    private Section getSectionByDownStation(Station downStation) {
+        return sectionList.stream()
+                .filter(s -> downStation.equals(s.getDownStation()))
                 .findFirst()
                 .orElseThrow(IllegalArgumentException::new);
     }

--- a/src/main/java/nextstep/subway/domain/Sections.java
+++ b/src/main/java/nextstep/subway/domain/Sections.java
@@ -19,9 +19,8 @@ public class Sections {
             throw new IllegalArgumentException();
         }
 
-        var section = getSectionByUpStation(upStation);
-        if (isExistStation(upStation) && section.isPresent()) {
-            section.get().setUpStation(downStation);
+        if (isExistStation(upStation) && isNotLastStation(upStation)) {
+            getSectionByUpStation(upStation).setUpStation(downStation);
         }
 
         var newSection = new Section(line, upStation, downStation, distance);
@@ -85,10 +84,11 @@ public class Sections {
                 .findFirst();
     }
 
-    private Optional<Section> getSectionByUpStation(Station upStation) {
+    private Section getSectionByUpStation(Station upStation) {
         return sectionList.stream()
                 .filter(s -> upStation.equals(s.getUpStation()))
-                .findFirst();
+                .findFirst()
+                .orElseThrow(IllegalArgumentException::new);
     }
 
     private boolean isExistStation(Station station) {

--- a/src/main/java/nextstep/subway/domain/Sections.java
+++ b/src/main/java/nextstep/subway/domain/Sections.java
@@ -7,6 +7,8 @@ import java.util.Optional;
 import javax.persistence.CascadeType;
 import javax.persistence.Embeddable;
 import javax.persistence.OneToMany;
+import nextstep.subway.domain.exception.NotValidDeleteTargetStation;
+import nextstep.subway.domain.exception.NotValidSectionStationsException;
 
 @Embeddable
 public class Sections {
@@ -16,7 +18,7 @@ public class Sections {
 
     public void add(Line line, Station upStation, Station downStation, int distance) {
         if (isNotValidStations(upStation, downStation)) {
-            throw new IllegalArgumentException();
+            throw new NotValidSectionStationsException();
         }
 
         if (isExistStation(upStation) && isNotLastStation(upStation)) {
@@ -34,7 +36,7 @@ public class Sections {
 
     public void removeByStation(Station downStation) {
         if (isNotLastStation(downStation)) {
-            throw new IllegalArgumentException();
+            throw new NotValidDeleteTargetStation();
         }
         sectionList.remove(sectionList.size() - 1);
     }

--- a/src/main/java/nextstep/subway/domain/exception/DomainException.java
+++ b/src/main/java/nextstep/subway/domain/exception/DomainException.java
@@ -1,0 +1,7 @@
+package nextstep.subway.domain.exception;
+
+public class DomainException extends RuntimeException {
+    public DomainException(String message) {
+        super(message);
+    }
+}

--- a/src/main/java/nextstep/subway/domain/exception/NotValidDeleteTargetStation.java
+++ b/src/main/java/nextstep/subway/domain/exception/NotValidDeleteTargetStation.java
@@ -1,0 +1,7 @@
+package nextstep.subway.domain.exception;
+
+public class NotValidDeleteTargetStation extends DomainException {
+    public NotValidDeleteTargetStation() {
+        super("구간의 마지막 역만 제거할 수 있습니다.");
+    }
+}

--- a/src/main/java/nextstep/subway/domain/exception/NotValidSectionDistanceException.java
+++ b/src/main/java/nextstep/subway/domain/exception/NotValidSectionDistanceException.java
@@ -1,0 +1,7 @@
+package nextstep.subway.domain.exception;
+
+public class NotValidSectionDistanceException extends DomainException {
+    public NotValidSectionDistanceException() {
+        super("구간의 거리는 1 보다 작을 수 없습니다");
+    }
+}

--- a/src/main/java/nextstep/subway/domain/exception/NotValidSectionStationsException.java
+++ b/src/main/java/nextstep/subway/domain/exception/NotValidSectionStationsException.java
@@ -1,0 +1,7 @@
+package nextstep.subway.domain.exception;
+
+public class NotValidSectionStationsException extends DomainException {
+    public NotValidSectionStationsException() {
+        super("구간의 상/하행역 중 한 역만 구간내 존재해야 합니다.");
+    }
+}

--- a/src/main/java/nextstep/subway/ui/ControllerExceptionHandler.java
+++ b/src/main/java/nextstep/subway/ui/ControllerExceptionHandler.java
@@ -1,5 +1,6 @@
 package nextstep.subway.ui;
 
+import nextstep.subway.domain.exception.DomainException;
 import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.ControllerAdvice;
@@ -9,6 +10,11 @@ import org.springframework.web.bind.annotation.ExceptionHandler;
 public class ControllerExceptionHandler {
     @ExceptionHandler(DataIntegrityViolationException.class)
     public ResponseEntity<Void> handleIllegalArgsException(DataIntegrityViolationException e) {
+        return ResponseEntity.badRequest().build();
+    }
+
+    @ExceptionHandler(DomainException.class)
+    public ResponseEntity<Void> handleDomainException() {
         return ResponseEntity.badRequest().build();
     }
 }

--- a/src/test/java/nextstep/subway/acceptance/LineSectionAcceptanceTest.java
+++ b/src/test/java/nextstep/subway/acceptance/LineSectionAcceptanceTest.java
@@ -1,19 +1,22 @@
 package nextstep.subway.acceptance;
 
+import static nextstep.subway.acceptance.LineSteps.지하철_노선_생성_요청;
+import static nextstep.subway.acceptance.LineSteps.지하철_노선_조회_요청;
+import static nextstep.subway.acceptance.LineSteps.지하철_노선에_지하철_구간_생성_요청;
+import static nextstep.subway.acceptance.LineSteps.지하철_노선에_지하철_구간_제거_요청;
+import static nextstep.subway.acceptance.StationSteps.지하철역_생성_요청;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertAll;
+
 import io.restassured.response.ExtractableResponse;
 import io.restassured.response.Response;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.http.HttpStatus;
-
-import java.util.HashMap;
-import java.util.Map;
-
-import static nextstep.subway.acceptance.LineSteps.*;
-import static nextstep.subway.acceptance.StationSteps.지하철역_생성_요청;
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.junit.jupiter.api.Assertions.assertAll;
 
 @DisplayName("지하철 구간 관리 기능")
 class LineSectionAcceptanceTest extends AcceptanceTest {
@@ -48,12 +51,7 @@ class LineSectionAcceptanceTest extends AcceptanceTest {
         지하철_노선에_지하철_구간_생성_요청(신분당선, createSectionCreateParams(양재역, 양재시민의숲역));
 
         // then
-        ExtractableResponse<Response> response = 지하철_노선_조회_요청(신분당선);
-
-        assertAll(
-                () -> assertThat(response.statusCode()).isEqualTo(HttpStatus.OK.value()),
-                () -> assertThat(response.jsonPath().getList("stations.id", Long.class)).containsExactly(강남역, 양재역, 양재시민의숲역)
-        );
+        구간이_올바른_순서대로_존재하는지_검증(신분당선, List.of(강남역, 양재역, 양재시민의숲역));
     }
 
     /**
@@ -68,13 +66,7 @@ class LineSectionAcceptanceTest extends AcceptanceTest {
         지하철_노선에_지하철_구간_생성_요청(신분당선, createSectionCreateParams(신논현역, 강남역));
 
         // then
-        var response = 지하철_노선_조회_요청(신분당선);
-
-        assertAll(
-                () -> assertThat(response.statusCode()).isEqualTo(HttpStatus.OK.value()),
-                () -> assertThat(response.jsonPath().getList("stations.id", Long.class))
-                        .containsExactly(신논현역, 강남역, 양재역)
-        );
+        구간이_올바른_순서대로_존재하는지_검증(신분당선, List.of(신논현역, 강남역, 양재역));
     }
 
     /**
@@ -89,13 +81,7 @@ class LineSectionAcceptanceTest extends AcceptanceTest {
         지하철_노선에_지하철_구간_생성_요청(신분당선, createSectionCreateParams(강남역, 강재역));
 
         // then
-        var response = 지하철_노선_조회_요청(신분당선);
-
-        assertAll(
-                () -> assertThat(response.statusCode()).isEqualTo(HttpStatus.OK.value()),
-                () -> assertThat(response.jsonPath().getList("stations.id", Long.class))
-                        .containsExactly(강남역, 강재역, 양재역)
-        );
+        구간이_올바른_순서대로_존재하는지_검증(신분당선, List.of(강남역, 강재역, 양재역));
     }
 
     @DisplayName("구간 사이에 새로운 구간을 등록 (상행역이 신규역)")
@@ -106,13 +92,7 @@ class LineSectionAcceptanceTest extends AcceptanceTest {
         지하철_노선에_지하철_구간_생성_요청(신분당선, createSectionCreateParams(강재역, 양재역));
 
         // then
-        var response = 지하철_노선_조회_요청(신분당선);
-
-        assertAll(
-                () -> assertThat(response.statusCode()).isEqualTo(HttpStatus.OK.value()),
-                () -> assertThat(response.jsonPath().getList("stations.id", Long.class))
-                        .containsExactly(강남역, 강재역, 양재역)
-        );
+        구간이_올바른_순서대로_존재하는지_검증(신분당선, List.of(강남역, 강재역, 양재역));
     }
 
     /**
@@ -153,5 +133,14 @@ class LineSectionAcceptanceTest extends AcceptanceTest {
         params.put("downStationId", downStationId + "");
         params.put("distance", 6 + "");
         return params;
+    }
+
+    private void 구간이_올바른_순서대로_존재하는지_검증(Long lineId, List<Long> stationIds) {
+        var response = 지하철_노선_조회_요청(lineId);
+
+        assertAll(
+                () -> assertThat(response.statusCode()).isEqualTo(HttpStatus.OK.value()),
+                () -> assertThat(response.jsonPath().getList("stations.id", Long.class)).containsExactlyElementsOf(stationIds)
+        );
     }
 }

--- a/src/test/java/nextstep/subway/acceptance/LineSectionAcceptanceTest.java
+++ b/src/test/java/nextstep/subway/acceptance/LineSectionAcceptanceTest.java
@@ -81,12 +81,29 @@ class LineSectionAcceptanceTest extends AcceptanceTest {
      * When 상행역을 기존 역, 하행역을 새로운 역으로 구간 사이에 추가 요청하면
      * Then 구간 사이에 새로운 구간이 추가된다
      */
-    @DisplayName("구간 사이에 새로운 구간을 등록")
+    @DisplayName("구간 사이에 새로운 구간을 등록 (하행역이 신규역)")
     @Test
-    void addLineSectionInMiddle() {
+    void addLineSectionWithNewDownStationInMiddle() {
         // when
         var 강재역 = 지하철역_생성_요청("강재역").jsonPath().getLong("id");
         지하철_노선에_지하철_구간_생성_요청(신분당선, createSectionCreateParams(강남역, 강재역));
+
+        // then
+        var response = 지하철_노선_조회_요청(신분당선);
+
+        assertAll(
+                () -> assertThat(response.statusCode()).isEqualTo(HttpStatus.OK.value()),
+                () -> assertThat(response.jsonPath().getList("stations.id", Long.class))
+                        .containsExactly(강남역, 강재역, 양재역)
+        );
+    }
+
+    @DisplayName("구간 사이에 새로운 구간을 등록 (상행역이 신규역)")
+    @Test
+    void addLineSectionWithNewUpStationInMiddle() {
+        // when
+        var 강재역 = 지하철역_생성_요청("강재역").jsonPath().getLong("id");
+        지하철_노선에_지하철_구간_생성_요청(신분당선, createSectionCreateParams(강재역, 양재역));
 
         // then
         var response = 지하철_노선_조회_요청(신분당선);

--- a/src/test/java/nextstep/subway/acceptance/LineSectionAcceptanceTest.java
+++ b/src/test/java/nextstep/subway/acceptance/LineSectionAcceptanceTest.java
@@ -13,6 +13,7 @@ import java.util.Map;
 import static nextstep.subway.acceptance.LineSteps.*;
 import static nextstep.subway.acceptance.StationSteps.지하철역_생성_요청;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertAll;
 
 @DisplayName("지하철 구간 관리 기능")
 class LineSectionAcceptanceTest extends AcceptanceTest {
@@ -36,20 +37,23 @@ class LineSectionAcceptanceTest extends AcceptanceTest {
     }
 
     /**
-     * When 지하철 노선에 새로운 구간 추가를 요청 하면
-     * Then 노선에 새로운 구간이 추가된다
+     * When 새로운 역을 하행 종점으로 추가요청하면
+     * Then 노선 맨 끝에 새로운 구간이 추가된다
      */
-    @DisplayName("지하철 노선에 구간을 등록")
+    @DisplayName("지하철 노선에 마지막 구간을 등록")
     @Test
-    void addLineSection() {
+    void addLastLineSection() {
         // when
-        Long 정자역 = 지하철역_생성_요청("정자역").jsonPath().getLong("id");
-        지하철_노선에_지하철_구간_생성_요청(신분당선, createSectionCreateParams(양재역, 정자역));
+        Long 양재시민의숲역 = 지하철역_생성_요청("양재시민의숲역").jsonPath().getLong("id");
+        지하철_노선에_지하철_구간_생성_요청(신분당선, createSectionCreateParams(양재역, 양재시민의숲역));
 
         // then
         ExtractableResponse<Response> response = 지하철_노선_조회_요청(신분당선);
-        assertThat(response.statusCode()).isEqualTo(HttpStatus.OK.value());
-        assertThat(response.jsonPath().getList("stations.id", Long.class)).containsExactly(강남역, 양재역, 정자역);
+
+        assertAll(
+                () -> assertThat(response.statusCode()).isEqualTo(HttpStatus.OK.value()),
+                () -> assertThat(response.jsonPath().getList("stations.id", Long.class)).containsExactly(강남역, 양재역, 양재시민의숲역)
+        );
     }
 
     /**

--- a/src/test/java/nextstep/subway/acceptance/LineSectionAcceptanceTest.java
+++ b/src/test/java/nextstep/subway/acceptance/LineSectionAcceptanceTest.java
@@ -78,6 +78,27 @@ class LineSectionAcceptanceTest extends AcceptanceTest {
     }
 
     /**
+     * When 상행역을 기존 역, 하행역을 새로운 역으로 구간 사이에 추가 요청하면
+     * Then 구간 사이에 새로운 구간이 추가된다
+     */
+    @DisplayName("구간 사이에 새로운 구간을 등록")
+    @Test
+    void addLineSectionInMiddle() {
+        // when
+        var 강재역 = 지하철역_생성_요청("강재역").jsonPath().getLong("id");
+        지하철_노선에_지하철_구간_생성_요청(신분당선, createSectionCreateParams(강남역, 강재역));
+
+        // then
+        var response = 지하철_노선_조회_요청(신분당선);
+
+        assertAll(
+                () -> assertThat(response.statusCode()).isEqualTo(HttpStatus.OK.value()),
+                () -> assertThat(response.jsonPath().getList("stations.id", Long.class))
+                        .containsExactly(강남역, 강재역, 양재역)
+        );
+    }
+
+    /**
      * Given 지하철 노선에 새로운 구간 추가를 요청 하고
      * When 지하철 노선의 마지막 구간 제거를 요청 하면
      * Then 노선에 구간이 제거된다

--- a/src/test/java/nextstep/subway/acceptance/LineSectionAcceptanceTest.java
+++ b/src/test/java/nextstep/subway/acceptance/LineSectionAcceptanceTest.java
@@ -57,6 +57,27 @@ class LineSectionAcceptanceTest extends AcceptanceTest {
     }
 
     /**
+     * When 새로운 역을 상행 종점으로 추가요청하면
+     * Then 노선 맨 처음에 새로운 구간이 추가된다
+     */
+    @DisplayName("지하철 노선에 첫 번째 구간을 등록")
+    @Test
+    void addFirstLineSection() {
+        // when
+        var 신논현역 = 지하철역_생성_요청("신논현역").jsonPath().getLong("id");
+        지하철_노선에_지하철_구간_생성_요청(신분당선, createSectionCreateParams(신논현역, 강남역));
+
+        // then
+        var response = 지하철_노선_조회_요청(신분당선);
+
+        assertAll(
+                () -> assertThat(response.statusCode()).isEqualTo(HttpStatus.OK.value()),
+                () -> assertThat(response.jsonPath().getList("stations.id", Long.class))
+                        .containsExactly(신논현역, 강남역, 양재역)
+        );
+    }
+
+    /**
      * Given 지하철 노선에 새로운 구간 추가를 요청 하고
      * When 지하철 노선의 마지막 구간 제거를 요청 하면
      * Then 노선에 구간이 제거된다

--- a/src/test/java/nextstep/subway/domain/SectionsTest.java
+++ b/src/test/java/nextstep/subway/domain/SectionsTest.java
@@ -1,0 +1,52 @@
+package nextstep.subway.domain;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+class SectionsTest {
+
+    private Sections sut;
+
+    private Line 분당선;
+    private Station 청량리역;
+    private Station 왕십리역;
+
+    @BeforeEach
+    void setUp() {
+        분당선 = new Line("분당선", "yellow");
+        청량리역 = new Station("청량리역");
+        왕십리역 = new Station("왕십리역");
+        sut = new Sections();
+    }
+
+    @DisplayName("구간 추가")
+    @Test
+    void addSection() {
+        sut.add(분당선, 청량리역, 왕십리역, 10);
+
+        assertThat(sut.getStations()).containsExactly(청량리역, 왕십리역);
+    }
+
+    @DisplayName("구간 제거")
+    @Test
+    void removeSection() {
+        sut.add(분당선, 청량리역, 왕십리역, 10);
+
+        sut.removeByStation(왕십리역);
+
+        assertThat(sut.getStations()).isEmpty();
+    }
+
+    @DisplayName("마지막 역이 아닌 역으로 구간 제거시 예외 발생")
+    @Test
+    void cantRemoveSectionByStationInMiddle() {
+        sut.add(분당선, 청량리역, 왕십리역, 10);
+
+        assertThrows(IllegalArgumentException.class, () -> sut.removeByStation(청량리역));
+    }
+
+}

--- a/src/test/java/nextstep/subway/domain/SectionsTest.java
+++ b/src/test/java/nextstep/subway/domain/SectionsTest.java
@@ -42,6 +42,15 @@ class SectionsTest {
         assertThat(sut.getStations()).containsExactly(새로운역, 청량리역, 왕십리역);
     }
 
+    @DisplayName("구간 사이에 새 구간 추가")
+    @Test
+    void addSectionInMiddle() {
+        var 중간역 = new Station("중간역");
+        sut.add(분당선, 청량리역, 중간역, 10);
+
+        assertThat(sut.getStations()).containsExactly(청량리역, 중간역, 왕십리역);
+    }
+
     @DisplayName("구간 제거")
     @Test
     void removeSection() {

--- a/src/test/java/nextstep/subway/domain/SectionsTest.java
+++ b/src/test/java/nextstep/subway/domain/SectionsTest.java
@@ -4,6 +4,9 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertAll;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
+import nextstep.subway.domain.exception.NotValidDeleteTargetStation;
+import nextstep.subway.domain.exception.NotValidSectionDistanceException;
+import nextstep.subway.domain.exception.NotValidSectionStationsException;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -105,7 +108,7 @@ class SectionsTest {
     void sectionAdditionFailsWhenDistanceOfNewSectionInMiddleIsGreater(int distance) {
         var 중간역 = new Station("중간역");
 
-        assertThrows(IllegalArgumentException.class, () -> sut.add(분당선, 청량리역, 중간역, distance));
+        assertThrows(NotValidSectionDistanceException.class, () -> sut.add(분당선, 청량리역, 중간역, distance));
     }
 
     @DisplayName("구간의 상하행역이 모두 노선에 존재하지 않으면 추가 실패")
@@ -114,7 +117,7 @@ class SectionsTest {
         var 새로운역 = new Station("새로운역");
         var 다른새로운역 = new Station("다른새로운역");
 
-        assertThrows(IllegalArgumentException.class, () -> sut.add(분당선, 새로운역, 다른새로운역, 10));
+        assertThrows(NotValidSectionStationsException.class, () -> sut.add(분당선, 새로운역, 다른새로운역, 10));
     }
 
     @DisplayName("구간 제거")
@@ -128,7 +131,7 @@ class SectionsTest {
     @DisplayName("마지막 역이 아닌 역으로 구간 제거시 예외 발생")
     @Test
     void cantRemoveSectionByStationInMiddle() {
-        assertThrows(IllegalArgumentException.class, () -> sut.removeByStation(청량리역));
+        assertThrows(NotValidDeleteTargetStation.class, () -> sut.removeByStation(청량리역));
     }
 
 }

--- a/src/test/java/nextstep/subway/domain/SectionsTest.java
+++ b/src/test/java/nextstep/subway/domain/SectionsTest.java
@@ -60,6 +60,15 @@ class SectionsTest {
         assertThat(sut.getStations()).containsExactly(청량리역, 중간역, 왕십리역);
     }
 
+    @DisplayName("구간의 상하행역이 모두 노선에 존재하지 않으면 추가 실패")
+    @Test
+    void sectionAdditionFailsWhenNeitherUpAndDownStationNotExist() {
+        var 새로운역 = new Station("새로운역");
+        var 다른새로운역 = new Station("다른새로운역");
+
+        assertThrows(IllegalArgumentException.class, () -> sut.add(분당선, 새로운역, 다른새로운역, 10));
+    }
+
     @DisplayName("구간 제거")
     @Test
     void removeSection() {

--- a/src/test/java/nextstep/subway/domain/SectionsTest.java
+++ b/src/test/java/nextstep/subway/domain/SectionsTest.java
@@ -1,6 +1,7 @@
 package nextstep.subway.domain;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertAll;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import org.junit.jupiter.api.BeforeEach;
@@ -30,18 +31,33 @@ class SectionsTest {
     @Test
     void addLastSection() {
         var 서울숲역 = new Station("서울숲역");
-        sut.add(분당선, 왕십리역, 서울숲역, 10);
+        var distance = 10;
+        sut.add(분당선, 왕십리역, 서울숲역, distance);
 
-        assertThat(sut.getStations()).containsExactly(청량리역, 왕십리역, 서울숲역);
+        var sections = sut.getOrderedSections();
+        var lastSection = sections.get(sections.size() - 1);
+        assertAll(
+                () -> assertThat(lastSection.getUpStation()).isEqualTo(왕십리역),
+                () -> assertThat(lastSection.getDownStation()).isEqualTo(서울숲역),
+                () -> assertThat(lastSection.getDistance()).isEqualTo(distance),
+                () -> assertThat(sut.getStations()).containsExactly(청량리역, 왕십리역, 서울숲역)
+        );
     }
 
     @DisplayName("첫 구간 추가")
     @Test
     void addFirstSection() {
         var 새로운역 = new Station("새로운역");
-        sut.add(분당선, 새로운역, 청량리역, 10);
+        var distance = 10;
+        sut.add(분당선, 새로운역, 청량리역, distance);
 
-        assertThat(sut.getStations()).containsExactly(새로운역, 청량리역, 왕십리역);
+        var firstSection = sut.getOrderedSections().get(0);
+        assertAll(
+                () -> assertThat(firstSection.getUpStation()).isEqualTo(새로운역),
+                () -> assertThat(firstSection.getDownStation()).isEqualTo(청량리역),
+                () -> assertThat(firstSection.getDistance()).isEqualTo(distance),
+                () -> assertThat(sut.getStations()).containsExactly(새로운역, 청량리역, 왕십리역)
+        );
     }
 
     @DisplayName("구간 사이에 새 구간 추가 (하행역이 신규역)")
@@ -50,7 +66,18 @@ class SectionsTest {
         var 중간역 = new Station("중간역");
         sut.add(분당선, 청량리역, 중간역, 5);
 
-        assertThat(sut.getStations()).containsExactly(청량리역, 중간역, 왕십리역);
+        var sections = sut.getOrderedSections();
+        var newSection = sections.get(0);
+        var updatedSection = sections.get(1);
+        assertAll(
+                () -> assertThat(newSection.getUpStation()).isEqualTo(청량리역),
+                () -> assertThat(newSection.getDownStation()).isEqualTo(중간역),
+                () -> assertThat(newSection.getDistance()).isEqualTo(5),
+                () -> assertThat(updatedSection.getUpStation()).isEqualTo(중간역),
+                () -> assertThat(updatedSection.getDownStation()).isEqualTo(왕십리역),
+                () -> assertThat(updatedSection.getDistance()).isEqualTo(5),
+                () -> assertThat(sut.getStations()).containsExactly(청량리역, 중간역, 왕십리역)
+        );
     }
 
     @DisplayName("구간 사이에 새 구간 추가 (상행역이 신규역)")
@@ -59,7 +86,18 @@ class SectionsTest {
         var 중간역 = new Station("중간역");
         sut.add(분당선, 중간역, 왕십리역, 5);
 
-        assertThat(sut.getStations()).containsExactly(청량리역, 중간역, 왕십리역);
+        var sections = sut.getOrderedSections();
+        var newSection = sections.get(1);
+        var updatedSection = sections.get(0);
+        assertAll(
+                () -> assertThat(newSection.getUpStation()).isEqualTo(중간역),
+                () -> assertThat(newSection.getDownStation()).isEqualTo(왕십리역),
+                () -> assertThat(newSection.getDistance()).isEqualTo(5),
+                () -> assertThat(updatedSection.getUpStation()).isEqualTo(청량리역),
+                () -> assertThat(updatedSection.getDownStation()).isEqualTo(중간역),
+                () -> assertThat(updatedSection.getDistance()).isEqualTo(5),
+                () -> assertThat(sut.getStations()).containsExactly(청량리역, 중간역, 왕십리역)
+        );
     }
 
     @ParameterizedTest(name = "구간 사이의 새 구간의 거리가 기존 구간보다 크거나 같으면 추가 실패 / distance = {0}")

--- a/src/test/java/nextstep/subway/domain/SectionsTest.java
+++ b/src/test/java/nextstep/subway/domain/SectionsTest.java
@@ -6,6 +6,8 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
 
 class SectionsTest {
 
@@ -46,7 +48,7 @@ class SectionsTest {
     @Test
     void addSectionWithNewDownStationInMiddle() {
         var 중간역 = new Station("중간역");
-        sut.add(분당선, 청량리역, 중간역, 10);
+        sut.add(분당선, 청량리역, 중간역, 5);
 
         assertThat(sut.getStations()).containsExactly(청량리역, 중간역, 왕십리역);
     }
@@ -55,9 +57,17 @@ class SectionsTest {
     @Test
     void addSectionWithNewUpStationInMiddle() {
         var 중간역 = new Station("중간역");
-        sut.add(분당선, 중간역, 왕십리역, 10);
+        sut.add(분당선, 중간역, 왕십리역, 5);
 
         assertThat(sut.getStations()).containsExactly(청량리역, 중간역, 왕십리역);
+    }
+
+    @ParameterizedTest(name = "구간 사이의 새 구간의 거리가 기존 구간보다 크거나 같으면 추가 실패 / distance = {0}")
+    @ValueSource(ints = {10, 15})
+    void sectionAdditionFailsWhenDistanceOfNewSectionInMiddleIsGreater(int distance) {
+        var 중간역 = new Station("중간역");
+
+        assertThrows(IllegalArgumentException.class, () -> sut.add(분당선, 청량리역, 중간역, distance));
     }
 
     @DisplayName("구간의 상하행역이 모두 노선에 존재하지 않으면 추가 실패")

--- a/src/test/java/nextstep/subway/domain/SectionsTest.java
+++ b/src/test/java/nextstep/subway/domain/SectionsTest.java
@@ -45,8 +45,6 @@ class SectionsTest {
     @DisplayName("구간 제거")
     @Test
     void removeSection() {
-        sut.add(분당선, 청량리역, 왕십리역, 10);
-
         sut.removeByStation(왕십리역);
 
         assertThat(sut.getStations()).isEmpty();
@@ -55,8 +53,6 @@ class SectionsTest {
     @DisplayName("마지막 역이 아닌 역으로 구간 제거시 예외 발생")
     @Test
     void cantRemoveSectionByStationInMiddle() {
-        sut.add(분당선, 청량리역, 왕십리역, 10);
-
         assertThrows(IllegalArgumentException.class, () -> sut.removeByStation(청량리역));
     }
 

--- a/src/test/java/nextstep/subway/domain/SectionsTest.java
+++ b/src/test/java/nextstep/subway/domain/SectionsTest.java
@@ -42,11 +42,20 @@ class SectionsTest {
         assertThat(sut.getStations()).containsExactly(새로운역, 청량리역, 왕십리역);
     }
 
-    @DisplayName("구간 사이에 새 구간 추가")
+    @DisplayName("구간 사이에 새 구간 추가 (하행역이 신규역)")
     @Test
-    void addSectionInMiddle() {
+    void addSectionWithNewDownStationInMiddle() {
         var 중간역 = new Station("중간역");
         sut.add(분당선, 청량리역, 중간역, 10);
+
+        assertThat(sut.getStations()).containsExactly(청량리역, 중간역, 왕십리역);
+    }
+
+    @DisplayName("구간 사이에 새 구간 추가 (상행역이 신규역)")
+    @Test
+    void addSectionWithNewUpStationInMiddle() {
+        var 중간역 = new Station("중간역");
+        sut.add(분당선, 중간역, 왕십리역, 10);
 
         assertThat(sut.getStations()).containsExactly(청량리역, 중간역, 왕십리역);
     }

--- a/src/test/java/nextstep/subway/domain/SectionsTest.java
+++ b/src/test/java/nextstep/subway/domain/SectionsTest.java
@@ -21,14 +21,25 @@ class SectionsTest {
         청량리역 = new Station("청량리역");
         왕십리역 = new Station("왕십리역");
         sut = new Sections();
+        sut.add(분당선, 청량리역, 왕십리역, 10);
     }
 
-    @DisplayName("구간 추가")
+    @DisplayName("마지막 구간 추가")
     @Test
-    void addSection() {
-        sut.add(분당선, 청량리역, 왕십리역, 10);
+    void addLastSection() {
+        var 서울숲역 = new Station("서울숲역");
+        sut.add(분당선, 왕십리역, 서울숲역, 10);
 
-        assertThat(sut.getStations()).containsExactly(청량리역, 왕십리역);
+        assertThat(sut.getStations()).containsExactly(청량리역, 왕십리역, 서울숲역);
+    }
+
+    @DisplayName("첫 구간 추가")
+    @Test
+    void addFirstSection() {
+        var 새로운역 = new Station("새로운역");
+        sut.add(분당선, 새로운역, 청량리역, 10);
+
+        assertThat(sut.getStations()).containsExactly(새로운역, 청량리역, 왕십리역);
     }
 
     @DisplayName("구간 제거")

--- a/src/test/java/nextstep/subway/unit/LineTest.java
+++ b/src/test/java/nextstep/subway/unit/LineTest.java
@@ -42,6 +42,16 @@ class LineTest {
         assertThat(sut.getStations()).containsExactly(호매실역, 광교역, 광교중앙역);
     }
 
+    @DisplayName("구간 사이에 새 구간 추가")
+    @Test
+    void addSectionInMiddle() {
+        var 광교중앙중앙역 = new Station("광교중앙중앙역");
+
+        sut.addSection(광교중앙중앙역, 광교역, 10);
+
+        assertThat(sut.getStations()).containsExactly(광교역, 광교중앙중앙역, 광교중앙역);
+    }
+
     @DisplayName("노선 내 역 조회")
     @Test
     void getStations() {

--- a/src/test/java/nextstep/subway/unit/LineTest.java
+++ b/src/test/java/nextstep/subway/unit/LineTest.java
@@ -47,7 +47,7 @@ class LineTest {
     void addSectionInMiddle() {
         var 광교중앙중앙역 = new Station("광교중앙중앙역");
 
-        sut.addSection(광교중앙중앙역, 광교역, 10);
+        sut.addSection(광교역, 광교중앙중앙역, 10);
 
         assertThat(sut.getStations()).containsExactly(광교역, 광교중앙중앙역, 광교중앙역);
     }

--- a/src/test/java/nextstep/subway/unit/LineTest.java
+++ b/src/test/java/nextstep/subway/unit/LineTest.java
@@ -4,6 +4,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 import nextstep.subway.domain.Line;
 import nextstep.subway.domain.Station;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
@@ -11,24 +12,40 @@ class LineTest {
 
     private Station 광교역 = new Station("광교역");
     private Station 광교중앙역 = new Station("광교중앙역");
-    private Station 상현역 = new Station("상현역");
 
-    @DisplayName("노선 추가")
+    private Line sut;
+
+    // Given: 구간 하나를 포함한 노선 추가
+    @BeforeEach
+    void setUp() {
+        sut = new Line();
+        sut.addSection(광교역, 광교중앙역, 10);
+    }
+
+    @DisplayName("마지막 구간 추가")
     @Test
-    void addSection() {
-        var sut = new Line();
-        var distance = 10;
+    void addLastSection() {
+        var 상현역 = new Station("상현역");
 
-        sut.addSection(광교역, 광교중앙역, distance);
+        sut.addSection(광교중앙역, 상현역, 10);
 
-        assertThat(sut.getStations()).containsExactly(광교역, 광교중앙역);
+        assertThat(sut.getStations()).containsExactly(광교역, 광교중앙역, 상현역);
+    }
+
+    @DisplayName("첫 구간 추가")
+    @Test
+    void addFirstSection() {
+        var 호매실역 = new Station("호매실역");
+
+        sut.addSection(호매실역, 광교역, 10);
+
+        assertThat(sut.getStations()).containsExactly(호매실역, 광교역, 광교중앙역);
     }
 
     @DisplayName("노선 내 역 조회")
     @Test
     void getStations() {
-        var sut = new Line();
-        sut.addSection(광교역, 광교중앙역, 10);
+        var 상현역 = new Station("상현역");
         sut.addSection(광교중앙역, 상현역, 10);
 
         var stations = sut.getStations();
@@ -39,8 +56,7 @@ class LineTest {
     @DisplayName("노선 내 구간 삭제")
     @Test
     void removeSection() {
-        var sut = new Line();
-        sut.addSection(광교역, 광교중앙역, 10);
+        var 상현역 = new Station("상현역");
         sut.addSection(광교중앙역, 상현역, 10);
 
         sut.removeSection(상현역);

--- a/src/test/java/nextstep/subway/unit/LineTest.java
+++ b/src/test/java/nextstep/subway/unit/LineTest.java
@@ -8,6 +8,8 @@ import nextstep.subway.domain.Station;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
 
 class LineTest {
 
@@ -48,7 +50,7 @@ class LineTest {
     void addSectionWithNewDownStationInMiddle() {
         var 광교중앙중앙역 = new Station("광교중앙중앙역");
 
-        sut.addSection(광교역, 광교중앙중앙역, 10);
+        sut.addSection(광교역, 광교중앙중앙역, 5);
 
         assertThat(sut.getStations()).containsExactly(광교역, 광교중앙중앙역, 광교중앙역);
     }
@@ -58,9 +60,17 @@ class LineTest {
     void addSectionWithNewUpStationInMiddle() {
         var 광교중앙중앙역 = new Station("광교중앙중앙역");
 
-        sut.addSection(광교중앙중앙역, 광교중앙역, 10);
+        sut.addSection(광교중앙중앙역, 광교중앙역, 5);
 
         assertThat(sut.getStations()).containsExactly(광교역, 광교중앙중앙역, 광교중앙역);
+    }
+
+    @ParameterizedTest(name = "구간 사이의 새 구간의 거리가 기존 구간보다 크거나 같으면 추가 실패 / distance = {0}")
+    @ValueSource(ints = {10, 15})
+    void sectionAdditionFailsWhenDistanceOfNewSectionInMiddleIsGreater(int distance) {
+        var 광교중앙중앙역 = new Station("중간역");
+
+        assertThrows(IllegalArgumentException.class, () -> sut.addSection(광교역, 광교중앙중앙역, distance));
     }
 
     @DisplayName("구간의 상하행역이 모두 노선에 존재하지 않으면 추가 실패")

--- a/src/test/java/nextstep/subway/unit/LineTest.java
+++ b/src/test/java/nextstep/subway/unit/LineTest.java
@@ -42,12 +42,22 @@ class LineTest {
         assertThat(sut.getStations()).containsExactly(호매실역, 광교역, 광교중앙역);
     }
 
-    @DisplayName("구간 사이에 새 구간 추가")
+    @DisplayName("구간 사이에 새 구간 추가 (하행역이 신규역)")
     @Test
-    void addSectionInMiddle() {
+    void addSectionWithNewDownStationInMiddle() {
         var 광교중앙중앙역 = new Station("광교중앙중앙역");
 
         sut.addSection(광교역, 광교중앙중앙역, 10);
+
+        assertThat(sut.getStations()).containsExactly(광교역, 광교중앙중앙역, 광교중앙역);
+    }
+
+    @DisplayName("구간 사이에 새 구간 추가 (상행역이 신규역)")
+    @Test
+    void addSectionWithNewUpStationInMiddle() {
+        var 광교중앙중앙역 = new Station("광교중앙중앙역");
+
+        sut.addSection(광교중앙중앙역, 광교중앙역, 10);
 
         assertThat(sut.getStations()).containsExactly(광교역, 광교중앙중앙역, 광교중앙역);
     }

--- a/src/test/java/nextstep/subway/unit/LineTest.java
+++ b/src/test/java/nextstep/subway/unit/LineTest.java
@@ -1,6 +1,7 @@
 package nextstep.subway.unit;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import nextstep.subway.domain.Line;
 import nextstep.subway.domain.Station;
@@ -60,6 +61,15 @@ class LineTest {
         sut.addSection(광교중앙중앙역, 광교중앙역, 10);
 
         assertThat(sut.getStations()).containsExactly(광교역, 광교중앙중앙역, 광교중앙역);
+    }
+
+    @DisplayName("구간의 상하행역이 모두 노선에 존재하지 않으면 추가 실패")
+    @Test
+    void sectionAdditionFailsWhenNeitherUpAndDownStationNotExist() {
+        var 새로운역 = new Station("새로운역");
+        var 다른새로운역 = new Station("다른새로운역");
+
+        assertThrows(IllegalArgumentException.class, () -> sut.addSection(새로운역, 다른새로운역, 10));
     }
 
     @DisplayName("노선 내 역 조회")

--- a/src/test/java/nextstep/subway/unit/LineTest.java
+++ b/src/test/java/nextstep/subway/unit/LineTest.java
@@ -5,6 +5,8 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import nextstep.subway.domain.Line;
 import nextstep.subway.domain.Station;
+import nextstep.subway.domain.exception.NotValidSectionDistanceException;
+import nextstep.subway.domain.exception.NotValidSectionStationsException;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -70,7 +72,7 @@ class LineTest {
     void sectionAdditionFailsWhenDistanceOfNewSectionInMiddleIsGreater(int distance) {
         var 광교중앙중앙역 = new Station("중간역");
 
-        assertThrows(IllegalArgumentException.class, () -> sut.addSection(광교역, 광교중앙중앙역, distance));
+        assertThrows(NotValidSectionDistanceException.class, () -> sut.addSection(광교역, 광교중앙중앙역, distance));
     }
 
     @DisplayName("구간의 상하행역이 모두 노선에 존재하지 않으면 추가 실패")
@@ -79,7 +81,7 @@ class LineTest {
         var 새로운역 = new Station("새로운역");
         var 다른새로운역 = new Station("다른새로운역");
 
-        assertThrows(IllegalArgumentException.class, () -> sut.addSection(새로운역, 다른새로운역, 10));
+        assertThrows(NotValidSectionStationsException.class, () -> sut.addSection(새로운역, 다른새로운역, 10));
     }
 
     @DisplayName("노선 내 역 조회")


### PR DESCRIPTION
## Summary

* 1단계 리뷰사항을 반영했습니다
* 지하철 구간 추가 제약사항 변경에 따른 인수 테스트 작성
* 지하철 구간 추가 제약사항 변경에 따른 기능 변경 및 유닛 테스트 추가

## Comments

안녕하세요 리뷰어님, 2단계 PR 요청드립니다!
먼저 1단계에서 리뷰주신 사항을 반영해 보았는데요, 변경 사항은 아래와 같습니다.

* `@Data` 를 사용한 부분은 실제 필요한 메서드만 생성하도록 다른 어노테이션으로 대체
* `Sections.removeByStation` 의 조건문 추출
* Jackson 으로 deserialize 되는 객체의 기본 생성자 추가 (gradle lombok plugin 덕에 정상동작 하고 있었네요 😅)
*  Sections 에 대한 테스트 추가

그리고 이번 과제를 진행하면서 궁금한 점이 몇가지 있는데요,

* 제약사항이 변경되면서 특정 상황에서 구간이 추가될 수 없는 조건이 몇가지 더 생겼습니다. 이러한 실패조건들을 인수 테스트 시나리오로 만들어야 하는지, 혹은 유닛 테스트 레벨에서 검증해도 충분한지 궁금합니다.
* 구간이 기존 구간 사이에 추가될 경우 distance 가 변경되고, 이때의 distance 제약 상황또한 존재하는데요 distance 제약 사항을 위반할경우 예외가 발생하는 것으로 실패 조건을 테스트 할 수는 있지만. 성공적으로 distance 가 변경되었을 경우에는 현재 요구사항에서 구간의 거리를 확인하는 경우가 없기 때문에 테스트 할 공개 메서드 또는 상태가 없는 상황입니다. 이 경우에 distance 를 가져올 수 있는 공개 메서드를 정의하여 테스트 해야 하는지 궁금합니다.