### PR TITLE
3단계 - 지하철 구간 제거 리팩터링

### DIFF
--- a/src/main/java/nextstep/subway/exception/MininumSectionException.java
+++ b/src/main/java/nextstep/subway/exception/MininumSectionException.java
@@ -1,0 +1,4 @@
+package nextstep.subway.exception;
+
+public class MininumSectionException extends RuntimeException {
+}

--- a/src/main/java/nextstep/subway/ui/LineController.java
+++ b/src/main/java/nextstep/subway/ui/LineController.java
@@ -6,6 +6,7 @@ import nextstep.subway.applicaion.dto.LineResponse;
 import nextstep.subway.applicaion.dto.SectionRequest;
 import nextstep.subway.exception.AllIncludedStationException;
 import nextstep.subway.exception.DistanceException;
+import nextstep.subway.exception.MininumSectionException;
 import nextstep.subway.exception.NonIncludedStationException;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
@@ -64,7 +65,7 @@ public class LineController {
         return ResponseEntity.ok().build();
     }
 
-    @ExceptionHandler({DistanceException.class, AllIncludedStationException.class, NonIncludedStationException.class})
+    @ExceptionHandler({DistanceException.class, AllIncludedStationException.class, NonIncludedStationException.class, MininumSectionException.class})
     public ResponseEntity<Void> addSectionExceptionHandler() {
         return ResponseEntity.badRequest().build();
     }


### PR DESCRIPTION
### Summary
구간 삭제에 대한 제약 사항 변경 구현

### Comment
> 이 부분부터 아래 조건문 까지 Section 내부로 캡슐화 해보는건 어떻게 생각하세요?

반영하였습니다. setter가 외부에서 호출되지 않아서 좋은 것 같습니다.

> 혹시 별도로 isEqualTo라는걸 정의해주신 이유가 있을까요?!

개인적으로 `equals()`를 override하는 것을 선호하지는 않습니다. 아마 예전에 프로젝트 할 때 크게 데인 것이 원인 같습니다.

> containsExactlyInAnyOrder로 변경해도 괜찮지 않을까요?

`containsExactlyInAnyOrder` 이런 느낌의 함수를 못찾아서 다른 것을 썼습니다. 감사합니다.