### PR TITLE
Step1 : 지하철 구간 추가 개선

### DIFF
--- a/src/main/java/nextstep/subway/applicaion/LineService.java
+++ b/src/main/java/nextstep/subway/applicaion/LineService.java
@@ -109,4 +109,8 @@ public class LineService {
 
         line.getSections().remove(line.getSections().size() - 1);
     }
+
+    public Line findLineById(Long lineId) {
+        return lineRepository.findById(lineId).orElseThrow(IllegalArgumentException::new);
+    }
 }

--- a/src/main/java/nextstep/subway/applicaion/LineService.java
+++ b/src/main/java/nextstep/subway/applicaion/LineService.java
@@ -88,11 +88,7 @@ public class LineService {
             return Collections.emptyList();
         }
 
-        List<Station> stations = line.getSections().stream()
-                .map(Section::getDownStation)
-                .collect(Collectors.toList());
-
-        stations.add(0, line.getSections().get(0).getUpStation());
+        List<Station> stations = line.getStations();
 
         return stations.stream()
                 .map(it -> stationService.createStationResponse(it))

--- a/src/main/java/nextstep/subway/applicaion/LineService.java
+++ b/src/main/java/nextstep/subway/applicaion/LineService.java
@@ -70,7 +70,8 @@ public class LineService {
         Station downStation = stationService.findById(sectionRequest.getDownStationId());
         Line line = lineRepository.findById(lineId).orElseThrow(IllegalArgumentException::new);
 
-        line.getSections().add(new Section(line, upStation, downStation, sectionRequest.getDistance()));
+        Section section = new Section(line, upStation, downStation, sectionRequest.getDistance());
+        line.addSection(section);
     }
 
     private LineResponse createLineResponse(Line line) {

--- a/src/main/java/nextstep/subway/applicaion/dto/SectionRequest.java
+++ b/src/main/java/nextstep/subway/applicaion/dto/SectionRequest.java
@@ -17,12 +17,6 @@ public class SectionRequest {
         return distance;
     }
 
-    /*
-        Q. test 위해서 불필요한 Request Constructor가 생성된 것이 아닌가?
-        쓰지 않고 addLine(long, sectionRequest)를 테스트 할 방법이 있는가?
-     */
-
-
     public SectionRequest(Long upStationId, Long downStationId, int distance) {
         this.upStationId = upStationId;
         this.downStationId = downStationId;

--- a/src/main/java/nextstep/subway/applicaion/dto/SectionRequest.java
+++ b/src/main/java/nextstep/subway/applicaion/dto/SectionRequest.java
@@ -16,4 +16,16 @@ public class SectionRequest {
     public int getDistance() {
         return distance;
     }
+
+    /*
+        Q. test 위해서 불필요한 Request Constructor가 생성된 것이 아닌가?
+        쓰지 않고 addLine(long, sectionRequest)를 테스트 할 방법이 있는가?
+     */
+
+
+    public SectionRequest(Long upStationId, Long downStationId, int distance) {
+        this.upStationId = upStationId;
+        this.downStationId = downStationId;
+        this.distance = distance;
+    }
 }

--- a/src/main/java/nextstep/subway/domain/Line.java
+++ b/src/main/java/nextstep/subway/domain/Line.java
@@ -1,11 +1,7 @@
 package nextstep.subway.domain;
 
-import java.util.LinkedList;
-import java.util.Objects;
-import java.util.stream.Collectors;
 import javax.persistence.*;
 import java.util.List;
-import org.springframework.dao.DataIntegrityViolationException;
 
 @Entity
 public class Line {
@@ -15,9 +11,8 @@ public class Line {
     private String name;
     private String color;
 
-    @OneToMany(mappedBy = "line", cascade = {CascadeType.PERSIST, CascadeType.MERGE}, orphanRemoval = true)
-    @OrderColumn(name="section_order")
-    private List<Section> sections = new LinkedList<>();
+    @Embedded
+    private Sections sections;
 
     public Line() {
     }
@@ -25,6 +20,7 @@ public class Line {
     public Line(String name, String color) {
         this.name = name;
         this.color = color;
+        this.sections = new Sections();
     }
 
     public Long getId() {
@@ -52,74 +48,11 @@ public class Line {
     }
 
     public List<Section> getSections() {
-        return sections;
+        return sections.getSections();
     }
 
     public void addSection(Section section) {
-        List<Station> stations = getStations();
-        validateAddSection(stations, section);
-
-        if (stations.isEmpty()) {
-            sections.add(section);
-            return;
-        }
-
-        for (int i = 0; i < sections.size(); i++) {
-            Section origin = sections.get(i);
-            if (Objects.equals(origin.getUpStation(), section.getUpStation())) {
-                addSectionBackOfUpStation(origin, section, i);
-            } else if (Objects.equals(origin.getDownStation(), section.getDownStation())) {
-                addSectionFrontOfDownStation(origin, section, i);
-            } else if (Objects.equals(origin.getUpStation(), section.getDownStation())) {
-                addUpStation(section);
-            } else if (Objects.equals(origin.getDownStation(), section.getUpStation())) {
-                addDownStation(section);
-            } else {
-                continue;
-            }
-            updateOrderValues();
-            return;
-        }
-    }
-
-    private void addUpStation(Section section) {
-        sections.add(0, section);
-    }
-
-    private void addDownStation(Section section) {
-        sections.add(section);
-    }
-
-    private void addSectionBackOfUpStation(Section origin ,Section newbie, int i) {
-        validateDistance(newbie, origin);
-
-        Section right = new Section(this, newbie.getDownStation(), origin.getDownStation(), origin.getDistance() - newbie.getDistance());
-        sections.set(i, newbie);
-        sections.add(i + 1, right);
-    }
-
-    private void addSectionFrontOfDownStation(Section origin, Section newbie, int i) {
-        validateDistance(newbie, origin);
-        Section left = new Section(this, origin.getUpStation(), newbie.getUpStation(), origin.getDistance() - newbie.getDistance());
-        sections.set(i, left);
-        sections.add(i + 1, newbie);
-    }
-
-
-    private void validateAddSection(List<Station> stations, Section section) {
-        if (stations.contains(section.getUpStation()) && stations.contains(section.getDownStation())) {
-            throw new DataIntegrityViolationException("둘 다 등록된 역입니다.");
-        }
-
-        if (!stations.isEmpty() && !stations.contains(section.getUpStation()) && !stations.contains(section.getDownStation())) {
-            throw new DataIntegrityViolationException("노선에 추가하려는 역이 모두 등록되지 않은 역입니다");
-        }
-    }
-
-    private void validateDistance(Section newbie, Section origin) {
-        if (newbie.getDistance() >= origin.getDistance()) {
-            throw new DataIntegrityViolationException("노선에 추가하려는 중간 구간의 거리가 기존 구간보다 깁니다");
-        }
+        sections.addSection(this, section);
     }
 
     public void removeSections(Section section) {
@@ -127,17 +60,6 @@ public class Line {
     }
 
     public List<Station> getStations() {
-        List<Station> stations = sections.stream().map(Section::getUpStation).collect(Collectors.toList());
-        if (stations.isEmpty()) {
-            return stations;
-        }
-        stations.add(sections.get(sections.size() - 1).getDownStation());
-        return stations;
-    }
-
-    private void updateOrderValues() {
-        for (int i = 0; i < sections.size(); i++) {
-            sections.get(i).setOrder(i);
-        }
+        return sections.getStations();
     }
 }

--- a/src/main/java/nextstep/subway/domain/Line.java
+++ b/src/main/java/nextstep/subway/domain/Line.java
@@ -1,9 +1,11 @@
 package nextstep.subway.domain;
 
+import java.util.LinkedList;
+import java.util.Objects;
 import java.util.stream.Collectors;
 import javax.persistence.*;
-import java.util.ArrayList;
 import java.util.List;
+import org.springframework.dao.DataIntegrityViolationException;
 
 @Entity
 public class Line {
@@ -14,7 +16,8 @@ public class Line {
     private String color;
 
     @OneToMany(mappedBy = "line", cascade = {CascadeType.PERSIST, CascadeType.MERGE}, orphanRemoval = true)
-    private List<Section> sections = new ArrayList<>();
+    @OrderColumn(name="section_order")
+    private List<Section> sections = new LinkedList<>();
 
     public Line() {
     }
@@ -53,7 +56,70 @@ public class Line {
     }
 
     public void addSection(Section section) {
+        List<Station> stations = getStations();
+        validateAddSection(stations, section);
+
+        if (stations.isEmpty()) {
+            sections.add(section);
+            return;
+        }
+
+        for (int i = 0; i < sections.size(); i++) {
+            Section origin = sections.get(i);
+            if (Objects.equals(origin.getUpStation(), section.getUpStation())) {
+                addSectionBackOfUpStation(origin, section, i);
+            } else if (Objects.equals(origin.getDownStation(), section.getDownStation())) {
+                addSectionFrontOfDownStation(origin, section, i);
+            } else if (Objects.equals(origin.getUpStation(), section.getDownStation())) {
+                addUpStation(section);
+            } else if (Objects.equals(origin.getDownStation(), section.getUpStation())) {
+                addDownStation(section);
+            } else {
+                continue;
+            }
+            updateOrderValues();
+            return;
+        }
+    }
+
+    private void addUpStation(Section section) {
+        sections.add(0, section);
+    }
+
+    private void addDownStation(Section section) {
         sections.add(section);
+    }
+
+    private void addSectionBackOfUpStation(Section origin ,Section newbie, int i) {
+        validateDistance(newbie, origin);
+
+        Section right = new Section(this, newbie.getDownStation(), origin.getDownStation(), origin.getDistance() - newbie.getDistance());
+        sections.set(i, newbie);
+        sections.add(i + 1, right);
+    }
+
+    private void addSectionFrontOfDownStation(Section origin, Section newbie, int i) {
+        validateDistance(newbie, origin);
+        Section left = new Section(this, origin.getUpStation(), newbie.getUpStation(), origin.getDistance() - newbie.getDistance());
+        sections.set(i, left);
+        sections.add(i + 1, newbie);
+    }
+
+
+    private void validateAddSection(List<Station> stations, Section section) {
+        if (stations.contains(section.getUpStation()) && stations.contains(section.getDownStation())) {
+            throw new DataIntegrityViolationException("둘 다 등록된 역입니다.");
+        }
+
+        if (!stations.isEmpty() && !stations.contains(section.getUpStation()) && !stations.contains(section.getDownStation())) {
+            throw new DataIntegrityViolationException("노선에 추가하려는 역이 모두 등록되지 않은 역입니다");
+        }
+    }
+
+    private void validateDistance(Section newbie, Section origin) {
+        if (newbie.getDistance() >= origin.getDistance()) {
+            throw new DataIntegrityViolationException("노선에 추가하려는 중간 구간의 거리가 기존 구간보다 깁니다");
+        }
     }
 
     public void removeSections(Section section) {
@@ -67,5 +133,11 @@ public class Line {
         }
         stations.add(sections.get(sections.size() - 1).getDownStation());
         return stations;
+    }
+
+    private void updateOrderValues() {
+        for (int i = 0; i < sections.size(); i++) {
+            sections.get(i).setOrder(i);
+        }
     }
 }

--- a/src/main/java/nextstep/subway/domain/Line.java
+++ b/src/main/java/nextstep/subway/domain/Line.java
@@ -1,5 +1,6 @@
 package nextstep.subway.domain;
 
+import java.util.stream.Collectors;
 import javax.persistence.*;
 import java.util.ArrayList;
 import java.util.List;
@@ -49,5 +50,22 @@ public class Line {
 
     public List<Section> getSections() {
         return sections;
+    }
+
+    public void addSection(Section section) {
+        sections.add(section);
+    }
+
+    public void removeSections(Section section) {
+        sections.remove(section);
+    }
+
+    public List<Station> getStations() {
+        List<Station> stations = sections.stream().map(Section::getUpStation).collect(Collectors.toList());
+        if (stations.isEmpty()) {
+            return stations;
+        }
+        stations.add(sections.get(sections.size() - 1).getDownStation());
+        return stations;
     }
 }

--- a/src/main/java/nextstep/subway/domain/Section.java
+++ b/src/main/java/nextstep/subway/domain/Section.java
@@ -20,6 +20,9 @@ public class Section {
     @JoinColumn(name = "down_station_id")
     private Station downStation;
 
+    @Column(name="section_order")
+    private Long order;
+
     private int distance;
 
     public Section() {
@@ -51,5 +54,9 @@ public class Section {
 
     public int getDistance() {
         return distance;
+    }
+
+    public void setOrder(int i) {
+        order = (long) i;
     }
 }

--- a/src/main/java/nextstep/subway/domain/Sections.java
+++ b/src/main/java/nextstep/subway/domain/Sections.java
@@ -1,0 +1,114 @@
+package nextstep.subway.domain;
+
+import java.util.Collections;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.Objects;
+import java.util.stream.Collectors;
+import javax.persistence.CascadeType;
+import javax.persistence.Embeddable;
+import javax.persistence.OneToMany;
+import javax.persistence.OrderColumn;
+import org.springframework.dao.DataIntegrityViolationException;
+
+@Embeddable
+public class Sections {
+
+  @OneToMany(mappedBy = "line", cascade = {CascadeType.PERSIST, CascadeType.MERGE}, orphanRemoval = true)
+  @OrderColumn(name="section_order")
+  private List<Section> sections;
+
+  public Sections() {
+    this.sections = new LinkedList<>();
+  }
+
+  public List<Section> getSections() {
+    return sections;
+  }
+
+  public void remove(Section section) {
+    sections.remove(section);
+  }
+
+  public List<Station> getStations() {
+    if (sections.isEmpty()) {
+      return Collections.emptyList();
+    }
+    List<Station> stations = sections.stream().map(Section::getUpStation).collect(Collectors.toList());
+    stations.add(sections.get(sections.size() - 1).getDownStation());
+    return stations;
+  }
+
+  public void addSection(Line line, Section section) {
+    List<Station> stations = getStations();
+    validateAddSection(stations, section);
+
+    if (stations.isEmpty()) {
+      sections.add(section);
+      return;
+    }
+
+    for (int i = 0; i < sections.size(); i++) {
+      Section origin = sections.get(i);
+      if (Objects.equals(origin.getUpStation(), section.getUpStation())) {
+        addSectionBackOfUpStation(line, origin, section, i);
+      } else if (Objects.equals(origin.getDownStation(), section.getDownStation())) {
+        addSectionFrontOfDownStation(line, origin, section, i);
+      } else if (Objects.equals(origin.getUpStation(), section.getDownStation())) {
+        addUpStation(section);
+      } else if (Objects.equals(origin.getDownStation(), section.getUpStation())) {
+        addDownStation(section);
+      } else {
+        continue;
+      }
+      updateOrderValues();
+      return;
+    }
+  }
+
+  private void addUpStation(Section section) {
+    sections.add(0, section);
+  }
+
+  private void addDownStation(Section section) {
+    sections.add(section);
+  }
+
+  private void addSectionBackOfUpStation(Line line, Section origin ,Section newbie, int i) {
+    validateDistance(newbie, origin);
+
+    Section right = new Section(line, newbie.getDownStation(), origin.getDownStation(), origin.getDistance() - newbie.getDistance());
+    sections.set(i, newbie);
+    sections.add(i + 1, right);
+  }
+
+  private void addSectionFrontOfDownStation(Line line, Section origin, Section newbie, int i) {
+    validateDistance(newbie, origin);
+    Section left = new Section(line, origin.getUpStation(), newbie.getUpStation(), origin.getDistance() - newbie.getDistance());
+    sections.set(i, left);
+    sections.add(i + 1, newbie);
+  }
+
+
+  private void validateAddSection(List<Station> stations, Section section) {
+    if (stations.contains(section.getUpStation()) && stations.contains(section.getDownStation())) {
+      throw new DataIntegrityViolationException("둘 다 등록된 역입니다.");
+    }
+
+    if (!stations.isEmpty() && !stations.contains(section.getUpStation()) && !stations.contains(section.getDownStation())) {
+      throw new DataIntegrityViolationException("노선에 추가하려는 역이 모두 등록되지 않은 역입니다");
+    }
+  }
+
+  private void validateDistance(Section newbie, Section origin) {
+    if (newbie.getDistance() >= origin.getDistance()) {
+      throw new DataIntegrityViolationException("노선에 추가하려는 중간 구간의 거리가 기존 구간보다 깁니다");
+    }
+  }
+
+  private void updateOrderValues() {
+    for (int i = 0; i < sections.size(); i++) {
+      sections.get(i).setOrder(i);
+    }
+  }
+}

--- a/src/test/java/nextstep/subway/acceptance/LineSectionAcceptanceTest.java
+++ b/src/test/java/nextstep/subway/acceptance/LineSectionAcceptanceTest.java
@@ -2,6 +2,7 @@ package nextstep.subway.acceptance;
 
 import io.restassured.response.ExtractableResponse;
 import io.restassured.response.Response;
+import java.util.List;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -49,8 +50,7 @@ class LineSectionAcceptanceTest extends AcceptanceTest {
 
         // then
         ExtractableResponse<Response> response = 지하철_노선_조회_요청(신분당선);
-        assertThat(response.statusCode()).isEqualTo(HttpStatus.OK.value());
-        assertThat(response.jsonPath().getList("stations.id", Long.class)).containsExactly(강남역, 양재역, 정자역);
+        응답_확인(response, 강남역, 양재역, 정자역);
     }
 
     /**
@@ -70,8 +70,7 @@ class LineSectionAcceptanceTest extends AcceptanceTest {
 
         // then
         ExtractableResponse<Response> response = 지하철_노선_조회_요청(신분당선);
-        assertThat(response.statusCode()).isEqualTo(HttpStatus.OK.value());
-        assertThat(response.jsonPath().getList("stations.id", Long.class)).containsExactly(강남역, 양재역);
+        응답_확인(response, 강남역, 양재역);
     }
 
     /**
@@ -90,8 +89,7 @@ class LineSectionAcceptanceTest extends AcceptanceTest {
 
         // then
         ExtractableResponse<Response> response = 지하철_노선_조회_요청(신분당선);
-        assertThat(response.statusCode()).isEqualTo(HttpStatus.OK.value());
-        assertThat(response.jsonPath().getList("stations.id", Long.class)).containsExactly(강남역, 뱅뱅사거리역, 양재역);
+        응답_확인(response, 강남역, 뱅뱅사거리역, 양재역);
     }
 
     /**
@@ -110,7 +108,7 @@ class LineSectionAcceptanceTest extends AcceptanceTest {
             지하철_노선에_지하철_구간_생성_요청(신분당선, createSectionCreateParams(뱅뱅사거리역, 양재역, 10));
 
         // then
-        assertThat(response.statusCode()).isEqualTo(HttpStatus.BAD_REQUEST.value());
+        응답은_에러를_반환한다(response);
     }
 
     /**
@@ -129,8 +127,7 @@ class LineSectionAcceptanceTest extends AcceptanceTest {
 
         // then
         ExtractableResponse<Response> response = 지하철_노선_조회_요청(신분당선);
-        assertThat(response.statusCode()).isEqualTo(HttpStatus.OK.value());
-        assertThat(response.jsonPath().getList("stations.id", Long.class)).containsExactly(신논현역, 강남역, 양재역);
+        응답_확인(response, 신논현역, 강남역, 양재역);
     }
 
     /**
@@ -147,7 +144,7 @@ class LineSectionAcceptanceTest extends AcceptanceTest {
             지하철_노선에_지하철_구간_생성_요청(신분당선, createSectionCreateParams(양재역, 강남역, 5));
 
         // then
-        assertThat(response.statusCode()).isEqualTo(HttpStatus.BAD_REQUEST.value());
+        응답은_에러를_반환한다(response);
     }
 
     /**
@@ -167,8 +164,18 @@ class LineSectionAcceptanceTest extends AcceptanceTest {
             지하철_노선에_지하철_구간_생성_요청(신분당선, createSectionCreateParams(정자역, 미금역, 5));
 
         // then
+        응답은_에러를_반환한다(response);
+    }
+
+    private void 응답은_에러를_반환한다(ExtractableResponse<Response> response) {
         assertThat(response.statusCode()).isEqualTo(HttpStatus.BAD_REQUEST.value());
     }
+
+    private void 응답_확인(ExtractableResponse<Response> response, Long... stations) {
+        assertThat(response.statusCode()).isEqualTo(HttpStatus.OK.value());
+        assertThat(response.jsonPath().getList("stations.id", Long.class)).containsExactlyElementsOf(List.of(stations));
+    }
+
 
     private Map<String, String> createLineCreateParams(Long upStationId, Long downStationId) {
         Map<String, String> lineCreateParams;

--- a/src/test/java/nextstep/subway/acceptance/LineSectionAcceptanceTest.java
+++ b/src/test/java/nextstep/subway/acceptance/LineSectionAcceptanceTest.java
@@ -11,6 +11,7 @@ import java.util.HashMap;
 import java.util.Map;
 
 import static nextstep.subway.acceptance.LineSteps.*;
+import static nextstep.subway.acceptance.LineSteps.지하철_노선에_지하철_구간_생성_요청;
 import static nextstep.subway.acceptance.StationSteps.지하철역_생성_요청;
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -44,7 +45,7 @@ class LineSectionAcceptanceTest extends AcceptanceTest {
     void addLineSection() {
         // when
         Long 정자역 = 지하철역_생성_요청("정자역").jsonPath().getLong("id");
-        지하철_노선에_지하철_구간_생성_요청(신분당선, createSectionCreateParams(양재역, 정자역));
+        지하철_노선에_지하철_구간_생성_요청(신분당선, createSectionCreateParams(양재역, 정자역, 6));
 
         // then
         ExtractableResponse<Response> response = 지하철_노선_조회_요청(신분당선);
@@ -62,7 +63,7 @@ class LineSectionAcceptanceTest extends AcceptanceTest {
     void removeLineSection() {
         // given
         Long 정자역 = 지하철역_생성_요청("정자역").jsonPath().getLong("id");
-        지하철_노선에_지하철_구간_생성_요청(신분당선, createSectionCreateParams(양재역, 정자역));
+        지하철_노선에_지하철_구간_생성_요청(신분당선, createSectionCreateParams(양재역, 정자역, 6));
 
         // when
         지하철_노선에_지하철_구간_제거_요청(신분당선, 정자역);
@@ -71,6 +72,102 @@ class LineSectionAcceptanceTest extends AcceptanceTest {
         ExtractableResponse<Response> response = 지하철_노선_조회_요청(신분당선);
         assertThat(response.statusCode()).isEqualTo(HttpStatus.OK.value());
         assertThat(response.jsonPath().getList("stations.id", Long.class)).containsExactly(강남역, 양재역);
+    }
+
+    /**
+     * Given 지하철 노선을 생성하고
+     * When 노선 중간에 신규 구간을 추가하면
+     * Then 기존 노선이 둘로 생긴다.
+     */
+    @DisplayName("노선 중간 역 추가")
+    @Test
+    void createMiddleStationSection() {
+        // given
+        Long 뱅뱅사거리역 = 지하철역_생성_요청("뱅뱅사거리역").jsonPath().getLong("id");
+
+        // when
+        지하철_노선에_지하철_구간_생성_요청(신분당선, createSectionCreateParams(뱅뱅사거리역, 양재역, 3));
+
+        // then
+        ExtractableResponse<Response> response = 지하철_노선_조회_요청(신분당선);
+        assertThat(response.statusCode()).isEqualTo(HttpStatus.OK.value());
+        assertThat(response.jsonPath().getList("stations.id", Long.class)).containsExactly(강남역, 뱅뱅사거리역, 양재역);
+    }
+
+    /**
+     * Given 지하철 노선을 생성하고
+     * When 해당 구간보다 긴 노선을 중간에 신규 추가하면
+     * Then Exception을 발생시킨다
+     */
+    @DisplayName("노선 중간에 새로 추가되는 구간이 기존 구간 이상의 거리를 가질 수 없음")
+    @Test
+    void createMiddleStationSectionException() {
+        // given
+        Long 뱅뱅사거리역 = 지하철역_생성_요청("뱅뱅사거리역").jsonPath().getLong("id");
+
+        // when
+        ExtractableResponse<Response> response =
+            지하철_노선에_지하철_구간_생성_요청(신분당선, createSectionCreateParams(뱅뱅사거리역, 양재역, 10));
+
+        // then
+        assertThat(response.statusCode()).isEqualTo(HttpStatus.BAD_REQUEST.value());
+    }
+
+    /**
+     * Given 지하철 노선을 생성하고
+     * When 상행역에 노선을 추가하면
+     * Then 신규 노선이 추가된다.
+     */
+    @DisplayName("노선의 상행역에 노선을 추가할 수 있다.")
+    @Test
+    void creataeUpStationSection() {
+        // given
+        Long 신논현역 = 지하철역_생성_요청("신논현역").jsonPath().getLong("id");
+
+        // when
+        지하철_노선에_지하철_구간_생성_요청(신분당선, createSectionCreateParams(신논현역, 강남역, 6));
+
+        // then
+        ExtractableResponse<Response> response = 지하철_노선_조회_요청(신분당선);
+        assertThat(response.statusCode()).isEqualTo(HttpStatus.OK.value());
+        assertThat(response.jsonPath().getList("stations.id", Long.class)).containsExactly(신논현역, 강남역, 양재역);
+    }
+
+    /**
+     * Given 지하철 노선을 생성하고
+     * When 이미 등록된 역을 상,하행역으로 노선을 추가하면
+     * Then 에러를 반환한다.
+     */
+    @DisplayName("노선에 이미 등록된 역들로 새로운 구간을 생성할 수 없다.")
+    @Test
+    void 이미_추가된_역들로_새로운_구간을_생성_할_수_없다() {
+        // given
+        // when
+        ExtractableResponse<Response> response =
+            지하철_노선에_지하철_구간_생성_요청(신분당선, createSectionCreateParams(양재역, 강남역, 5));
+
+        // then
+        assertThat(response.statusCode()).isEqualTo(HttpStatus.BAD_REQUEST.value());
+    }
+
+    /**
+     * Given 지하철 노선을 생성하고
+     * When 상, 하행역이 모두 등록되지 않은 노선을 추가하면
+     * Then 에러를 반환한다.
+     */
+    @DisplayName("노선에 새로 추가되는 구간의 역이 하나도 등록되지 않은 경우, 에러를 반환한다")
+    @Test
+    void 노선에_상하행선_모두_등록되지_않은_경우() {
+        // given
+        Long 정자역 = 지하철역_생성_요청("정자역").jsonPath().getLong("id");
+        Long 미금역 = 지하철역_생성_요청("미금역").jsonPath().getLong("id");
+
+        // when
+        ExtractableResponse<Response> response =
+            지하철_노선에_지하철_구간_생성_요청(신분당선, createSectionCreateParams(정자역, 미금역, 5));
+
+        // then
+        assertThat(response.statusCode()).isEqualTo(HttpStatus.BAD_REQUEST.value());
     }
 
     private Map<String, String> createLineCreateParams(Long upStationId, Long downStationId) {
@@ -84,7 +181,7 @@ class LineSectionAcceptanceTest extends AcceptanceTest {
         return lineCreateParams;
     }
 
-    private Map<String, String> createSectionCreateParams(Long upStationId, Long downStationId) {
+    private Map<String, String> createSectionCreateParams(Long upStationId, Long downStationId, Integer distance) {
         Map<String, String> params = new HashMap<>();
         params.put("upStationId", upStationId + "");
         params.put("downStationId", downStationId + "");

--- a/src/test/java/nextstep/subway/acceptance/LineSectionAcceptanceTest.java
+++ b/src/test/java/nextstep/subway/acceptance/LineSectionAcceptanceTest.java
@@ -120,7 +120,7 @@ class LineSectionAcceptanceTest extends AcceptanceTest {
      */
     @DisplayName("노선의 상행역에 노선을 추가할 수 있다.")
     @Test
-    void creataeUpStationSection() {
+    void createUpStationSection() {
         // given
         Long 신논현역 = 지하철역_생성_요청("신논현역").jsonPath().getLong("id");
 
@@ -185,7 +185,7 @@ class LineSectionAcceptanceTest extends AcceptanceTest {
         Map<String, String> params = new HashMap<>();
         params.put("upStationId", upStationId + "");
         params.put("downStationId", downStationId + "");
-        params.put("distance", 6 + "");
+        params.put("distance", distance + "");
         return params;
     }
 }

--- a/src/test/java/nextstep/subway/unit/LineServiceMockTest.java
+++ b/src/test/java/nextstep/subway/unit/LineServiceMockTest.java
@@ -1,9 +1,24 @@
 package nextstep.subway.unit;
 
+import static nextstep.subway.utils.MockString.line2;
+import static nextstep.subway.utils.MockString.봉천역;
+import static nextstep.subway.utils.MockString.서울대입구역;
+import static nextstep.subway.utils.MockString.초록색;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import java.util.Optional;
+import nextstep.subway.applicaion.LineService;
 import nextstep.subway.applicaion.StationService;
+import nextstep.subway.applicaion.dto.SectionRequest;
+import nextstep.subway.domain.Line;
 import nextstep.subway.domain.LineRepository;
+import nextstep.subway.domain.Station;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
@@ -14,15 +29,33 @@ public class LineServiceMockTest {
     @Mock
     private StationService stationService;
 
+    @InjectMocks
+    private LineService lineService;
+
     @Test
     void addSection() {
         // given
         // lineRepository, stationService stub 설정을 통해 초기값 셋팅
+        Line mockLine = new Line(line2, 초록색);
+        Station upStation = new Station(서울대입구역);
+        Station downStation = new Station(봉천역);
+        SectionRequest request = mock(SectionRequest.class);
+
+        when(request.getUpStationId()).thenReturn(1L);
+        when(request.getDownStationId()).thenReturn(2L);
+        when(request.getDistance()).thenReturn(10);
+        when(lineRepository.findById(any())).thenReturn(Optional.of(mockLine));
+        when(stationService.findById(1L)).thenReturn(upStation);
+        when(stationService.findById(2L)).thenReturn(downStation);
 
         // when
         // lineService.addSection 호출
+        lineService.addSection(mockLine.getId(), request);
 
         // then
-        // line.findLineById 메서드를 통해 검증
+        // lineService.findLineById 메서드를 통해 검증
+        Line updated = lineService.findLineById(mockLine.getId());
+        assertThat(updated.getSections().get(0).getUpStation()).isEqualTo(upStation);
+        assertThat(updated.getSections().get(0).getDownStation()).isEqualTo(downStation);
     }
 }

--- a/src/test/java/nextstep/subway/unit/LineServiceTest.java
+++ b/src/test/java/nextstep/subway/unit/LineServiceTest.java
@@ -1,7 +1,16 @@
 package nextstep.subway.unit;
 
+import static nextstep.subway.utils.MockString.line2;
+import static nextstep.subway.utils.MockString.봉천역;
+import static nextstep.subway.utils.MockString.서울대입구역;
+import static nextstep.subway.utils.MockString.초록색;
+import static org.assertj.core.api.Assertions.assertThat;
+
 import nextstep.subway.applicaion.LineService;
+import nextstep.subway.applicaion.dto.SectionRequest;
+import nextstep.subway.domain.Line;
 import nextstep.subway.domain.LineRepository;
+import nextstep.subway.domain.Station;
 import nextstep.subway.domain.StationRepository;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -23,11 +32,18 @@ public class LineServiceTest {
     void addSection() {
         // given
         // stationRepository와 lineRepository를 활용하여 초기값 셋팅
+        Line line = lineRepository.save(new Line(line2, 초록색));
+        Station upStation = stationRepository.save(new Station(서울대입구역));
+        Station downStation = stationRepository.save(new Station(봉천역));
 
         // when
         // lineService.addSection 호출
+        lineService.addSection(line.getId(), new SectionRequest(upStation.getId(), downStation.getId(), 10));
 
         // then
         // line.getSections 메서드를 통해 검증
+        Line updated = lineRepository.findById(line.getId()).orElseThrow(IllegalArgumentException::new);
+        assertThat(updated.getSections().get(0).getUpStation()).isEqualTo(upStation);
+        assertThat(updated.getSections().get(0).getDownStation()).isEqualTo(downStation);
     }
 }

--- a/src/test/java/nextstep/subway/unit/LineTest.java
+++ b/src/test/java/nextstep/subway/unit/LineTest.java
@@ -1,5 +1,8 @@
 package nextstep.subway.unit;
 
+import static nextstep.subway.utils.MockString.봉천역;
+import static nextstep.subway.utils.MockString.서울대입구역;
+import static nextstep.subway.utils.MockString.신림역;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import nextstep.subway.domain.Line;
@@ -12,7 +15,7 @@ class LineTest {
     void addSection() {
         Line line = new Line("2호선", "초록색");
         Section section = createTestSection(line);
-        line.addSections(section);
+        line.addSection(section);
 
         assertThat(line.getSections().size()).isEqualTo(1);
     }
@@ -20,24 +23,30 @@ class LineTest {
     @Test
     void getStations() {
         Line line = new Line("2호선", "초록색");
-        line.addSections(createTestSection(line));
-        assertThat(line.getStations().size()).isEqualTo(0);
+        line.addSection(createTestSection(line, 서울대입구역, 봉천역));
+        line.addSection(createTestSection(line, 봉천역, 신림역));
+        assertThat(line.getStations().size()).isEqualTo(3);
     }
 
     @Test
     void removeSection() {
         Line line = new Line("2호선", "초록색");
         Section section = createTestSection(line);
-        line.addSections(section);
+        line.addSection(section);
 
         line.removeSections(section);
-
         assertThat(line.getSections().size()).isEqualTo(0);
     }
 
     private Section createTestSection(Line line) {
-        Station upStation = new Station("서울대입구역");
-        Station downStation = new Station("봉천역");
+        Station upStation = new Station(서울대입구역);
+        Station downStation = new Station(봉천역);
+        return new Section(line, upStation, downStation,10);
+    }
+
+    private Section createTestSection(Line line, String station1, String station2) {
+        Station upStation = new Station(station1);
+        Station downStation = new Station(station2);
         return new Section(line, upStation, downStation,10);
     }
 }

--- a/src/test/java/nextstep/subway/unit/LineTest.java
+++ b/src/test/java/nextstep/subway/unit/LineTest.java
@@ -1,17 +1,43 @@
 package nextstep.subway.unit;
 
+import static org.assertj.core.api.Assertions.assertThat;
+
+import nextstep.subway.domain.Line;
+import nextstep.subway.domain.Section;
+import nextstep.subway.domain.Station;
 import org.junit.jupiter.api.Test;
 
 class LineTest {
     @Test
     void addSection() {
+        Line line = new Line("2호선", "초록색");
+        Section section = createTestSection(line);
+        line.addSections(section);
+
+        assertThat(line.getSections().size()).isEqualTo(1);
     }
 
     @Test
     void getStations() {
+        Line line = new Line("2호선", "초록색");
+        line.addSections(createTestSection(line));
+        assertThat(line.getStations().size()).isEqualTo(0);
     }
 
     @Test
     void removeSection() {
+        Line line = new Line("2호선", "초록색");
+        Section section = createTestSection(line);
+        line.addSections(section);
+
+        line.removeSections(section);
+
+        assertThat(line.getSections().size()).isEqualTo(0);
+    }
+
+    private Section createTestSection(Line line) {
+        Station upStation = new Station("서울대입구역");
+        Station downStation = new Station("봉천역");
+        return new Section(line, upStation, downStation,10);
     }
 }

--- a/src/test/java/nextstep/subway/unit/LineTest.java
+++ b/src/test/java/nextstep/subway/unit/LineTest.java
@@ -22,9 +22,14 @@ class LineTest {
 
     @Test
     void getStations() {
+        Station 서울대 = new Station(서울대입구역);
+        Station 봉천 = new Station(봉천역);
+        Station 신림 = new Station(신림역);
         Line line = new Line("2호선", "초록색");
-        line.addSection(createTestSection(line, 서울대입구역, 봉천역));
-        line.addSection(createTestSection(line, 봉천역, 신림역));
+
+        line.addSection(createTestSection(line, 서울대, 봉천));
+        line.addSection(createTestSection(line, 봉천, 신림));
+
         assertThat(line.getStations().size()).isEqualTo(3);
     }
 
@@ -44,9 +49,7 @@ class LineTest {
         return new Section(line, upStation, downStation,10);
     }
 
-    private Section createTestSection(Line line, String station1, String station2) {
-        Station upStation = new Station(station1);
-        Station downStation = new Station(station2);
+    private Section createTestSection(Line line, Station upStation, Station downStation) {
         return new Section(line, upStation, downStation,10);
     }
 }

--- a/src/test/java/nextstep/subway/unit/LineTest.java
+++ b/src/test/java/nextstep/subway/unit/LineTest.java
@@ -4,11 +4,13 @@ import static nextstep.subway.utils.MockString.봉천역;
 import static nextstep.subway.utils.MockString.서울대입구역;
 import static nextstep.subway.utils.MockString.신림역;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import nextstep.subway.domain.Line;
 import nextstep.subway.domain.Section;
 import nextstep.subway.domain.Station;
 import org.junit.jupiter.api.Test;
+import org.springframework.dao.DataIntegrityViolationException;
 
 class LineTest {
     @Test
@@ -27,8 +29,8 @@ class LineTest {
         Station 신림 = new Station(신림역);
         Line line = new Line("2호선", "초록색");
 
-        line.addSection(createTestSection(line, 서울대, 봉천));
-        line.addSection(createTestSection(line, 봉천, 신림));
+        line.addSection(createTestSection(line, 서울대, 봉천,10));
+        line.addSection(createTestSection(line, 봉천, 신림, 10));
 
         assertThat(line.getStations().size()).isEqualTo(3);
     }
@@ -43,13 +45,34 @@ class LineTest {
         assertThat(line.getSections().size()).isEqualTo(0);
     }
 
+    @Test
+    void addDuplicateSection() {
+        Line line = new Line("2호선", "초록색");
+        Section section = createTestSection(line);
+        line.addSection(section);
+
+        assertThrows(DataIntegrityViolationException.class, () -> line.addSection(section));
+    }
+
+    @Test
+    void 중간_구간_추가시_기존_구간보다_길면_에러() {
+        Line line = new Line("2호선", "초록색");
+        Station 서울대 = new Station(서울대입구역);
+        Station 봉천 = new Station(봉천역);
+        Station 신림 = new Station(신림역);
+        line.addSection(createTestSection(line, 서울대, 신림,10));
+        Section 신규_구간 = createTestSection(line, 봉천, 신림, 20);
+
+        assertThrows(DataIntegrityViolationException.class, () -> line.addSection(신규_구간));
+    }
+
     private Section createTestSection(Line line) {
         Station upStation = new Station(서울대입구역);
         Station downStation = new Station(봉천역);
         return new Section(line, upStation, downStation,10);
     }
 
-    private Section createTestSection(Line line, Station upStation, Station downStation) {
-        return new Section(line, upStation, downStation,10);
+    private Section createTestSection(Line line, Station upStation, Station downStation, int distance) {
+        return new Section(line, upStation, downStation,distance);
     }
 }

--- a/src/test/java/nextstep/subway/unit/SectionsTest.java
+++ b/src/test/java/nextstep/subway/unit/SectionsTest.java
@@ -51,6 +51,20 @@ public class SectionsTest {
   }
 
   @Test
+  void 구간_상행역에_구간_추가() {
+    Sections sections = new Sections();
+    Section section1 = 신규_구간_생성(역삼역, 선릉역, 10);
+    Section section2 = 신규_구간_생성(강남역, 역삼역, 20);
+    sections.addSection(line, section1);
+    sections.addSection(line, section2);
+
+    List<Station> stations = sections.getStations();
+
+    assertThat(stations.stream().map(Station::getName).collect(Collectors.toList()))
+        .containsExactly(강남역.getName(), 역삼역.getName(), 선릉역.getName());
+  }
+
+  @Test
   void 구간_내_역_조회() {
     Sections sections = new Sections();
     Section section1 = 신규_구간_생성(강남역, 역삼역, 10);

--- a/src/test/java/nextstep/subway/unit/SectionsTest.java
+++ b/src/test/java/nextstep/subway/unit/SectionsTest.java
@@ -1,0 +1,70 @@
+package nextstep.subway.unit;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.List;
+import java.util.stream.Collectors;
+import nextstep.subway.domain.Line;
+import nextstep.subway.domain.Section;
+import nextstep.subway.domain.Sections;
+import nextstep.subway.domain.Station;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+public class SectionsTest {
+
+  private Line line;
+  private Station 강남역;
+  private Station 역삼역;
+  private Station 선릉역;
+
+  @BeforeEach
+  void 기본_값_준비() {
+    line =  new Line();
+    강남역 = new Station("강남역");
+    역삼역 = new Station("역삼역");
+    선릉역 = new Station("선릉역");
+  }
+
+  @Test
+  void 구간_추가() {
+    Sections sections = new Sections();
+    Section section = 신규_구간_생성(강남역, 역삼역, 10);
+
+    sections.addSection(line, section);
+
+    assertThat(sections.getSections()).contains(section);
+  }
+
+  @Test
+  void 구간_중간에_새로운_구간_추가() {
+    Sections sections = new Sections();
+    Section section1 = 신규_구간_생성(강남역, 선릉역, 20);
+    Section section2 = 신규_구간_생성(역삼역, 선릉역, 10);
+    sections.addSection(line, section1);
+    sections.addSection(line, section2);
+
+    List<Station> stations = sections.getStations();
+
+    assertThat(stations.stream().map(Station::getName).collect(Collectors.toList()))
+        .containsExactly(강남역.getName(), 역삼역.getName(), 선릉역.getName());
+  }
+
+  @Test
+  void 구간_내_역_조회() {
+    Sections sections = new Sections();
+    Section section1 = 신규_구간_생성(강남역, 역삼역, 10);
+    Section section2 = 신규_구간_생성(역삼역, 선릉역, 10);
+    sections.addSection(line, section1);
+    sections.addSection(line, section2);
+
+    List<Station> stations = sections.getStations();
+
+    assertThat(stations.stream().map(Station::getName).collect(Collectors.toList()))
+        .containsExactly(강남역.getName(), 역삼역.getName(), 선릉역.getName());
+  }
+
+  private Section 신규_구간_생성(Station upStation, Station downStation, Integer distance) {
+    return new Section(line, upStation, downStation,distance);
+  }
+}

--- a/src/test/java/nextstep/subway/utils/MockString.java
+++ b/src/test/java/nextstep/subway/utils/MockString.java
@@ -1,0 +1,10 @@
+package nextstep.subway.utils;
+
+public class MockString {
+  public static String line2 = "2호선";
+
+  public static String 서울대입구역 = "서울대입구역";
+  public static String 봉천역 = "봉천역";
+
+  public static String 초록색 = "초록색";
+}

--- a/src/test/java/nextstep/subway/utils/MockString.java
+++ b/src/test/java/nextstep/subway/utils/MockString.java
@@ -6,5 +6,7 @@ public class MockString {
   public static String 서울대입구역 = "서울대입구역";
   public static String 봉천역 = "봉천역";
 
+  public static String 신림역 = "신림역";
+
   public static String 초록색 = "초록색";
 }


### PR DESCRIPTION
## 요약
1. 단위 테스트 실습 및 지하철 구간 추가 기능 개선
2. 구간 순서 조회 기능은 order column을 추가하여 구현
  - 스펙에 적혀있는 상행 종점부터 하행 종점까지 iteration을 해서 찾는 부분은 구현 이후에 발견해버려서 따로 반영하지 못했습니다. 😅😅

## 질문
1. SectionRequest.java에 SectionRequest constructor가 하나 새롭게 추가되었는데, 이는 기존 LineServiceTest.java에서 sectionRequest instance를 생성해서 addSection()을 호출할 수 없어 추가하게 되었습니다.
그러나 이건 테스트코드를 위해서 프로덕션 코드에 변형이 생긴 것이라 좋은 패턴이 아니라고 알고 있습니다.
혹시 이를 고치기 위한 좋은 방법이 있을까요?