### PR TITLE
Step1. 단위 테스트 작성

### DIFF
--- a/src/main/java/nextstep/subway/applicaion/LineService.java
+++ b/src/main/java/nextstep/subway/applicaion/LineService.java
@@ -70,7 +70,7 @@ public class LineService {
         Station downStation = stationService.findById(sectionRequest.getDownStationId());
         Line line = lineRepository.findById(lineId).orElseThrow(IllegalArgumentException::new);
 
-        line.getSections().add(new Section(line, upStation, downStation, sectionRequest.getDistance()));
+        line.addSection(upStation, downStation, sectionRequest.getDistance());
     }
 
     private LineResponse createLineResponse(Line line) {

--- a/src/main/java/nextstep/subway/applicaion/LineService.java
+++ b/src/main/java/nextstep/subway/applicaion/LineService.java
@@ -103,10 +103,6 @@ public class LineService {
         Line line = lineRepository.findById(lineId).orElseThrow(IllegalArgumentException::new);
         Station station = stationService.findById(stationId);
 
-        if (!line.getSections().get(line.getSections().size() - 1).getDownStation().equals(station)) {
-            throw new IllegalArgumentException();
-        }
-
-        line.getSections().remove(line.getSections().size() - 1);
+        line.removeSection(stationId);
     }
 }

--- a/src/main/java/nextstep/subway/applicaion/LineService.java
+++ b/src/main/java/nextstep/subway/applicaion/LineService.java
@@ -32,7 +32,7 @@ public class LineService {
         if (request.getUpStationId() != null && request.getDownStationId() != null && request.getDistance() != 0) {
             Station upStation = stationService.findById(request.getUpStationId());
             Station downStation = stationService.findById(request.getDownStationId());
-            line.getSections().add(new Section(line, upStation, downStation, request.getDistance()));
+            line.addSection(upStation, downStation, request.getDistance());
         }
         return createLineResponse(line);
     }

--- a/src/main/java/nextstep/subway/applicaion/dto/SectionRequest.java
+++ b/src/main/java/nextstep/subway/applicaion/dto/SectionRequest.java
@@ -5,6 +5,12 @@ public class SectionRequest {
     private Long downStationId;
     private int distance;
 
+    public SectionRequest(Long upStationId, Long downStationId, int distance) {
+        this.upStationId = upStationId;
+        this.downStationId = downStationId;
+        this.distance = distance;
+    }
+
     public Long getUpStationId() {
         return upStationId;
     }

--- a/src/main/java/nextstep/subway/domain/Line.java
+++ b/src/main/java/nextstep/subway/domain/Line.java
@@ -1,10 +1,7 @@
 package nextstep.subway.domain;
 
 import javax.persistence.*;
-import java.util.ArrayList;
-import java.util.Collections;
 import java.util.List;
-import java.util.stream.Collectors;
 
 @Entity
 public class Line {
@@ -14,8 +11,8 @@ public class Line {
     private String name;
     private String color;
 
-    @OneToMany(mappedBy = "line", cascade = {CascadeType.PERSIST, CascadeType.MERGE}, orphanRemoval = true)
-    private List<Section> sections = new ArrayList<>();
+    @Embedded
+    private Sections sections = new Sections();
 
     public Line() {
     }
@@ -32,15 +29,11 @@ public class Line {
     }
 
     public void addSection(Station upStation, Station downStation, int distance) {
-        sections.add(new Section(this, upStation, downStation, distance));
+        sections.addSection(new Section(this, upStation, downStation, distance));
     }
 
     public List<Station> getStations() {
-        return sections.stream()
-                .map(Section::getStations)
-                .flatMap(List::stream)
-                .distinct()
-                .collect(Collectors.toList());
+        return sections.getStations();
     }
 
     public void removeSection(Long stationId) {
@@ -48,11 +41,11 @@ public class Line {
             throw new IllegalArgumentException();
         }
 
-        sections.removeIf(section -> section.getDownStation().getId() == stationId);
+        sections.removeSection(stationId);
     }
 
     public Station getLastStation() {
-        return sections.get(sections.size() - 1).getDownStation();
+        return sections.getLastStation();
     }
 
     public Long getId() {
@@ -80,6 +73,6 @@ public class Line {
     }
 
     public List<Section> getSections() {
-        return Collections.unmodifiableList(sections);
+        return sections.getSections();
     }
 }

--- a/src/main/java/nextstep/subway/domain/Line.java
+++ b/src/main/java/nextstep/subway/domain/Line.java
@@ -4,6 +4,7 @@ import javax.persistence.*;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
+import java.util.stream.Collectors;
 
 @Entity
 public class Line {
@@ -32,6 +33,14 @@ public class Line {
 
     public void addSection(Station upStation, Station downStation, int distance) {
         sections.add(new Section(this, upStation, downStation, distance));
+    }
+
+    public List<Station> getStations() {
+        return sections.stream()
+                .map(Section::getStations)
+                .flatMap(List::stream)
+                .distinct()
+                .collect(Collectors.toList());
     }
 
     public Long getId() {

--- a/src/main/java/nextstep/subway/domain/Line.java
+++ b/src/main/java/nextstep/subway/domain/Line.java
@@ -44,7 +44,7 @@ public class Line {
     }
 
     public void removeSection(Long stationId) {
-        if (sections.get(sections.size() - 1).getDownStation().getId() != stationId) {
+        if (!getLastStation().compare(stationId)) {
             throw new IllegalArgumentException();
         }
 

--- a/src/main/java/nextstep/subway/domain/Line.java
+++ b/src/main/java/nextstep/subway/domain/Line.java
@@ -23,6 +23,16 @@ public class Line {
         this.color = color;
     }
 
+    public Line(Long id, String name, String color) {
+        this.id = id;
+        this.name = name;
+        this.color = color;
+    }
+
+    public void addSection(Station upStation, Station downStation, int distance) {
+        sections.add(new Section(this, upStation, downStation, distance));
+    }
+
     public Long getId() {
         return id;
     }

--- a/src/main/java/nextstep/subway/domain/Line.java
+++ b/src/main/java/nextstep/subway/domain/Line.java
@@ -43,6 +43,18 @@ public class Line {
                 .collect(Collectors.toList());
     }
 
+    public void removeSection(Long stationId) {
+        if (sections.get(sections.size() - 1).getDownStation().getId() != stationId) {
+            throw new IllegalArgumentException();
+        }
+
+        sections.removeIf(section -> section.getDownStation().getId() == stationId);
+    }
+
+    public Station getLastStation() {
+        return sections.get(sections.size() - 1).getDownStation();
+    }
+
     public Long getId() {
         return id;
     }

--- a/src/main/java/nextstep/subway/domain/Line.java
+++ b/src/main/java/nextstep/subway/domain/Line.java
@@ -2,6 +2,7 @@ package nextstep.subway.domain;
 
 import javax.persistence.*;
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
 
 @Entity
@@ -58,6 +59,6 @@ public class Line {
     }
 
     public List<Section> getSections() {
-        return sections;
+        return Collections.unmodifiableList(sections);
     }
 }

--- a/src/main/java/nextstep/subway/domain/Section.java
+++ b/src/main/java/nextstep/subway/domain/Section.java
@@ -1,6 +1,7 @@
 package nextstep.subway.domain;
 
 import javax.persistence.*;
+import java.util.List;
 
 @Entity
 public class Section {
@@ -31,6 +32,10 @@ public class Section {
         this.upStation = upStation;
         this.downStation = downStation;
         this.distance = distance;
+    }
+
+    public List<Station> getStations() {
+        return List.of(upStation, downStation);
     }
 
     public Long getId() {

--- a/src/main/java/nextstep/subway/domain/Sections.java
+++ b/src/main/java/nextstep/subway/domain/Sections.java
@@ -1,0 +1,42 @@
+package nextstep.subway.domain;
+
+import javax.persistence.CascadeType;
+import javax.persistence.Embeddable;
+import javax.persistence.OneToMany;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.stream.Collectors;
+
+@Embeddable
+public class Sections {
+    @OneToMany(mappedBy = "line", cascade = {CascadeType.PERSIST, CascadeType.MERGE}, orphanRemoval = true)
+    private List<Section> sections = new ArrayList<>();
+
+    public Sections() {
+    }
+
+    public void addSection(Section section) {
+        sections.add(section);
+    }
+
+    public List<Station> getStations() {
+        return sections.stream()
+                .map(Section::getStations)
+                .flatMap(List::stream)
+                .distinct()
+                .collect(Collectors.toList());
+    }
+
+    public Station getLastStation() {
+        return sections.get(sections.size() - 1).getDownStation();
+    }
+
+    public void removeSection(Long stationId) {
+        sections.removeIf(section -> section.getDownStation().compare(stationId));
+    }
+
+    public List<Section> getSections() {
+        return Collections.unmodifiableList(sections);
+    }
+}

--- a/src/main/java/nextstep/subway/domain/Station.java
+++ b/src/main/java/nextstep/subway/domain/Station.java
@@ -19,6 +19,11 @@ public class Station {
         this.name = name;
     }
 
+    public Station(Long id, String name) {
+        this.id = id;
+        this.name = name;
+    }
+
     public Long getId() {
         return id;
     }

--- a/src/main/java/nextstep/subway/domain/Station.java
+++ b/src/main/java/nextstep/subway/domain/Station.java
@@ -24,6 +24,10 @@ public class Station {
         this.name = name;
     }
 
+    public boolean compare(Long stationId) {
+        return this.id == stationId;
+    }
+
     public Long getId() {
         return id;
     }

--- a/src/test/java/nextstep/subway/unit/LineServiceMockTest.java
+++ b/src/test/java/nextstep/subway/unit/LineServiceMockTest.java
@@ -1,11 +1,22 @@
 package nextstep.subway.unit;
 
+import nextstep.subway.applicaion.LineService;
 import nextstep.subway.applicaion.StationService;
+import nextstep.subway.applicaion.dto.SectionRequest;
+import nextstep.subway.domain.Line;
 import nextstep.subway.domain.LineRepository;
+import nextstep.subway.domain.Station;
+import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.doReturn;
 
 @ExtendWith(MockitoExtension.class)
 public class LineServiceMockTest {
@@ -14,15 +25,37 @@ public class LineServiceMockTest {
     @Mock
     private StationService stationService;
 
+    @InjectMocks
+    private LineService lineService;
+
+    private static final Long ONE_ID = 1L;
+    private static final Long TWO_ID = 2L;
+    private static final String LINE_ONE_NM = "일호선";
+    private static final String LINE_ONE_COLOR = "blue";
+    private static final String UP_STATION_NM_= "신도림";
+    private static final String DOWN_STATION_NM = "가산디지털단지";
+    private static final int DISTANCE_DEFAULT = 10;
+
+    private final Line 일호선 = new Line(ONE_ID, LINE_ONE_NM, LINE_ONE_COLOR);
+    private final Station 신도림 = new Station(ONE_ID, UP_STATION_NM_);
+    private final Station 가산디지털단지 = new Station(TWO_ID, DOWN_STATION_NM);
+
     @Test
+    @DisplayName("구간을 생성한다.")
     void addSection() {
         // given
         // lineRepository, stationService stub 설정을 통해 초기값 셋팅
+        doReturn(Optional.of(일호선)).when(lineRepository).findById(ONE_ID);
+        doReturn(신도림).when(stationService).findById(ONE_ID);
+        doReturn(가산디지털단지).when(stationService).findById(TWO_ID);
 
         // when
         // lineService.addSection 호출
+        SectionRequest sectionRequest = new SectionRequest(ONE_ID, TWO_ID, DISTANCE_DEFAULT);
+        lineService.addSection(ONE_ID, sectionRequest);
 
         // then
         // line.findLineById 메서드를 통해 검증
+        assertThat(일호선.getSections()).hasSize(1);
     }
 }

--- a/src/test/java/nextstep/subway/unit/LineServiceTest.java
+++ b/src/test/java/nextstep/subway/unit/LineServiceTest.java
@@ -1,12 +1,17 @@
 package nextstep.subway.unit;
 
 import nextstep.subway.applicaion.LineService;
+import nextstep.subway.applicaion.dto.SectionRequest;
+import nextstep.subway.domain.Line;
 import nextstep.subway.domain.LineRepository;
+import nextstep.subway.domain.Station;
 import nextstep.subway.domain.StationRepository;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.transaction.annotation.Transactional;
+
+import static org.assertj.core.api.Assertions.assertThat;
 
 @SpringBootTest
 @Transactional
@@ -19,15 +24,32 @@ public class LineServiceTest {
     @Autowired
     private LineService lineService;
 
+    private static final String LINE_ONE_NM = "일호선";
+    private static final String LINE_ONE_COLOR = "blue";
+    private static final String UP_STATION_NM_= "신도림";
+    private static final String DOWN_STATION_NM = "가산디지털단지";
+    private static final int DISTANCE_DEFAULT = 10;
+
+    private final Line 일호선 = new Line(LINE_ONE_NM, LINE_ONE_COLOR);
+    private final Station 신도림 = new Station(UP_STATION_NM_);
+    private final Station 가산디지털단지 = new Station(DOWN_STATION_NM);
+
     @Test
     void addSection() {
         // given
         // stationRepository와 lineRepository를 활용하여 초기값 셋팅
+        Station _신도림 = stationRepository.save(신도림);
+        Station _가산디지털단지 = stationRepository.save(가산디지털단지);
+
+        Line _일호선 = lineRepository.save(일호선);
 
         // when
         // lineService.addSection 호출
+        SectionRequest sectionRequest = new SectionRequest(_신도림.getId(), _가산디지털단지.getId(), DISTANCE_DEFAULT);
+        lineService.addSection(_일호선.getId(), sectionRequest);
 
         // then
         // line.getSections 메서드를 통해 검증
+        assertThat(_일호선.getSections()).hasSize(1);
     }
 }

--- a/src/test/java/nextstep/subway/unit/LineTest.java
+++ b/src/test/java/nextstep/subway/unit/LineTest.java
@@ -9,6 +9,8 @@ import org.junit.jupiter.api.Test;
 import java.util.List;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.junit.jupiter.api.Assertions.assertAll;
 
 class LineTest {
     private static final Long ONE_ID = 1L;
@@ -64,5 +66,22 @@ class LineTest {
 
         // then
         assertThat(일호선.getSections()).hasSize(1);
+    }
+
+    @Test
+    @DisplayName("구간 삭제 실패한다.")
+    void failToRemoveSection() {
+        // given
+        일호선.addSection(신도림, 가산디지털단지, DISTANCE_DEFAULT);
+        일호선.addSection(가산디지털단지, 독산, DISTANCE_DEFAULT);
+
+        // when(then)
+        assertAll(() -> {
+            assertThatThrownBy(() -> 일호선.removeSection(신도림.getId())).isInstanceOf(IllegalArgumentException.class);
+            assertThatThrownBy(() -> 일호선.removeSection(가산디지털단지.getId())).isInstanceOf(IllegalArgumentException.class);
+
+            일호선.removeSection(독산.getId());
+            assertThat(일호선.getSections()).hasSize(1);
+        });
     }
 }

--- a/src/test/java/nextstep/subway/unit/LineTest.java
+++ b/src/test/java/nextstep/subway/unit/LineTest.java
@@ -13,15 +13,18 @@ import static org.assertj.core.api.Assertions.assertThat;
 class LineTest {
     private static final Long ONE_ID = 1L;
     private static final Long TWO_ID = 2L;
+    private static final Long THREE_ID = 3L;
     private static final String LINE_ONE_NM = "일호선";
     private static final String LINE_ONE_COLOR = "blue";
     private static final String UP_STATION_NM_= "신도림";
     private static final String DOWN_STATION_NM = "가산디지털단지";
+    private static final String ADDITIONAL_STATION_NM = "독산";
     private static final int DISTANCE_DEFAULT = 10;
 
     private final Line 일호선 = new Line(ONE_ID, LINE_ONE_NM, LINE_ONE_COLOR);
     private final Station 신도림 = new Station(ONE_ID, UP_STATION_NM_);
     private final Station 가산디지털단지 = new Station(TWO_ID, DOWN_STATION_NM);
+    private final Station 독산 = new Station(THREE_ID, ADDITIONAL_STATION_NM);
 
     @Test
     @DisplayName("구간을 생성한다.")
@@ -49,6 +52,17 @@ class LineTest {
     }
 
     @Test
+    @DisplayName("구간을 삭제한다.")
     void removeSection() {
+        // given
+        일호선.addSection(신도림, 가산디지털단지, DISTANCE_DEFAULT);
+        일호선.addSection(가산디지털단지, 독산, DISTANCE_DEFAULT);
+
+        // when
+        Station 일호선_종착역 = 일호선.getLastStation();
+        일호선.removeSection(일호선_종착역.getId());
+
+        // then
+        assertThat(일호선.getSections()).hasSize(1);
     }
 }

--- a/src/test/java/nextstep/subway/unit/LineTest.java
+++ b/src/test/java/nextstep/subway/unit/LineTest.java
@@ -6,6 +6,8 @@ import nextstep.subway.domain.Station;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
+import java.util.List;
+
 import static org.assertj.core.api.Assertions.assertThat;
 
 class LineTest {
@@ -34,7 +36,16 @@ class LineTest {
     }
 
     @Test
+    @DisplayName("노선의 역을 조회한다.")
     void getStations() {
+        // given
+        일호선.addSection(신도림, 가산디지털단지, DISTANCE_DEFAULT);
+
+        // when
+        List<Station> stations = 일호선.getStations();
+
+        // then
+        assertThat(stations).containsExactly(신도림, 가산디지털단지);
     }
 
     @Test

--- a/src/test/java/nextstep/subway/unit/LineTest.java
+++ b/src/test/java/nextstep/subway/unit/LineTest.java
@@ -1,10 +1,36 @@
 package nextstep.subway.unit;
 
+import nextstep.subway.domain.Line;
+import nextstep.subway.domain.Section;
+import nextstep.subway.domain.Station;
+import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
+import static org.assertj.core.api.Assertions.assertThat;
+
 class LineTest {
+    private static final Long ONE_ID = 1L;
+    private static final Long TWO_ID = 2L;
+    private static final String LINE_ONE_NM = "일호선";
+    private static final String LINE_ONE_COLOR = "blue";
+    private static final String UP_STATION_NM_= "신도림";
+    private static final String DOWN_STATION_NM = "가산디지털단지";
+    private static final int DISTANCE_DEFAULT = 10;
+
+    private final Line 일호선 = new Line(ONE_ID, LINE_ONE_NM, LINE_ONE_COLOR);
+    private final Station 신도림 = new Station(ONE_ID, UP_STATION_NM_);
+    private final Station 가산디지털단지 = new Station(TWO_ID, DOWN_STATION_NM);
+
     @Test
+    @DisplayName("구간을 생성한다.")
     void addSection() {
+        // when
+        일호선.addSection(신도림, 가산디지털단지, DISTANCE_DEFAULT);
+
+        // then
+        assertThat(일호선.getSections()).filteredOn(
+                section -> section.equals(new Section(일호선, 신도림, 가산디지털단지, DISTANCE_DEFAULT))
+        );
     }
 
     @Test


### PR DESCRIPTION
안녕하세요.
리뷰이 엄홍준이라고 합니다.

미션을 이해하기 어려워 다른 분 코드를 많이 참고하여 이해하고자 했습니다. TDD까지는 가지도 못하고 테스트 코드 작성도 쉽지가 않았네요. 미션 중 LineTest는 DB(영속성)와 관계없는 테스트이고, 나머지 2개는 DB(영속성)와 관계있으나 가짜 객체를 사용하는지에 따라 방법이 나뉜다고 이해했는데요. 제대로 이해한건지 궁금합니다.

만약 제가 생각한게 맞다면 LineTest의 addSection 메소드의 경우 DB와 상관 없이 자바 메모리에 구간을 추가하는 것이므로 ID를 포함한 생성자를 추가해주었습니다. 반면 서비스단 테스트(LineServiceTest)의 경우 노선 혹은 역 생성 시 ID를 제외하고 생성해주었고요. 어차피 DB, 즉 엔티티로 관리(save)가 되면 ID값이 자동적으로 추가될 거라는 생각을 했습니다.
확인해보기 위해 LineTest의 addSection 메소드를 다음과 같이 확인해보았는데요.

```java
private final Line 일호선 = new Line(LINE_ONE_NM, LINE_ONE_COLOR);
private final Station 신도림 = new Station(UP_STATION_NM_);
private final Station 가산디지털단지 = new Station(DOWN_STATION_NM);

@Test
void addSection() {
	// given
	System.out.println("신도림1: " + 신도림);
	
	Station _신도림 = stationRepository.save(신도림);
	Station _가산디지털단지 = stationRepository.save(가산디지털단지);
	
	System.out.println("신도림2: " + 신도림);
	System.out.println("신도림3: " + _신도림);

	Line _일호선 = lineRepository.save(일호선);
	
	// when
	SectionRequest sectionRequest = new SectionRequest(_신도림.getId(), _가산디지털단지.getId(), DISTANCE_DEFAULT);
	lineService.addSection(_일호선.getId(), sectionRequest);

	// then
	assertThat(_일호선.getSections()).hasSize(1);
}
```

실행 결과는 다음과 같습니다.

```txt
신도림1: Station{id=null, name='신도림'}
신도림2: Station{id=1, name='신도림'}
신도림3: Station{id=1, name='신도림'}
```

제가 의아한 것은 lineService.addSection 메소드의 첫 번째 인자로 _일호선.getId()를 넣어주었는데요. 이는 영속성 컨텍스트로 관리되는, 즉 ID가 생긴 것은 반환받은 `_신도림`이지 파라미터 `신도림`이 아니라고 생각했기 때문입니다. 하지만 `_신도림`뿐 아니라 `신도림` 또한 ID가 생성된 것을 볼 수 있었는데요. 이 두 인스턴스가 왜 같은건지 혹시 힌트를 주실 수 있으실지요?

감사합니다.