### PR TITLE
🚀 2단계 - 지하철 구간 제거 기능 개선

### DIFF
--- a/src/main/java/nextstep/subway/common/constants/ErrorConstant.java
+++ b/src/main/java/nextstep/subway/common/constants/ErrorConstant.java
@@ -5,4 +5,5 @@ public class ErrorConstant {
     public static final String MORE_THEN_DISTANCE = "기존 구간 사이에 역을 등록할 경우 기존 역 사이 길이보다 크거나 같으면 등록할 수 없습니다.";
     public static final String ALREADY_ENROLL_STATION = "상행 역과 하행 역이 이미 노선에 모두 등록되어 있다면 등록할 수 없습니다.";
     public static final String NOT_ENROLL_STATION = "상행 역과 하행 역 둘 중 하나도 포함되어 있지 않으면 등록할 수 없습니다.";
+    public static final String LESS_THAN_ONE_SECTION = "노선에 등록된 구간이 하나 이하일 경우 구간을 제거할 수 없습니다.";
 }

--- a/src/main/java/nextstep/subway/common/constants/ErrorConstant.java
+++ b/src/main/java/nextstep/subway/common/constants/ErrorConstant.java
@@ -6,4 +6,5 @@ public class ErrorConstant {
     public static final String ALREADY_ENROLL_STATION = "상행 역과 하행 역이 이미 노선에 모두 등록되어 있다면 등록할 수 없습니다.";
     public static final String NOT_ENROLL_STATION = "상행 역과 하행 역 둘 중 하나도 포함되어 있지 않으면 등록할 수 없습니다.";
     public static final String LESS_THAN_ONE_SECTION = "노선에 등록된 구간이 하나 이하일 경우 구간을 제거할 수 없습니다.";
+    public static final String NOT_FOUND_STATION = "역을 찾을 수 없습니다.";
 }

--- a/src/main/java/nextstep/subway/domain/Section.java
+++ b/src/main/java/nextstep/subway/domain/Section.java
@@ -45,6 +45,10 @@ public class Section {
         return this.distance - distance;
     }
 
+    public void changeUpStation(Station station) {
+        upStation = station;
+    }
+
     public Section() {
 
     }

--- a/src/main/java/nextstep/subway/domain/Sections.java
+++ b/src/main/java/nextstep/subway/domain/Sections.java
@@ -160,7 +160,18 @@ public class Sections {
 
         if (getUpStation().equals(station)) {
             sections.remove(findSectionByUpStation(station));
+            return;
         }
+
+        removeMiddle(station);
+    }
+
+    private void removeMiddle(Station station) {
+        Section section = findSectionByDownStation(station);
+        Section nextSection = findSectionByUpStation(station);
+        nextSection.changeUpStation(section.getUpStation());
+
+        sections.remove(section);
     }
 
     private void removeValidation(Station station) {

--- a/src/main/java/nextstep/subway/domain/Sections.java
+++ b/src/main/java/nextstep/subway/domain/Sections.java
@@ -70,35 +70,25 @@ public class Sections {
     }
 
     private void addValidation(Section newSection) {
-        List<Section> containUpStation = new ArrayList<>();
-        List<Section> containDownStation = new ArrayList<>();
-
-        for (Section section : sections) {
-            if (section.isContainStation(newSection.getUpStation())) {
-                containUpStation.add(section);
-            }
-
-            if (section.isContainStation(newSection.getDownStation())) {
-                containDownStation.add(section);
-            }
-        }
-
-        alreadyEnrollUpAndDownStation(containUpStation, containDownStation);
-
-        notEnrollUpAndDownStation(containUpStation, containDownStation);
-    }
-    private void alreadyEnrollUpAndDownStation(List<Section> containUpStation, List<Section> containDownStation) {
-        if (!(containUpStation.isEmpty() || containDownStation.isEmpty())) {
-            throw new IllegalArgumentException(ALREADY_ENROLL_STATION);
-        }
+        checkAlreadyEnrollSection(newSection);
+        checkNotFoundSection(newSection);
     }
 
-    private void notEnrollUpAndDownStation(List<Section> containUpStation, List<Section> containDownStation) {
-        if (containUpStation.isEmpty() && containDownStation.isEmpty()) {
+    private void checkNotFoundSection(Section newSection) {
+        if (!(isContainStation(newSection.getUpStation()) || isContainStation(newSection.getDownStation()))) {
             throw new IllegalArgumentException(NOT_ENROLL_STATION);
         }
     }
 
+    private void checkAlreadyEnrollSection(Section newSection) {
+        if (isContainStation(newSection.getUpStation()) && isContainStation(newSection.getDownStation())) {
+            throw new IllegalArgumentException(ALREADY_ENROLL_STATION);
+        }
+    }
+
+    private boolean isContainStation(Station newStation) {
+        return sections.stream().anyMatch(section -> section.isContainStation(newStation));
+    }
 
     public List<Station> getStations() {
         if (sections.isEmpty()) {
@@ -163,6 +153,10 @@ public class Sections {
     public void removeSection(Station station) {
         if (sections.size() <= 1) {
             throw new IllegalArgumentException(LESS_THAN_ONE_SECTION);
+        }
+
+        if (!isContainStation(station)) {
+            throw new IllegalArgumentException(NOT_FOUND_STATION);
         }
 
         if (!getDownStation().equals(station)) {

--- a/src/main/java/nextstep/subway/domain/Sections.java
+++ b/src/main/java/nextstep/subway/domain/Sections.java
@@ -83,14 +83,22 @@ public class Sections {
             }
         }
 
+        alreadyEnrollUpAndDownStation(containUpStation, containDownStation);
+
+        notEnrollUpAndDownStation(containUpStation, containDownStation);
+    }
+    private void alreadyEnrollUpAndDownStation(List<Section> containUpStation, List<Section> containDownStation) {
         if (!(containUpStation.isEmpty() || containDownStation.isEmpty())) {
             throw new IllegalArgumentException(ALREADY_ENROLL_STATION);
         }
+    }
 
+    private void notEnrollUpAndDownStation(List<Section> containUpStation, List<Section> containDownStation) {
         if (containUpStation.isEmpty() && containDownStation.isEmpty()) {
             throw new IllegalArgumentException(NOT_ENROLL_STATION);
         }
     }
+
 
     public List<Station> getStations() {
         if (sections.isEmpty()) {

--- a/src/main/java/nextstep/subway/domain/Sections.java
+++ b/src/main/java/nextstep/subway/domain/Sections.java
@@ -161,6 +161,10 @@ public class Sections {
     }
 
     public void removeSection(Station station) {
+        if (sections.size() <= 1) {
+            throw new IllegalArgumentException(LESS_THAN_ONE_SECTION);
+        }
+
         if (!getDownStation().equals(station)) {
             throw new IllegalArgumentException();
         }

--- a/src/main/java/nextstep/subway/domain/Sections.java
+++ b/src/main/java/nextstep/subway/domain/Sections.java
@@ -42,7 +42,7 @@ public class Sections {
     private void addMiddleStation(Section newSection) {
         for (Section section : sections) {
             if (addStation(section, newSection)) {
-                break;
+                return;
             }
         }
     }

--- a/src/main/java/nextstep/subway/domain/Sections.java
+++ b/src/main/java/nextstep/subway/domain/Sections.java
@@ -48,10 +48,10 @@ public class Sections {
     }
 
     private boolean addStation(Section section, Section newSection) {
-        return sameUpStation(section, newSection) || sameDownStation(section, newSection);
+        return addDownStation(section, newSection) || addUpStation(section, newSection);
     }
 
-    private boolean sameUpStation(Section section, Section newSection) {
+    private boolean addDownStation(Section section, Section newSection) {
         if (section.getUpStation().equals(newSection.getUpStation())) {
             sections.add(section.addStation(newSection.getDownStation(), section.getDistance() - newSection.getDistance()));
             return true;
@@ -60,7 +60,7 @@ public class Sections {
         return false;
     }
 
-    private boolean sameDownStation(Section newSection, Section section) {
+    private boolean addUpStation(Section section, Section newSection) {
         if (section.getDownStation().equals(newSection.getDownStation())) {
             sections.add(section.addStation(newSection.getUpStation(), newSection.getDistance()));
             return true;

--- a/src/main/java/nextstep/subway/domain/Sections.java
+++ b/src/main/java/nextstep/subway/domain/Sections.java
@@ -151,6 +151,19 @@ public class Sections {
     }
 
     public void removeSection(Station station) {
+        removeValidation(station);
+
+        if (getDownStation().equals(station)) {
+            sections.remove(findSectionByDownStation(station));
+            return;
+        }
+
+        if (getUpStation().equals(station)) {
+            sections.remove(findSectionByUpStation(station));
+        }
+    }
+
+    private void removeValidation(Station station) {
         if (sections.size() <= 1) {
             throw new IllegalArgumentException(LESS_THAN_ONE_SECTION);
         }
@@ -158,12 +171,6 @@ public class Sections {
         if (!isContainStation(station)) {
             throw new IllegalArgumentException(NOT_FOUND_STATION);
         }
-
-        if (!getDownStation().equals(station)) {
-            throw new IllegalArgumentException();
-        }
-
-        sections.remove(sections.size() - 1);
     }
 
     public List<Section> getSections() {

--- a/src/main/java/nextstep/subway/ui/ControllerExceptionHandler.java
+++ b/src/main/java/nextstep/subway/ui/ControllerExceptionHandler.java
@@ -1,14 +1,13 @@
 package nextstep.subway.ui;
 
-import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.ControllerAdvice;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 
 @ControllerAdvice
 public class ControllerExceptionHandler {
-    @ExceptionHandler(DataIntegrityViolationException.class)
-    public ResponseEntity<Void> handleIllegalArgsException(DataIntegrityViolationException e) {
-        return ResponseEntity.badRequest().build();
+    @ExceptionHandler(IllegalArgumentException.class)
+    public ResponseEntity<String> handleIllegalArgumentException(IllegalArgumentException e) {
+        return ResponseEntity.badRequest().body(e.getMessage());
     }
 }

--- a/src/test/java/nextstep/subway/acceptance/LineSectionAcceptanceTest.java
+++ b/src/test/java/nextstep/subway/acceptance/LineSectionAcceptanceTest.java
@@ -178,9 +178,19 @@ class LineSectionAcceptanceTest extends AcceptanceTest {
     }
 
     /**
-     * When 등록된 구간이 하나인 노선에서 마지막 구간을 제거하면
+     * When 등록된 구간이 하나 이하인 노선에서 마지막 구간을 제거하면
      * Then 예외가 발생한다.
      */
+    @Test
+    @DisplayName("등록된 구간이 하나 이하인 노선에서 구간을 제거")
+    void removeLineSection_lessThanOneSection() {
+        // when
+        ExtractableResponse<Response> response = 지하철_노선에_지하철_구간_제거_요청(신분당선, 양재역);
+
+        // then
+        assertThat(response.statusCode()).isEqualTo(HttpStatus.BAD_REQUEST.value());
+        assertThat(response.body().asString()).isEqualTo("노선에 등록된 구간이 하나 이하일 경우 구간을 제거할 수 없습니다.");
+    }
 
     /**
      * When 노선에 등록되지 않은 역을 제거하면

--- a/src/test/java/nextstep/subway/acceptance/LineSectionAcceptanceTest.java
+++ b/src/test/java/nextstep/subway/acceptance/LineSectionAcceptanceTest.java
@@ -238,6 +238,21 @@ class LineSectionAcceptanceTest extends AcceptanceTest {
      * When 상행 종점역 제거를 요청 하면
      * Then 노선에서 제거되고, 양재역이 하행 종점역이 된다.
      */
+    @Test
+    @DisplayName("상행 종점역 제거")
+    void removeLineSection_frontStation() {
+        // given
+        Long 정자역 = 지하철역_생성_요청("정자역").jsonPath().getLong("id");
+        지하철_노선에_지하철_구간_생성_요청(신분당선, createSectionCreateParams(양재역, 정자역));
+
+        // when
+        지하철_노선에_지하철_구간_제거_요청(신분당선, 강남역);
+
+        // then
+        ExtractableResponse<Response> response = 지하철_노선_조회_요청(신분당선);
+        assertThat(response.statusCode()).isEqualTo(HttpStatus.OK.value());
+        assertThat(response.jsonPath().getLong("stations[0].id")).isEqualTo(양재역);
+    }
 
     /**
      * Given 지하철 노선에 새로운 양재-정자 구간 추가를 요청 하고

--- a/src/test/java/nextstep/subway/acceptance/LineSectionAcceptanceTest.java
+++ b/src/test/java/nextstep/subway/acceptance/LineSectionAcceptanceTest.java
@@ -196,6 +196,21 @@ class LineSectionAcceptanceTest extends AcceptanceTest {
      * When 노선에 등록되지 않은 역을 제거하면
      * Then 예외가 발생한다.
      */
+    @Test
+    @DisplayName("노선에 등록되지 않은 구간 제거")
+    void removeLineSection_notFoundStation() {
+        // given
+        Long 정자역 = 지하철역_생성_요청("정자역").jsonPath().getLong("id");
+        Long 판교역 = 지하철역_생성_요청("판교역").jsonPath().getLong("id");
+        지하철_노선에_지하철_구간_생성_요청(신분당선, createSectionCreateParams(양재역, 정자역));
+
+        // when
+        ExtractableResponse<Response> response = 지하철_노선에_지하철_구간_제거_요청(신분당선, 판교역);
+
+        // then
+        assertThat(response.statusCode()).isEqualTo(HttpStatus.BAD_REQUEST.value());
+        assertThat(response.body().asString()).isEqualTo("역을 찾을 수 없습니다.");
+    }
 
     /**
      * Given 지하철 노선에 새로운 양재-정자 구간 추가를 요청 하고

--- a/src/test/java/nextstep/subway/acceptance/LineSectionAcceptanceTest.java
+++ b/src/test/java/nextstep/subway/acceptance/LineSectionAcceptanceTest.java
@@ -217,6 +217,21 @@ class LineSectionAcceptanceTest extends AcceptanceTest {
      * When 하행 종점역 제거를 요청 하면
      * Then 노선에서 제거되고, 양재역이 하행 종점역이 된다.
      */
+    @Test
+    @DisplayName("하행 종점역 제거")
+    void removeLineSection_lastStation() {
+        // given
+        Long 정자역 = 지하철역_생성_요청("정자역").jsonPath().getLong("id");
+        지하철_노선에_지하철_구간_생성_요청(신분당선, createSectionCreateParams(양재역, 정자역));
+
+        // when
+        지하철_노선에_지하철_구간_제거_요청(신분당선, 양재역);
+
+        // then
+        ExtractableResponse<Response> response = 지하철_노선_조회_요청(신분당선);
+        assertThat(response.statusCode()).isEqualTo(HttpStatus.OK.value());
+        assertThat(response.jsonPath().getLong("stations[-1].id")).isEqualTo(정자역);
+    }
 
     /**
      * Given 지하철 노선에 새로운 양재-정자 구간 추가를 요청 하고

--- a/src/test/java/nextstep/subway/acceptance/LineSectionAcceptanceTest.java
+++ b/src/test/java/nextstep/subway/acceptance/LineSectionAcceptanceTest.java
@@ -259,6 +259,21 @@ class LineSectionAcceptanceTest extends AcceptanceTest {
      * When 중간역인 양재역 제거를 요청 하면
      * Then 노선에 양재역 구간이 제거되고, 강남-정자 구간으로 재배치 된다.
      */
+    @Test
+    @DisplayName("노선의 중간역 제거")
+    void removeLineSection_middleStation() {
+        // given
+        Long 정자역 = 지하철역_생성_요청("정자역").jsonPath().getLong("id");
+        지하철_노선에_지하철_구간_생성_요청(신분당선, createSectionCreateParams(양재역, 정자역));
+
+        // when
+        지하철_노선에_지하철_구간_제거_요청(신분당선, 양재역);
+
+        // then
+        ExtractableResponse<Response> response = 지하철_노선_조회_요청(신분당선);
+        assertThat(response.statusCode()).isEqualTo(HttpStatus.OK.value());
+        assertThat(response.jsonPath().getList("stations.id", Long.class)).containsExactly(강남역, 정자역);
+    }
 
     private Map<String, String> createLineCreateParams(Long upStationId, Long downStationId) {
         Map<String, String> lineCreateParams;

--- a/src/test/java/nextstep/subway/acceptance/LineSectionAcceptanceTest.java
+++ b/src/test/java/nextstep/subway/acceptance/LineSectionAcceptanceTest.java
@@ -177,6 +177,34 @@ class LineSectionAcceptanceTest extends AcceptanceTest {
         assertThat(response.jsonPath().getList("stations.id", Long.class)).containsExactly(강남역, 양재역);
     }
 
+    /**
+     * When 등록된 구간이 하나인 노선에서 마지막 구간을 제거하면
+     * Then 예외가 발생한다.
+     */
+
+    /**
+     * When 노선에 등록되지 않은 역을 제거하면
+     * Then 예외가 발생한다.
+     */
+
+    /**
+     * Given 지하철 노선에 새로운 양재-정자 구간 추가를 요청 하고
+     * When 하행 종점역 제거를 요청 하면
+     * Then 노선에서 제거되고, 양재역이 하행 종점역이 된다.
+     */
+
+    /**
+     * Given 지하철 노선에 새로운 양재-정자 구간 추가를 요청 하고
+     * When 상행 종점역 제거를 요청 하면
+     * Then 노선에서 제거되고, 양재역이 하행 종점역이 된다.
+     */
+
+    /**
+     * Given 지하철 노선에 새로운 양재-정자 구간 추가를 요청 하고
+     * When 중간역인 양재역 제거를 요청 하면
+     * Then 노선에 양재역 구간이 제거되고, 강남-정자 구간으로 재배치 된다.
+     */
+
     private Map<String, String> createLineCreateParams(Long upStationId, Long downStationId) {
         Map<String, String> lineCreateParams;
         lineCreateParams = new HashMap<>();

--- a/src/test/java/nextstep/subway/acceptance/LineSectionAcceptanceTest.java
+++ b/src/test/java/nextstep/subway/acceptance/LineSectionAcceptanceTest.java
@@ -53,6 +53,59 @@ class LineSectionAcceptanceTest extends AcceptanceTest {
     }
 
     /**
+     * Given 양재-정자 구간을 추가하고
+     * When 지하철 노선에 같은 구간 길이인 양재-논현 구간을 추가하면
+     * Then 예외가 발생한다.
+     */
+    @DisplayName("지하철 노선에 기존 구간 길이보다 크거나 같은 구간을 등록")
+    @Test
+    void addLineSection_moreThenDistance() {
+        // given
+        Long 정자역 = 지하철역_생성_요청("정자역").jsonPath().getLong("id");
+        지하철_노선에_지하철_구간_생성_요청(신분당선, createSectionCreateParams(양재역, 정자역));
+
+        // when
+        Long 논현역 = 지하철역_생성_요청("논현역").jsonPath().getLong("id");
+        ExtractableResponse<Response> response = 지하철_노선에_지하철_구간_생성_요청(신분당선, createSectionCreateParams(양재역, 논현역));
+
+        // then
+        assertThat(response.statusCode()).isEqualTo(HttpStatus.BAD_REQUEST.value());
+        assertThat(response.body().asString()).isEqualTo("기존 구간 사이에 역을 등록할 경우 기존 역 사이 길이보다 크거나 같으면 등록할 수 없습니다.");
+    }
+
+    /**
+     * When 지하철 노선에 상행역과 하행역 모두 이미 등록된 구간을 추가하면
+     * Then 예외가 발생한다.
+     */
+    @DisplayName("지하철 노선에 상행역과 하행역 모두 이미 등록된 구간을 등록")
+    @Test
+    void addLineSection_alreadyEnrollStation() {
+        // when
+        ExtractableResponse<Response> response = 지하철_노선에_지하철_구간_생성_요청(신분당선, createSectionCreateParams(강남역, 양재역));
+
+        // then
+        assertThat(response.statusCode()).isEqualTo(HttpStatus.BAD_REQUEST.value());
+        assertThat(response.body().asString()).isEqualTo("상행 역과 하행 역이 이미 노선에 모두 등록되어 있다면 등록할 수 없습니다.");
+    }
+
+    /**
+     * When 지하철 노선에 상행역과 하행역 둘 중 하나도 등록되지 않은 구간을 추가하면
+     * Then 예외가 발생한다.
+     */
+    @DisplayName("지하철 노선에 상행역과 하행역 둘 중 하나도 등록되지 않은 구간을 등록")
+    @Test
+    void addLineSection_notEnrollStation() {
+        // when
+        Long 정자역 = 지하철역_생성_요청("정자역").jsonPath().getLong("id");
+        Long 판교역 = 지하철역_생성_요청("판교역").jsonPath().getLong("id");
+        ExtractableResponse<Response> response = 지하철_노선에_지하철_구간_생성_요청(신분당선, createSectionCreateParams(정자역, 판교역));
+
+        // then
+        assertThat(response.statusCode()).isEqualTo(HttpStatus.BAD_REQUEST.value());
+        assertThat(response.body().asString()).isEqualTo("상행 역과 하행 역 둘 중 하나도 포함되어 있지 않으면 등록할 수 없습니다.");
+    }
+
+    /**
      * When 지하철 노선의 강남-양재 구간에 새로운 역(정자역)을 갖는 강남-정자 구간을 등록하면
      * Then 강남-정자 구간과 정자-양재 구간이 생성된다.
      */

--- a/src/test/java/nextstep/subway/unit/LineServiceMockTest.java
+++ b/src/test/java/nextstep/subway/unit/LineServiceMockTest.java
@@ -202,4 +202,22 @@ public class LineServiceMockTest {
         List<Station> stations = line.getStations();
         assertThat(stations).extracting("name").containsExactly("강남역", "정자역");
     }
+
+    @Test
+    @DisplayName("상행 종점역 삭제")
+    void removeSection_frontStation() {
+        // given
+        when(stationService.findById(3L)).thenReturn(new Station("정자역"));
+
+        lineService.addSection(1L, new SectionRequest(1L, 2L, 10));
+        lineService.addSection(1L, new SectionRequest(3L, 2L, 6));
+
+        // when
+        lineService.deleteSection(1L, 1L);
+
+        // then
+        Line line = lineService.findLineById(1L);
+        List<Station> stations = line.getStations();
+        assertThat(stations).extracting("name").containsExactly("정자역", "양재역");
+    }
 }

--- a/src/test/java/nextstep/subway/unit/LineServiceMockTest.java
+++ b/src/test/java/nextstep/subway/unit/LineServiceMockTest.java
@@ -167,4 +167,21 @@ public class LineServiceMockTest {
                 .isInstanceOf(IllegalArgumentException.class)
                 .hasMessage(LESS_THAN_ONE_SECTION);
     }
+
+    @Test
+    @DisplayName("등록되지 않은 구간 삭제")
+    void removeSection_notFoundStation() {
+        // given
+        when(stationService.findById(3L)).thenReturn(new Station("정자역"));
+        when(stationService.findById(4L)).thenReturn(new Station("판교역"));
+
+        lineService.addSection(1L, new SectionRequest(1L, 2L, 10));
+        lineService.addSection(1L, new SectionRequest(3L, 2L, 6));
+
+        // when
+        // then
+        assertThatThrownBy(() -> lineService.deleteSection(1L, 4L))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage(NOT_FOUND_STATION);
+    }
 }

--- a/src/test/java/nextstep/subway/unit/LineServiceMockTest.java
+++ b/src/test/java/nextstep/subway/unit/LineServiceMockTest.java
@@ -154,4 +154,17 @@ public class LineServiceMockTest {
         List<Station> stations = line.getStations();
         assertThat(stations).extracting("name").containsExactly("판교역", "강남역", "양재역");
     }
+
+    @Test
+    @DisplayName("등록된 구간이 하나 이하인 노선 구간 삭제")
+    void removeSection_lessThanOneSection() {
+        // given
+        lineService.addSection(1L, new SectionRequest(1L, 2L, 10));
+
+        // when
+        // then
+        assertThatThrownBy(() -> lineService.deleteSection(1L, 2L))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage(LESS_THAN_ONE_SECTION);
+    }
 }

--- a/src/test/java/nextstep/subway/unit/LineServiceMockTest.java
+++ b/src/test/java/nextstep/subway/unit/LineServiceMockTest.java
@@ -184,4 +184,22 @@ public class LineServiceMockTest {
                 .isInstanceOf(IllegalArgumentException.class)
                 .hasMessage(NOT_FOUND_STATION);
     }
+
+    @Test
+    @DisplayName("하행 종점역 삭제")
+    void removeSection_lastStation() {
+        // given
+        when(stationService.findById(3L)).thenReturn(new Station("정자역"));
+
+        lineService.addSection(1L, new SectionRequest(1L, 2L, 10));
+        lineService.addSection(1L, new SectionRequest(3L, 2L, 6));
+
+        // when
+        lineService.deleteSection(1L, 2L);
+
+        // then
+        Line line = lineService.findLineById(1L);
+        List<Station> stations = line.getStations();
+        assertThat(stations).extracting("name").containsExactly("강남역", "정자역");
+    }
 }

--- a/src/test/java/nextstep/subway/unit/LineServiceMockTest.java
+++ b/src/test/java/nextstep/subway/unit/LineServiceMockTest.java
@@ -6,6 +6,7 @@ import nextstep.subway.applicaion.dto.SectionRequest;
 import nextstep.subway.domain.Line;
 import nextstep.subway.domain.LineRepository;
 import nextstep.subway.domain.Station;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -13,9 +14,12 @@ import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
+import java.util.List;
 import java.util.Optional;
 
+import static nextstep.subway.common.constants.ErrorConstant.*;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.junit.jupiter.api.Assertions.assertAll;
 import static org.mockito.Mockito.when;
 
@@ -31,15 +35,18 @@ public class LineServiceMockTest {
     @Mock
     private StationService stationService;
 
-    @Test
-    @DisplayName("지하철 구간 추가")
-    void addSection() {
+    @BeforeEach
+    void setUp() {
         // given
         // lineRepository, stationService stub 설정을 통해 초기값 셋팅
         when(lineRepository.findById(1L)).thenReturn(Optional.of(new Line("신분당선", "RED")));
         when(stationService.findById(1L)).thenReturn(new Station("강남역"));
         when(stationService.findById(2L)).thenReturn(new Station("양재역"));
+    }
 
+    @Test
+    @DisplayName("지하철 구간 추가")
+    void addSection() {
         // when
         // lineService.addSection 호출
         lineService.addSection(1L, new SectionRequest(1L, 2L, 10));
@@ -51,5 +58,100 @@ public class LineServiceMockTest {
                 () -> assertThat(line.getName()).isEqualTo("신분당선"),
                 () -> assertThat(line.getColor()).isEqualTo("RED")
         );
+    }
+
+    @Test
+    @DisplayName("기존 구간 길이보다 크거나 같은 역 사이 새로운 역을 갖는 구간 추가")
+    void addSection_moreThenDistance() {
+        // given
+        when(stationService.findById(3L)).thenReturn(new Station("정자역"));
+
+        lineService.addSection(1L, new SectionRequest(1L, 2L, 10));
+
+        // when
+        // then
+        assertThatThrownBy(() -> lineService.addSection(1L, new SectionRequest(3L, 2L, 10)))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage(MORE_THEN_DISTANCE);
+    }
+
+    @Test
+    @DisplayName("상행역과 하행역 모두 이미 등록된 구간 추가")
+    void addSection_alreadyEnrollStation() {
+        // given
+        lineService.addSection(1L, new SectionRequest(1L, 2L, 10));
+
+        // when
+        // then
+        assertThatThrownBy(() -> lineService.addSection(1L, new SectionRequest(1L, 2L, 10)))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage(ALREADY_ENROLL_STATION);
+    }
+
+    @Test
+    @DisplayName("상행역과 하행역 둘 중 하나도 등록되지 않은 구간 추가")
+    void addSection_notEnrollStation() {
+        // given
+        when(stationService.findById(3L)).thenReturn(new Station("정자역"));
+        when(stationService.findById(4L)).thenReturn(new Station("판교역"));
+
+        lineService.addSection(1L, new SectionRequest(1L, 2L, 10));
+
+        // when
+        // then
+        assertThatThrownBy(() -> lineService.addSection(1L, new SectionRequest(3L, 4L, 6)))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage(NOT_ENROLL_STATION);
+    }
+
+    @Test
+    @DisplayName("기존 구간 사이 역을 갖는 구간 추가")
+    void addSection_middleStation() {
+        // given
+        when(stationService.findById(3L)).thenReturn(new Station("정자역"));
+
+        lineService.addSection(1L, new SectionRequest(1L, 2L, 10));
+
+        // when
+        lineService.addSection(1L, new SectionRequest(3L, 2L, 6));
+
+        // then
+        Line line = lineService.findLineById(1L);
+        List<Station> stations = line.getStations();
+        assertThat(stations).extracting("name").containsExactly("강남역", "정자역", "양재역");
+    }
+
+    @Test
+    @DisplayName("하행 종점역을 상행역으로 갖는 구간 추가")
+    void addSection_lastStation() {
+        // given
+        when(stationService.findById(3L)).thenReturn(new Station("정자역"));
+
+        lineService.addSection(1L, new SectionRequest(1L, 2L, 10));
+
+        // when
+        lineService.addSection(1L, new SectionRequest(2L, 3L, 6));
+
+        // then
+        Line line = lineService.findLineById(1L);
+        List<Station> stations = line.getStations();
+        assertThat(stations).extracting("name").containsExactly("강남역", "양재역", "정자역");
+    }
+
+    @Test
+    @DisplayName("상행 종점역을 하행역으로 갖는 구간 추가")
+    void addSection_frontStation() {
+        // given
+        when(stationService.findById(3L)).thenReturn(new Station("판교역"));
+
+        lineService.addSection(1L, new SectionRequest(1L, 2L, 10));
+
+        // when
+        lineService.addSection(1L, new SectionRequest(3L, 1L, 6));
+
+        // then
+        Line line = lineService.findLineById(1L);
+        List<Station> stations = line.getStations();
+        assertThat(stations).extracting("name").containsExactly("판교역", "강남역", "양재역");
     }
 }

--- a/src/test/java/nextstep/subway/unit/LineServiceMockTest.java
+++ b/src/test/java/nextstep/subway/unit/LineServiceMockTest.java
@@ -220,4 +220,22 @@ public class LineServiceMockTest {
         List<Station> stations = line.getStations();
         assertThat(stations).extracting("name").containsExactly("정자역", "양재역");
     }
+
+    @Test
+    @DisplayName("중역역 삭제")
+    void removeSection_middleStation() {
+        // given
+        when(stationService.findById(3L)).thenReturn(new Station("정자역"));
+
+        lineService.addSection(1L, new SectionRequest(1L, 2L, 10));
+        lineService.addSection(1L, new SectionRequest(2L, 3L, 6));
+
+        // when
+        lineService.deleteSection(1L, 2L);
+
+        // then
+        Line line = lineService.findLineById(1L);
+        List<Station> stations = line.getStations();
+        assertThat(stations).extracting("name").containsExactly("강남역", "정자역");
+    }
 }

--- a/src/test/java/nextstep/subway/unit/LineServiceTest.java
+++ b/src/test/java/nextstep/subway/unit/LineServiceTest.java
@@ -19,6 +19,7 @@ import static nextstep.subway.common.constants.ErrorConstant.*;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.junit.jupiter.api.Assertions.assertAll;
+import static org.mockito.Mockito.when;
 
 @SpringBootTest
 @Transactional
@@ -222,4 +223,21 @@ public class LineServiceTest {
         assertThat(stations).extracting("name").containsExactly("정자역", "양재역");
     }
 
+    @Test
+    @DisplayName("중간역 삭제")
+    void removeSection_middleStation() {
+        // given
+        Station 정자역 = stationRepository.save(new Station("정자역"));
+
+        lineService.addSection(신분당선.getId(), new SectionRequest(강남역.getId(), 양재역.getId(), 10));
+        lineService.addSection(신분당선.getId(), new SectionRequest(양재역.getId(), 정자역.getId(), 6));
+
+        // when
+        lineService.deleteSection(신분당선.getId(), 양재역.getId());
+
+        // then
+        Line line = lineService.findLineById(신분당선.getId());
+        List<Station> stations = line.getStations();
+        assertThat(stations).extracting("name").containsExactly("강남역", "정자역");
+    }
 }

--- a/src/test/java/nextstep/subway/unit/LineServiceTest.java
+++ b/src/test/java/nextstep/subway/unit/LineServiceTest.java
@@ -6,13 +6,18 @@ import nextstep.subway.domain.Line;
 import nextstep.subway.domain.LineRepository;
 import nextstep.subway.domain.Station;
 import nextstep.subway.domain.StationRepository;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.util.List;
+
+import static nextstep.subway.common.constants.ErrorConstant.*;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.junit.jupiter.api.Assertions.assertAll;
 
 @SpringBootTest
@@ -27,16 +32,22 @@ public class LineServiceTest {
     @Autowired
     private LineService lineService;
 
+    Station 강남역;
+    Station 양재역;
+    Line 신분당선;
+    @BeforeEach
+    void setUp() {
+        // given
+        // stationRepository와 lineRepository를 활용하여 초기값 셋팅
+        강남역 = stationRepository.save(new Station("강남역"));
+        양재역 = stationRepository.save(new Station("양재역"));
+
+        신분당선 = lineRepository.save(new Line("신분당선", "RED"));
+    }
+
     @Test
     @DisplayName("지하철 구간 추가")
     void addSection() {
-        // given
-        // stationRepository와 lineRepository를 활용하여 초기값 셋팅
-        Station 강남역 = stationRepository.save(new Station("강남역"));
-        Station 양재역 = stationRepository.save(new Station("양재역"));
-
-        Line 신분당선 = lineRepository.save(new Line("신분당선", "RED"));
-
         // when
         // lineService.addSection 호출
         lineService.addSection(신분당선.getId(), new SectionRequest(강남역.getId(), 양재역.getId(), 10));
@@ -48,5 +59,100 @@ public class LineServiceTest {
                 () -> assertThat(신분당선.getColor()).isEqualTo("RED"),
                 () -> assertThat(신분당선.getStations()).extracting("name").containsExactly("강남역", "양재역")
         );
+    }
+
+    @Test
+    @DisplayName("기존 구간 길이보다 크거나 같은 역 사이 새로운 역을 갖는 구간 추가")
+    void addSection_moreThenDistance() {
+        // given
+        Station 정자역 = stationRepository.save(new Station("정자역"));
+
+        lineService.addSection(신분당선.getId(), new SectionRequest(강남역.getId(), 양재역.getId(), 10));
+
+        // when
+        // then
+        assertThatThrownBy(() -> lineService.addSection(신분당선.getId(), new SectionRequest(정자역.getId(), 양재역.getId(), 10)))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage(MORE_THEN_DISTANCE);
+    }
+
+    @Test
+    @DisplayName("상행역과 하행역 모두 이미 등록된 구간 추가")
+    void addSection_alreadyEnrollStation() {
+        // given
+        lineService.addSection(신분당선.getId(), new SectionRequest(강남역.getId(), 양재역.getId(), 10));
+
+        // when
+        // then
+        assertThatThrownBy(() -> lineService.addSection(신분당선.getId(), new SectionRequest(강남역.getId(), 양재역.getId(), 10)))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage(ALREADY_ENROLL_STATION);
+    }
+
+    @Test
+    @DisplayName("상행역과 하행역 둘 중 하나도 등록되지 않은 구간 추가")
+    void addSection_notEnrollStation() {
+        // given
+        Station 정자역 = stationRepository.save(new Station("정자역"));
+        Station 판교역 = stationRepository.save(new Station("판교역"));
+
+        lineService.addSection(신분당선.getId(), new SectionRequest(강남역.getId(), 양재역.getId(), 10));
+
+        // when
+        // then
+        assertThatThrownBy(() -> lineService.addSection(신분당선.getId(), new SectionRequest(정자역.getId(), 판교역.getId(), 6)))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage(NOT_ENROLL_STATION);
+    }
+
+    @Test
+    @DisplayName("기존 구간 사이 역을 갖는 구간 추가")
+    void addSection_middleStation() {
+        // given
+        Station 정자역 = stationRepository.save(new Station("정자역"));
+
+        lineService.addSection(신분당선.getId(), new SectionRequest(강남역.getId(), 양재역.getId(), 10));
+
+        // when
+        lineService.addSection(신분당선.getId(), new SectionRequest(정자역.getId(), 양재역.getId(), 6));
+
+        // then
+        Line line = lineService.findLineById(신분당선.getId());
+        List<Station> stations = line.getStations();
+        assertThat(stations).extracting("name").containsExactly("강남역", "정자역", "양재역");
+    }
+
+    @Test
+    @DisplayName("하행 종점역을 상행역으로 갖는 구간 추가")
+    void addSection_lastStation() {
+        // given
+        Station 정자역 = stationRepository.save(new Station("정자역"));
+
+        lineService.addSection(신분당선.getId(), new SectionRequest(강남역.getId(), 양재역.getId(), 10));
+
+        // when
+        lineService.addSection(신분당선.getId(), new SectionRequest(양재역.getId(), 정자역.getId(), 10));
+
+        // then
+        Line line = lineService.findLineById(신분당선.getId());
+        List<Station> stations = line.getStations();
+        assertThat(stations).extracting("name").containsExactly("강남역", "양재역", "정자역");
+    }
+
+    @Test
+    @DisplayName("상행 종점역을 하행역으로 갖는 구간 추가")
+    void addSection_frontStation() {
+        // given
+        Station 판교역 = stationRepository.save(new Station("판교역"));
+
+        lineService.addSection(신분당선.getId(), new SectionRequest(강남역.getId(), 양재역.getId(), 10));
+
+        // when
+        lineService.addSection(신분당선.getId(), new SectionRequest(판교역.getId(), 강남역.getId(), 6));
+
+        // then
+        Line line = lineService.findLineById(신분당선.getId());
+        List<Station> stations = line.getStations();
+        assertThat(stations).extracting("name").containsExactly("판교역", "강남역", "양재역");
     }
 }

--- a/src/test/java/nextstep/subway/unit/LineServiceTest.java
+++ b/src/test/java/nextstep/subway/unit/LineServiceTest.java
@@ -168,4 +168,21 @@ public class LineServiceTest {
                 .isInstanceOf(IllegalArgumentException.class)
                 .hasMessage(LESS_THAN_ONE_SECTION);
     }
+
+    @Test
+    @DisplayName("등록되지 않은 구간 삭제")
+    void removeSection_notFoundStation() {
+        // given
+        Station 정자역 = stationRepository.save(new Station("정자역"));
+        Station 판교역 = stationRepository.save(new Station("판교역"));
+
+        lineService.addSection(신분당선.getId(), new SectionRequest(강남역.getId(), 양재역.getId(), 10));
+        lineService.addSection(신분당선.getId(), new SectionRequest(양재역.getId(), 정자역.getId(), 6));
+
+        // when
+        // then
+        assertThatThrownBy(() -> lineService.deleteSection(신분당선.getId(), 판교역.getId()))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage(NOT_FOUND_STATION);
+    }
 }

--- a/src/test/java/nextstep/subway/unit/LineServiceTest.java
+++ b/src/test/java/nextstep/subway/unit/LineServiceTest.java
@@ -203,4 +203,23 @@ public class LineServiceTest {
         List<Station> stations = line.getStations();
         assertThat(stations).extracting("name").containsExactly("강남역", "정자역");
     }
+
+    @Test
+    @DisplayName("상행 종점역 삭제")
+    void removeSection_frontStation() {
+        // given
+        Station 정자역 = stationRepository.save(new Station("정자역"));
+
+        lineService.addSection(신분당선.getId(), new SectionRequest(강남역.getId(), 양재역.getId(), 10));
+        lineService.addSection(신분당선.getId(), new SectionRequest(정자역.getId(), 양재역.getId(), 6));
+
+        // when
+        lineService.deleteSection(신분당선.getId(), 강남역.getId());
+
+        // then
+        Line line = lineService.findLineById(신분당선.getId());
+        List<Station> stations = line.getStations();
+        assertThat(stations).extracting("name").containsExactly("정자역", "양재역");
+    }
+
 }

--- a/src/test/java/nextstep/subway/unit/LineServiceTest.java
+++ b/src/test/java/nextstep/subway/unit/LineServiceTest.java
@@ -185,4 +185,22 @@ public class LineServiceTest {
                 .isInstanceOf(IllegalArgumentException.class)
                 .hasMessage(NOT_FOUND_STATION);
     }
+
+    @Test
+    @DisplayName("하행 종점역 삭제")
+    void removeSection_lastStation() {
+        // given
+        Station 정자역 = stationRepository.save(new Station("정자역"));
+
+        lineService.addSection(신분당선.getId(), new SectionRequest(강남역.getId(), 양재역.getId(), 10));
+        lineService.addSection(신분당선.getId(), new SectionRequest(정자역.getId(), 양재역.getId(), 6));
+
+        // when
+        lineService.deleteSection(신분당선.getId(), 양재역.getId());
+
+        // then
+        Line line = lineService.findLineById(신분당선.getId());
+        List<Station> stations = line.getStations();
+        assertThat(stations).extracting("name").containsExactly("강남역", "정자역");
+    }
 }

--- a/src/test/java/nextstep/subway/unit/LineServiceTest.java
+++ b/src/test/java/nextstep/subway/unit/LineServiceTest.java
@@ -155,4 +155,17 @@ public class LineServiceTest {
         List<Station> stations = line.getStations();
         assertThat(stations).extracting("name").containsExactly("판교역", "강남역", "양재역");
     }
+
+    @Test
+    @DisplayName("등록된 구간이 하나 이하인 노선 구간 삭제")
+    void removeSection_lessThanOneSection() {
+        // given
+        lineService.addSection(신분당선.getId(), new SectionRequest(강남역.getId(), 양재역.getId(), 10));
+
+        // when
+        // then
+        assertThatThrownBy(() -> lineService.deleteSection(신분당선.getId(), 양재역.getId()))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage(LESS_THAN_ONE_SECTION);
+    }
 }

--- a/src/test/java/nextstep/subway/unit/SectionsTest.java
+++ b/src/test/java/nextstep/subway/unit/SectionsTest.java
@@ -138,4 +138,21 @@ public class SectionsTest {
                 .isInstanceOf(IllegalArgumentException.class)
                 .hasMessage(LESS_THAN_ONE_SECTION);
     }
+
+    @Test
+    @DisplayName("구간 삭제 실패-노선에 등록지 않은 구간")
+    void removeSection_notFoundStation() {
+        // given
+        Station 정자역 = new Station("정자역");
+        Section 강남_정자_구간 = new Section(신분당선, 강남역, 정자역, 6);
+        신분당선.addSection(강남_정자_구간);
+
+        Station 판교역 = new Station("판교역");
+
+        // when
+        // then
+        assertThatThrownBy(() -> 신분당선.removeSection(판교역))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage(NOT_FOUND_STATION);
+    }
 }

--- a/src/test/java/nextstep/subway/unit/SectionsTest.java
+++ b/src/test/java/nextstep/subway/unit/SectionsTest.java
@@ -185,4 +185,19 @@ public class SectionsTest {
         // then
         assertThat(신분당선.getStations()).extracting("name").containsExactly("정자역", "양재역");
     }
+
+    @Test
+    @DisplayName("중간역 삭제")
+    void removeSection_middleStation() {
+        // given
+        Station 정자역 = new Station("정자역");
+        Section 강남_정자_구간 = new Section(신분당선, 강남역, 정자역, 6);
+        신분당선.addSection(강남_정자_구간);
+
+        // when
+        신분당선.removeSection(정자역);
+
+        // then
+        assertThat(신분당선.getStations()).extracting("name").containsExactly("강남역", "양재역");
+    }
 }

--- a/src/test/java/nextstep/subway/unit/SectionsTest.java
+++ b/src/test/java/nextstep/subway/unit/SectionsTest.java
@@ -170,4 +170,19 @@ public class SectionsTest {
         // then
         assertThat(신분당선.getStations()).extracting("name").containsExactly("강남역", "정자역");
     }
+
+    @Test
+    @DisplayName("상행 종점역 삭제")
+    void removeSection_frontStation() {
+        // given
+        Station 정자역 = new Station("정자역");
+        Section 강남_정자_구간 = new Section(신분당선, 강남역, 정자역, 6);
+        신분당선.addSection(강남_정자_구간);
+
+        // when
+        신분당선.removeSection(강남역);
+
+        // then
+        assertThat(신분당선.getStations()).extracting("name").containsExactly("정자역", "양재역");
+    }
 }

--- a/src/test/java/nextstep/subway/unit/SectionsTest.java
+++ b/src/test/java/nextstep/subway/unit/SectionsTest.java
@@ -155,4 +155,19 @@ public class SectionsTest {
                 .isInstanceOf(IllegalArgumentException.class)
                 .hasMessage(NOT_FOUND_STATION);
     }
+
+    @Test
+    @DisplayName("하행 종점역 삭제")
+    void removeSection_lastStation() {
+        // given
+        Station 정자역 = new Station("정자역");
+        Section 강남_정자_구간 = new Section(신분당선, 강남역, 정자역, 6);
+        신분당선.addSection(강남_정자_구간);
+
+        // when
+        신분당선.removeSection(양재역);
+
+        // then
+        assertThat(신분당선.getStations()).extracting("name").containsExactly("강남역", "정자역");
+    }
 }

--- a/src/test/java/nextstep/subway/unit/SectionsTest.java
+++ b/src/test/java/nextstep/subway/unit/SectionsTest.java
@@ -128,4 +128,14 @@ public class SectionsTest {
         // then
         assertThat(신분당선.getStations()).extracting("name").containsExactly("강남역", "양재역", "판교역");
     }
+
+    @Test
+    @DisplayName("구간 삭제 실패-등록된 구간이 하나 이하인 노선")
+    void removeSection_lessThanOneSection() {
+        // when
+        // then
+        assertThatThrownBy(() -> 신분당선.removeSection(양재역))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage(LESS_THAN_ONE_SECTION);
+    }
 }


### PR DESCRIPTION
안녕하세요!
2단계 지하철 구간 제거 기능 개선입니다.

- 노선 하행 종점역 제거
- 노선 상행 종점역 제거
- 노선 중간역 제거
- 예외 케이스
  + 노선에 등록된 구간이 하나 이하라면 제거 불가
  +  노선에 등록된 역이 아니라면 제거 불가

리뷰요청 드립니다.