### PR TITLE
Step1 : 지하철 구간 추가 기능 개선

### DIFF
--- a/src/main/java/nextstep/subway/applicaion/LineService.java
+++ b/src/main/java/nextstep/subway/applicaion/LineService.java
@@ -70,8 +70,7 @@ public class LineService {
         Station upStation = stationService.findById(sectionRequest.getUpStationId());
         Station downStation = stationService.findById(sectionRequest.getDownStationId());
         Line line = lineRepository.findById(lineId).orElseThrow(IllegalArgumentException::new);
-
-        line.getSections().add(new Section(line, upStation, downStation, sectionRequest.getDistance()));
+        line.addSections(new Section(line, upStation, downStation, sectionRequest.getDistance()));
     }
 
     private LineResponse createLineResponse(Line line) {

--- a/src/main/java/nextstep/subway/common/ErrorMessage.java
+++ b/src/main/java/nextstep/subway/common/ErrorMessage.java
@@ -3,7 +3,13 @@ package nextstep.subway.common;
 public enum ErrorMessage {
     ENOUGH_NOT_SECTION_SIZE("지하철 구간은 1개 이상이어야 합니다."),
     ENOUGH_REMOVE_DOWN("하행종점역만 삭제 할 수 있습니다."),
-    ENOUGH_ADD_CONNECT("마지막역의 하행종점역이 추가하는 구간의 상행역이여야 추가할 수 있습니다.")
+    ENOUGH_ADD_CONNECT("마지막역의 하행종점역이 추가하는 구간의 상행역이여야 추가할 수 있습니다."),
+    INVALID_SECTION_STATE("저장된 구간정보가 정상적이지 않습니다."),
+    DUPLICATED_STATION("상행역과 하행역이 이미 노선에 모두 등록되어 있습니다."),
+    NOT_CONNECT_STATION("상행역 또는 하행역과 연결되지 않은 지하철은 등록할 수 없습니다."),
+    NOT_FOUND_UP_STATION("존재하지 않는 상행역입니다."),
+    NOT_FOUND_DOWN_STATION("존재하지 않는 하행역입니다."),
+    INVALID_DISTANCE("지하철 구간의 간격이 잘못되었습니다."),
     ;
 
     private final String message;

--- a/src/main/java/nextstep/subway/domain/Distance.java
+++ b/src/main/java/nextstep/subway/domain/Distance.java
@@ -1,0 +1,30 @@
+package nextstep.subway.domain;
+
+import nextstep.subway.common.ErrorMessage;
+
+import javax.persistence.Embeddable;
+
+@Embeddable
+public class Distance {
+    private int distance;
+
+    public Distance(int distance) {
+        this.distance = distance;
+    }
+
+
+    protected Distance() {
+
+    }
+
+    public int getDistance() {
+        return distance;
+    }
+
+    public void decrease(int value) {
+        if (distance - value <= 0) {
+            throw new IllegalStateException(ErrorMessage.INVALID_DISTANCE.toString());
+        }
+        distance = distance - value;
+    }
+}

--- a/src/main/java/nextstep/subway/domain/Line.java
+++ b/src/main/java/nextstep/subway/domain/Line.java
@@ -3,9 +3,7 @@ package nextstep.subway.domain;
 import nextstep.subway.common.ErrorMessage;
 
 import javax.persistence.*;
-import java.util.ArrayList;
 import java.util.List;
-import java.util.Objects;
 import java.util.stream.Collectors;
 
 @Entity
@@ -16,8 +14,8 @@ public class Line {
     private String name;
     private String color;
 
-    @OneToMany(mappedBy = "line", cascade = {CascadeType.PERSIST, CascadeType.MERGE}, orphanRemoval = true)
-    private List<Section> sections = new ArrayList<>();
+    @Embedded
+    private SectionCollection sectionCollection = new SectionCollection();
 
     public Line() {
     }
@@ -52,36 +50,20 @@ public class Line {
     }
 
     public List<Section> getSections() {
-        return sections;
+        return sectionCollection.getSections();
     }
 
     public void addSections(Section section) {
-        Section lastSection = getLastStation();
-        if (lastSection != null && !Objects.equals(lastSection.getDownStation(), section.getUpStation())) {
-            throw new IllegalStateException(ErrorMessage.ENOUGH_ADD_CONNECT.toString());
-        }
-        sections.add(section);
-    }
-
-    private Section getLastStation() {
-        int index = sections.size() - 1;
-        if (index == -1) {
-            return null;
-        }
-        return sections.get(index);
+        sectionCollection.addSection(section);
     }
 
     public List<Station> getStations() {
-        List<Station> stations = sections.stream()
-                .map(Section::getDownStation)
-                .collect(Collectors.toList());
 
-        stations.add(0, sections.get(0).getUpStation());
-
-        return stations;
+        return sectionCollection.getStations();
     }
 
     public void removeStation(Station station) {
+        List<Section> sections = sectionCollection.getSections();
         int index = sections.size() - 1;
 
         if (index < 1) {

--- a/src/main/java/nextstep/subway/domain/Line.java
+++ b/src/main/java/nextstep/subway/domain/Line.java
@@ -63,16 +63,6 @@ public class Line {
     }
 
     public void removeStation(Station station) {
-        List<Section> sections = sectionCollection.getSections();
-        int index = sections.size() - 1;
-
-        if (index < 1) {
-            throw new IllegalStateException(ErrorMessage.ENOUGH_NOT_SECTION_SIZE.toString());
-        }
-        if (!sections.get(index).getDownStation().equals(station)) {
-            throw new IllegalArgumentException(ErrorMessage.ENOUGH_REMOVE_DOWN.toString());
-        }
-
-        sections.remove(index);
+        sectionCollection.removeSection(station);
     }
 }

--- a/src/main/java/nextstep/subway/domain/Section.java
+++ b/src/main/java/nextstep/subway/domain/Section.java
@@ -20,7 +20,8 @@ public class Section {
     @JoinColumn(name = "down_station_id")
     private Station downStation;
 
-    private int distance;
+    @Embedded
+    private Distance distance;
 
     public Section() {
 
@@ -30,7 +31,7 @@ public class Section {
         this.line = line;
         this.upStation = upStation;
         this.downStation = downStation;
-        this.distance = distance;
+        this.distance = new Distance(distance);
     }
 
     public Long getId() {
@@ -50,6 +51,16 @@ public class Section {
     }
 
     public int getDistance() {
-        return distance;
+        return distance.getDistance();
+    }
+
+    public void updateUpStation(Station updateStation, int distance) {
+        this.upStation = updateStation;
+        this.distance.decrease(distance);
+    }
+
+    public void updateDownStation(Station updateStation, int distance) {
+        this.downStation = updateStation;
+        this.distance.decrease(distance);
     }
 }

--- a/src/main/java/nextstep/subway/domain/SectionCollection.java
+++ b/src/main/java/nextstep/subway/domain/SectionCollection.java
@@ -1,0 +1,138 @@
+package nextstep.subway.domain;
+
+import nextstep.subway.common.ErrorMessage;
+
+import javax.persistence.CascadeType;
+import javax.persistence.Embeddable;
+import javax.persistence.OneToMany;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Objects;
+import java.util.Optional;
+import java.util.stream.Collectors;
+
+@Embeddable
+public class SectionCollection {
+
+    @OneToMany(mappedBy = "line", cascade = {CascadeType.PERSIST, CascadeType.MERGE}, orphanRemoval = true)
+    private List<Section> sections = new ArrayList<>();
+
+
+    public List<Section> getSections() {
+        return sections;
+    }
+
+    private Station getLastStation() {
+        List<Station> upStations = sections.stream()
+                .map(Section::getUpStation)
+                .collect(Collectors.toList());
+
+        return sections.stream()
+                .map(Section::getDownStation)
+                .filter(station -> !upStations.contains(station))
+                .findFirst()
+                .orElseThrow(() -> new IllegalStateException(ErrorMessage.INVALID_SECTION_STATE.toString()));
+    }
+
+    public void addSection(Section section) {
+        validation(section);
+        AddSectionStrategy addSectionStrategy = createAddSection(section);
+        addSectionStrategy.addSection(section);
+    }
+
+    private void validation(Section section) {
+        if (sections.isEmpty()) {
+            return;
+        }
+
+        Station upStation = section.getUpStation();
+        Station downStation = section.getDownStation();
+        List<Station> stations = getStations();
+        if (stations.contains(upStation) && stations.contains(downStation)) {
+            throw new IllegalStateException(ErrorMessage.DUPLICATED_STATION.toString());
+        }
+        if (!stations.contains(upStation) && !stations.contains(downStation)) {
+            throw new IllegalStateException(ErrorMessage.NOT_CONNECT_STATION.toString());
+        }
+    }
+
+    private Station getFirstStation() {
+        List<Station> downStations = sections.stream()
+                .map(Section::getDownStation)
+                .collect(Collectors.toList());
+
+        return sections.stream()
+                .map(Section::getUpStation)
+                .filter(station -> !downStations.contains(station))
+                .findFirst()
+                .orElseThrow(() -> new IllegalStateException(ErrorMessage.INVALID_SECTION_STATE.toString()));
+    }
+
+
+    AddSectionStrategy createAddSection(Section section) {
+        if (sections.isEmpty()) {
+            return new BasicAddSection();
+        }
+        Station upStation = section.getUpStation();
+        Station downStation = section.getDownStation();
+        Station firstStation = getFirstStation();
+        Station lastStation = getLastStation();
+
+        if (Objects.equals(downStation, firstStation) || Objects.equals(upStation, lastStation)) {
+            return new BasicAddSection();
+        }
+
+        return new MiddleAddSection();
+    }
+
+    public List<Station> getStations() {
+        List<Station> stations = new ArrayList<>();
+        Station nowStation = getFirstStation();
+        Station lastStation = getLastStation();
+        stations.add(nowStation);
+
+        while (!Objects.equals(nowStation, lastStation)) {
+            Section section = getUpStation(nowStation).orElseThrow(() -> new IllegalStateException(ErrorMessage.INVALID_SECTION_STATE.toString()));
+            nowStation = section.getDownStation();
+            stations.add(nowStation);
+        }
+        return stations;
+    }
+
+    private Optional<Section> getUpStation(Station upStation) {
+        return sections.stream()
+                .filter(section -> section.getUpStation().equals(upStation))
+                .findFirst();
+    }
+
+    private Optional<Section> getDownStation(Station downStation) {
+        return sections.stream()
+                .filter(section -> section.getDownStation().equals(downStation))
+                .findFirst();
+    }
+
+    interface AddSectionStrategy {
+        void addSection(Section section);
+    }
+
+    class MiddleAddSection implements AddSectionStrategy {
+
+        @Override
+        public void addSection(Section section) {
+            Station upStation = section.getUpStation();
+            Station downStation = section.getDownStation();
+            int distance = section.getDistance();
+            getUpStation(upStation).ifPresent(updateSection -> updateSection.updateUpStation(downStation, distance));
+            getDownStation(downStation).ifPresent(updateSection -> updateSection.updateDownStation(upStation, distance));
+            sections.add(section);
+        }
+    }
+
+    class BasicAddSection implements AddSectionStrategy {
+
+        @Override
+        public void addSection(Section section) {
+            sections.add(section);
+        }
+    }
+}

--- a/src/main/java/nextstep/subway/ui/ControllerExceptionHandler.java
+++ b/src/main/java/nextstep/subway/ui/ControllerExceptionHandler.java
@@ -11,4 +11,9 @@ public class ControllerExceptionHandler {
     public ResponseEntity<Void> handleIllegalArgsException(DataIntegrityViolationException e) {
         return ResponseEntity.badRequest().build();
     }
+
+    @ExceptionHandler(IllegalStateException.class)
+    public ResponseEntity<Void> handleIllegalStateException(IllegalStateException e) {
+        return ResponseEntity.badRequest().build();
+    }
 }

--- a/src/test/java/nextstep/subway/acceptance/LineAcceptanceTest.java
+++ b/src/test/java/nextstep/subway/acceptance/LineAcceptanceTest.java
@@ -27,7 +27,6 @@ class LineAcceptanceTest extends AcceptanceTest {
         ExtractableResponse<Response> response = 지하철_노선_생성_요청("2호선", "green");
 
         // then
-        assertThat(response.statusCode()).isEqualTo(HttpStatus.CREATED.value());
         ExtractableResponse<Response> listResponse = 지하철_노선_목록_조회_요청();
 
         assertThat(listResponse.jsonPath().getList("name")).contains("2호선");
@@ -49,7 +48,6 @@ class LineAcceptanceTest extends AcceptanceTest {
         ExtractableResponse<Response> response = 지하철_노선_목록_조회_요청();
 
         // then
-        assertThat(response.statusCode()).isEqualTo(HttpStatus.OK.value());
         assertThat(response.jsonPath().getList("name")).contains("2호선", "3호선");
     }
 
@@ -68,7 +66,6 @@ class LineAcceptanceTest extends AcceptanceTest {
         ExtractableResponse<Response> response = 지하철_노선_조회_요청(createResponse);
 
         // then
-        assertThat(response.statusCode()).isEqualTo(HttpStatus.OK.value());
         assertThat(response.jsonPath().getString("name")).isEqualTo("2호선");
     }
 
@@ -95,7 +92,6 @@ class LineAcceptanceTest extends AcceptanceTest {
 
         // then
         ExtractableResponse<Response> response = 지하철_노선_조회_요청(createResponse);
-        assertThat(response.statusCode()).isEqualTo(HttpStatus.OK.value());
         assertThat(response.jsonPath().getString("color")).isEqualTo("red");
     }
 

--- a/src/test/java/nextstep/subway/acceptance/LineSectionAcceptanceTest.java
+++ b/src/test/java/nextstep/subway/acceptance/LineSectionAcceptanceTest.java
@@ -53,6 +53,22 @@ class LineSectionAcceptanceTest extends AcceptanceTest {
     }
 
     /**
+     * Given 신분당선을 생성하고
+     * When 강남역 - 양재역 구간 사이에 새로운 구간(강남역 - 청계산역)을 등록하면
+     * Then 강남역 - 청계신역 - 양재역 구간이 생성된다.
+     */
+    @DisplayName("지하철 노선 추가")
+    @Test
+    void addStation() {
+        Long 청계산역 = 지하철역_생성_요청("청계산역").jsonPath().getLong("id");
+        지하철_노선에_지하철_구간_생성_요청(신분당선, createSectionCreateParams(강남역, 청계산역));
+
+        ExtractableResponse<Response> response = 지하철_노선_조회_요청(신분당선);
+        assertThat(response.statusCode()).isEqualTo(HttpStatus.OK.value());
+        assertThat(response.jsonPath().getList("stations.id", Long.class)).containsExactly(강남역, 청계산역, 양재역);
+    }
+
+    /**
      * Given 지하철 노선에 새로운 구간 추가를 요청 하고
      * When 지하철 노선의 마지막 구간 제거를 요청 하면
      * Then 노선에 구간이 제거된다

--- a/src/test/java/nextstep/subway/acceptance/LineSectionAcceptanceTest.java
+++ b/src/test/java/nextstep/subway/acceptance/LineSectionAcceptanceTest.java
@@ -69,6 +69,83 @@ class LineSectionAcceptanceTest extends AcceptanceTest {
     }
 
     /**
+     * Given 신분당선을 생성하고
+     * When 강남역 - 양재역 구간 뒤에 새로운 구간(양재역 - 청계산역)을 등록하면
+     * Then 강남역 - 양재역 - 청계산역 구간이 생성된다.
+     */
+    @DisplayName("지하철 노선 추가")
+    @Test
+    void addStation_2() {
+        Long 청계산역 = 지하철역_생성_요청("청계산역").jsonPath().getLong("id");
+        지하철_노선에_지하철_구간_생성_요청(신분당선, createSectionCreateParams(양재역, 청계산역));
+
+        ExtractableResponse<Response> response = 지하철_노선_조회_요청(신분당선);
+        assertThat(response.statusCode()).isEqualTo(HttpStatus.OK.value());
+        assertThat(response.jsonPath().getList("stations.id", Long.class)).containsExactly(강남역, 양재역, 청계산역);
+    }
+
+    /**
+     * Given 신분당선을 생성하고
+     * When 강남역 - 양재역 구간 앞에 새로운 구간(서초역 - 강남역)을 등록하면
+     * Then 서초역 - 강남역 - 양재역 구간이 생성된다.
+     */
+    @DisplayName("지하철 노선 추가")
+    @Test
+    void addStation_3() {
+        Long 서초역 = 지하철역_생성_요청("서초역").jsonPath().getLong("id");
+        지하철_노선에_지하철_구간_생성_요청(신분당선, createSectionCreateParams(서초역, 강남역));
+
+        ExtractableResponse<Response> response = 지하철_노선_조회_요청(신분당선);
+        assertThat(response.statusCode()).isEqualTo(HttpStatus.OK.value());
+        assertThat(response.jsonPath().getList("stations.id", Long.class)).containsExactly(서초역, 강남역, 양재역);
+    }
+
+    /**
+     * Given 신분당선을 생성하고
+     * When 강남역 - 양재역 구간 사이에 새로운 구간(강남역 - 청계산역)을 등록할때 구간 간격이 기존의 구간보다 크면
+     * Then 요청이 실패한다.
+     */
+    @DisplayName("지하철 노선 추가 실패")
+    @Test
+    void addStationFail() {
+        Long 서초역 = 지하철역_생성_요청("서초역").jsonPath().getLong("id");
+        ExtractableResponse<Response> response = 지하철_노선에_지하철_구간_생성_요청(신분당선, createSectionCreateParams(강남역, 서초역, 20));
+
+        assertThat(response.statusCode()).isEqualTo(HttpStatus.BAD_REQUEST.value());
+    }
+
+    /**
+     * Given 신분당선을 생성하고
+     * When 상행역과 하행역이 이미 등록되어 있으
+     * Then 요청이 실패한다.
+     */
+    @DisplayName("지하철 노선 추가 실패")
+    @Test
+    void addStationFail_2() {
+        지하철_노선에_지하철_구간_생성_요청(신분당선, createSectionCreateParams(강남역, 양재역,20));
+
+        ExtractableResponse<Response> response = 지하철_노선_조회_요청(신분당선);
+        assertThat(response.statusCode()).isEqualTo(HttpStatus.BAD_REQUEST.value());
+    }
+
+    /**
+     * Given 신분당선을 생성하고
+     * When 상행역과 하행역이 모두 등록되어 있지않으면
+     * Then 요청이 실패한다.
+     */
+    @DisplayName("지하철 노선 추가 실패")
+    @Test
+    void addStationFail_3() {
+        Long 서초역 = 지하철역_생성_요청("서초역").jsonPath().getLong("id");
+        Long 사당역 = 지하철역_생성_요청("사당역").jsonPath().getLong("id");
+        ExtractableResponse<Response> response = 지하철_노선에_지하철_구간_생성_요청(신분당선, createSectionCreateParams(서초역, 사당역, 20));
+        assertThat(response.statusCode()).isEqualTo(HttpStatus.BAD_REQUEST.value());
+    }
+
+
+
+
+    /**
      * Given 지하철 노선에 새로운 구간 추가를 요청 하고
      * When 지하철 노선의 마지막 구간 제거를 요청 하면
      * Then 노선에 구간이 제거된다
@@ -105,6 +182,13 @@ class LineSectionAcceptanceTest extends AcceptanceTest {
         params.put("upStationId", upStationId + "");
         params.put("downStationId", downStationId + "");
         params.put("distance", 6 + "");
+        return params;
+    }
+    private Map<String, String> createSectionCreateParams(Long upStationId, Long downStationId,int distance) {
+        Map<String, String> params = new HashMap<>();
+        params.put("upStationId", upStationId + "");
+        params.put("downStationId", downStationId + "");
+        params.put("distance", distance + "");
         return params;
     }
 }

--- a/src/test/java/nextstep/subway/acceptance/LineSectionAcceptanceTest.java
+++ b/src/test/java/nextstep/subway/acceptance/LineSectionAcceptanceTest.java
@@ -57,7 +57,7 @@ class LineSectionAcceptanceTest extends AcceptanceTest {
      * When 강남역 - 양재역 구간 사이에 새로운 구간(강남역 - 청계산역)을 등록하면
      * Then 강남역 - 청계신역 - 양재역 구간이 생성된다.
      */
-    @DisplayName("지하철 노선 추가")
+    @DisplayName("지하철 노선 맨 뒤에 추가")
     @Test
     void addStation() {
         Long 청계산역 = 지하철역_생성_요청("청계산역").jsonPath().getLong("id");
@@ -73,7 +73,7 @@ class LineSectionAcceptanceTest extends AcceptanceTest {
      * When 강남역 - 양재역 구간 뒤에 새로운 구간(양재역 - 청계산역)을 등록하면
      * Then 강남역 - 양재역 - 청계산역 구간이 생성된다.
      */
-    @DisplayName("지하철 노선 추가")
+    @DisplayName("지하철 노선 중간 추가")
     @Test
     void addStation_2() {
         Long 청계산역 = 지하철역_생성_요청("청계산역").jsonPath().getLong("id");
@@ -89,7 +89,7 @@ class LineSectionAcceptanceTest extends AcceptanceTest {
      * When 강남역 - 양재역 구간 앞에 새로운 구간(서초역 - 강남역)을 등록하면
      * Then 서초역 - 강남역 - 양재역 구간이 생성된다.
      */
-    @DisplayName("지하철 노선 추가")
+    @DisplayName("지하철 노선 맨 앞에 추가")
     @Test
     void addStation_3() {
         Long 서초역 = 지하철역_생성_요청("서초역").jsonPath().getLong("id");
@@ -105,7 +105,7 @@ class LineSectionAcceptanceTest extends AcceptanceTest {
      * When 강남역 - 양재역 구간 사이에 새로운 구간(강남역 - 청계산역)을 등록할때 구간 간격이 기존의 구간보다 크면
      * Then 요청이 실패한다.
      */
-    @DisplayName("지하철 노선 추가 실패")
+    @DisplayName("지하철 노선 중간 삽입 시 구간 길이가 더 클때 추가 실패")
     @Test
     void addStationFail() {
         Long 서초역 = 지하철역_생성_요청("서초역").jsonPath().getLong("id");
@@ -119,12 +119,11 @@ class LineSectionAcceptanceTest extends AcceptanceTest {
      * When 상행역과 하행역이 이미 등록되어 있으
      * Then 요청이 실패한다.
      */
-    @DisplayName("지하철 노선 추가 실패")
+    @DisplayName("지하철 노선 이미등록된 구간을 추가할 경우 실패")
     @Test
     void addStationFail_2() {
-        지하철_노선에_지하철_구간_생성_요청(신분당선, createSectionCreateParams(강남역, 양재역,20));
+        var response = 지하철_노선에_지하철_구간_생성_요청(신분당선, createSectionCreateParams(강남역, 양재역,20));
 
-        ExtractableResponse<Response> response = 지하철_노선_조회_요청(신분당선);
         assertThat(response.statusCode()).isEqualTo(HttpStatus.BAD_REQUEST.value());
     }
 
@@ -133,7 +132,7 @@ class LineSectionAcceptanceTest extends AcceptanceTest {
      * When 상행역과 하행역이 모두 등록되어 있지않으면
      * Then 요청이 실패한다.
      */
-    @DisplayName("지하철 노선 추가 실패")
+    @DisplayName("지하철 노선 이어져있찌 않은 구간의 경우 실패")
     @Test
     void addStationFail_3() {
         Long 서초역 = 지하철역_생성_요청("서초역").jsonPath().getLong("id");

--- a/src/test/java/nextstep/subway/acceptance/LineSteps.java
+++ b/src/test/java/nextstep/subway/acceptance/LineSteps.java
@@ -3,29 +3,39 @@ package nextstep.subway.acceptance;
 import io.restassured.RestAssured;
 import io.restassured.response.ExtractableResponse;
 import io.restassured.response.Response;
+import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 
 import java.util.HashMap;
 import java.util.Map;
+
+import static org.assertj.core.api.Assertions.assertThat;
 
 public class LineSteps {
     public static ExtractableResponse<Response> 지하철_노선_생성_요청(String name, String color) {
         Map<String, String> params = new HashMap<>();
         params.put("name", name);
         params.put("color", color);
-        return RestAssured
+        var response = RestAssured
                 .given().log().all()
                 .body(params)
                 .contentType(MediaType.APPLICATION_JSON_VALUE)
                 .when().post("/lines")
                 .then().log().all().extract();
+
+        assertThat(response.statusCode()).isEqualTo(HttpStatus.CREATED.value());
+
+        return response;
     }
 
     public static ExtractableResponse<Response> 지하철_노선_목록_조회_요청() {
-        return RestAssured
+        var response = RestAssured
                 .given().log().all()
                 .when().get("/lines")
                 .then().log().all().extract();
+        assertThat(response.statusCode()).isEqualTo(HttpStatus.OK.value());
+
+        return response;
     }
 
     public static ExtractableResponse<Response> 지하철_노선_조회_요청(ExtractableResponse<Response> createResponse) {

--- a/src/test/java/nextstep/subway/unit/LineServiceMockTest.java
+++ b/src/test/java/nextstep/subway/unit/LineServiceMockTest.java
@@ -47,8 +47,6 @@ public class LineServiceMockTest {
         firstStation = new Station("강남역");
         secondStation = new Station("판교역");
         section = new Section(line, firstStation, secondStation, 10);
-
-        line.addSections(section);
     }
 
     @Test

--- a/src/test/java/nextstep/subway/unit/LineServiceTest.java
+++ b/src/test/java/nextstep/subway/unit/LineServiceTest.java
@@ -49,13 +49,13 @@ public class LineServiceTest {
     @Test
     void addSection() {
         section = new Section(line, firstStation, secondStation, 10);
-        line.addSections(section);
+
         SectionRequest sectionRequest = new SectionRequest(firstStation.getId(), secondStation.getId(), 10);
         lineService.addSection(line.getId(), sectionRequest);
 
         // then
         // line.getSections 메서드를 통해 검증
         LineResponse response = lineService.findById(line.getId());
-        assertThat(response.getStations()).hasSize(3);
+        assertThat(response.getStations()).hasSize(2);
     }
 }

--- a/src/test/java/nextstep/subway/unit/LineTest.java
+++ b/src/test/java/nextstep/subway/unit/LineTest.java
@@ -10,6 +10,7 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
 import java.util.List;
+import java.util.stream.Collectors;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
@@ -41,14 +42,68 @@ class LineTest {
     }
 
     @Test
-    @DisplayName("추가하는 역의 상행역이 마지막 역의 하행역이 아니면 추가할 수 없다.")
-    void addSectionFail() {
+    @DisplayName("강남 - 판교 사이에 양재역을 추가하여서 강남 - 양재 -판교 구간을 만들 수 있다.")
+    void addSectionCase_1() {
         Station lastStation = new Station("양재역");
-        section = new Section(line, firstStation, lastStation, 10);
+        section = new Section(line, firstStation, lastStation, 5);
+        line.addSections(section);
+
+        List<String> names = line.getStations().stream().map(Station::getName).collect(Collectors.toList());
+        assertThat(names).containsExactly("강남역","양재역","판교역");
+    }
+
+    @Test
+    @DisplayName("서초 - 강남 구간을 추가해서 서초 - 강남 -판교 구간을 만들 수 있다.")
+    void addSectionCase_2() {
+        Station addStation = new Station("서초역");
+        section = new Section(line, addStation, firstStation, 5);
+        line.addSections(section);
+
+        List<String> names = line.getStations().stream().map(Station::getName).collect(Collectors.toList());
+        assertThat(names).containsExactly("서초역", "강남역","판교역");
+    }
+
+    @Test
+    @DisplayName("판교 - 청계산 구간을 추가해서 강남 - 판교 - 청계산 구간을 만들 수 있다.")
+    void addSectionCase_3() {
+        Station addStation = new Station("청계산역");
+        section = new Section(line, secondStation, addStation, 5);
+        line.addSections(section);
+
+        List<String> names = line.getStations().stream().map(Station::getName).collect(Collectors.toList());
+        assertThat(names).containsExactly( "강남역","판교역","청계산역");
+    }
+
+    @Test
+    @DisplayName("역사이에 새로운 역을 등록할 경우 기존 역 사이 길이보다 크거나 같으면 등록할 수 없다.")
+    void addSectionFail_1() {
+        Station addStation = new Station("청계산역");
+        section = new Section(line, firstStation, addStation, 10);
         assertThatThrownBy(() -> line.addSections(section))
                 .isInstanceOf(IllegalStateException.class)
-                .hasMessage(ErrorMessage.ENOUGH_ADD_CONNECT.toString());
+                .hasMessage(ErrorMessage.INVALID_DISTANCE.toString());
     }
+
+    @Test
+    @DisplayName("상행역과 하행역이 이미 노선에 등록되있으면 등록할 수 없다.")
+    void addSectionFail_2() {
+        section = new Section(line, secondStation, firstStation, 10);
+        assertThatThrownBy(() -> line.addSections(section))
+                .isInstanceOf(IllegalStateException.class)
+                .hasMessage(ErrorMessage.DUPLICATED_STATION.toString());
+    }
+
+    @Test
+    @DisplayName("상행역과 하행역 중 하나라도 노선에 포함되어 있지 않으면 추가할 수 없다.")
+    void addSectionFail_3() {
+        Station addStation = new Station("청계산역");
+        Station addTwoStation = new Station("양재역");
+        section = new Section(line, addTwoStation, addStation, 10);
+        assertThatThrownBy(() -> line.addSections(section))
+                .isInstanceOf(IllegalStateException.class)
+                .hasMessage(ErrorMessage.NOT_CONNECT_STATION.toString());
+    }
+
 
     @Test
     @DisplayName("지하철 노선을 조회할 수 있따.")


### PR DESCRIPTION
안녕하세요 준우님 1단계 미션도 잘부탁드립니다!
구간 추가 로직에서 헤메다 보니 테스트 사이클을 제대로 지키지 못했네요.
다음 단계부터는 더 열심히 지켜보겠습니다!
저번 리뷰의 삭제테스트의 경우 step2에서 함께 진행하겠습니다!

0단계의 리뷰대로 일급컬렉션을 활용해보았는데 적절히 활용했는지 봐주시면 좋겠습니다!
일급컬렉션 내부에서 전략패턴을 도입하였는데 적절한지도 봐주시면 감사하겠습니다!
(초기에는 삽입 로직을 예시와 마찬가지로 3가지로 나누어서 할려고 도입하였는데 짜다보니 2가지로도 가능해져서 부적절한게 아닌가라는 생각이 들었습니다!)
현재 비즈니스 로직이 복잡해져서 sections를 순회하면서 find와 contain하는 로직이 반복하는데 list의 contain 복잡도가 n * 2 이다보니 이부분을 set으로 바꾸면 어떨까요?
이때 set으로 바꿀때 엔티티 자체를 set으로 가져갈지 아니면 조회와 contain을 할때만 set으로 변환할지에 대한 생각이 궁금합니다.

Q1. 엔티티를 set으로 설정하는것에 대해서 성능이슈가 있는것으로 알고 있는데 이러한 성능이슈 vs 조회, contain 시간복잡도
Q2. 리스트를 set으로 변환하는 리소스 vs 조회, contain 시간복잡도
입니다!

개인적으로 일급컬렉션에 관한 리뷰가 너무 감사했습니다!! 이번에도 많은 지적부탁드립니다!
