### PR TITLE
1단계 - 지하철 구간 추가 기능 개선

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -16,6 +16,7 @@ dependencies {
     // spring
     implementation 'org.springframework.boot:spring-boot-starter-web'
     implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
+    implementation 'org.springframework.boot:spring-boot-starter-validation'
 
     // log
     implementation 'net.rakugakibox.spring.boot:logback-access-spring-boot-starter:2.7.1'

--- a/src/main/java/nextstep/subway/applicaion/LineService.java
+++ b/src/main/java/nextstep/subway/applicaion/LineService.java
@@ -1,0 +1,112 @@
+package nextstep.subway.applicaion;
+
+import nextstep.subway.applicaion.dto.LineRequest;
+import nextstep.subway.applicaion.dto.LineResponse;
+import nextstep.subway.applicaion.dto.SectionRequest;
+import nextstep.subway.applicaion.dto.StationResponse;
+import nextstep.subway.domain.Line;
+import nextstep.subway.domain.LineRepository;
+import nextstep.subway.domain.Section;
+import nextstep.subway.domain.Station;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.stream.Collectors;
+
+@Service
+@Transactional(readOnly = true)
+public class LineService {
+    private LineRepository lineRepository;
+    private StationService stationService;
+
+    public LineService(LineRepository lineRepository, StationService stationService) {
+        this.lineRepository = lineRepository;
+        this.stationService = stationService;
+    }
+
+    @Transactional
+    public LineResponse saveLine(LineRequest request) {
+        Line line = lineRepository.save(new Line(request.getName(), request.getColor()));
+        if (request.getUpStationId() != null && request.getDownStationId() != null && request.getDistance() != 0) {
+            Station upStation = stationService.findById(request.getUpStationId());
+            Station downStation = stationService.findById(request.getDownStationId());
+            line.getSections().add(new Section(line, upStation, downStation, request.getDistance()));
+        }
+        return createLineResponse(line);
+    }
+
+    public List<LineResponse> showLines() {
+        return lineRepository.findAll().stream()
+                .map(this::createLineResponse)
+                .collect(Collectors.toList());
+    }
+
+    public LineResponse findById(Long id) {
+        return createLineResponse(lineRepository.findById(id).orElseThrow(IllegalArgumentException::new));
+    }
+
+    @Transactional
+    public void updateLine(Long id, LineRequest lineRequest) {
+        Line line = lineRepository.findById(id).orElseThrow(IllegalArgumentException::new);
+
+        if (lineRequest.getName() != null) {
+            line.setName(lineRequest.getName());
+        }
+        if (lineRequest.getColor() != null) {
+            line.setColor(lineRequest.getColor());
+        }
+    }
+
+    @Transactional
+    public void deleteLine(Long id) {
+        lineRepository.deleteById(id);
+    }
+
+    @Transactional
+    public void addSection(Long lineId, SectionRequest sectionRequest) {
+        Station upStation = stationService.findById(sectionRequest.getUpStationId());
+        Station downStation = stationService.findById(sectionRequest.getDownStationId());
+        Line line = lineRepository.findById(lineId).orElseThrow(IllegalArgumentException::new);
+
+        line.getSections().add(new Section(line, upStation, downStation, sectionRequest.getDistance()));
+    }
+
+    private LineResponse createLineResponse(Line line) {
+        return new LineResponse(
+                line.getId(),
+                line.getName(),
+                line.getColor(),
+                createStationResponses(line)
+        );
+    }
+
+    private List<StationResponse> createStationResponses(Line line) {
+        if (line.getSections().isEmpty()) {
+            return Collections.emptyList();
+        }
+
+        List<Station> stations = line.getSections().stream()
+                .map(Section::getDownStation)
+                .collect(Collectors.toList());
+
+        stations.add(0, line.getSections().get(0).getUpStation());
+
+        return stations.stream()
+                .map(it -> stationService.createStationResponse(it))
+                .collect(Collectors.toList());
+    }
+
+    @Transactional
+    public void deleteSection(Long lineId, Long stationId) {
+        Line line = lineRepository.findById(lineId).orElseThrow(IllegalArgumentException::new);
+        Station station = stationService.findById(stationId);
+
+        if (!line.getSections().get(line.getSections().size() - 1).getDownStation().equals(station)) {
+            throw new IllegalArgumentException();
+        }
+
+        line.getSections().remove(line.getSections().size() - 1);
+    }
+}

--- a/src/main/java/nextstep/subway/applicaion/LineService.java
+++ b/src/main/java/nextstep/subway/applicaion/LineService.java
@@ -4,14 +4,16 @@ import nextstep.subway.applicaion.dto.LineRequest;
 import nextstep.subway.applicaion.dto.LineResponse;
 import nextstep.subway.applicaion.dto.SectionRequest;
 import nextstep.subway.applicaion.dto.StationResponse;
-import nextstep.subway.domain.*;
-import org.jgrapht.alg.shortestpath.DijkstraShortestPath;
-import org.jgrapht.graph.DefaultWeightedEdge;
-import org.jgrapht.graph.WeightedMultigraph;
+import nextstep.subway.domain.Line;
+import nextstep.subway.domain.LineRepository;
+import nextstep.subway.domain.Section;
+import nextstep.subway.domain.Station;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
-import java.util.*;
+import java.util.Collections;
+import java.util.List;
+import java.util.Set;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
@@ -77,7 +79,7 @@ public class LineService {
         line.getSections().add(new Section(line, upStation, downStation, sectionRequest.getDistance()));
     }
 
-    void updateSectionInformation(Line line,
+    private void updateSectionInformation(Line line,
                                   Station newUpStation,
                                   Station newDownStation,
                                   int newSectionDistance) {
@@ -126,7 +128,7 @@ public class LineService {
         }
     }
 
-    void validateAddSectionConditions(Line line, Long newUpStationId, Long newDownStationId) {
+    private void validateAddSectionConditions(Line line, Long newUpStationId, Long newDownStationId) {
         List<Section> sections = line.getSections();
 
         List<Long> sectionUpStationIds = sections.stream()
@@ -147,27 +149,6 @@ public class LineService {
         if (!stationIds.contains(newUpStationId) && !stationIds.contains(newDownStationId)) {
             throw new IllegalArgumentException();
         }
-    }
-
-
-    List<Long> sortLineSectionsByOrder(Long lineId) {
-        Line line = lineRepository.findById(lineId).orElseThrow(NoSuchElementException::new);
-        List<Section> sections = line.getSections();
-
-        Long source = line.getFinalUpStationId();
-        Long target = line.getFinalDownStationId();
-
-        WeightedMultigraph<Long, DefaultWeightedEdge> graph = new WeightedMultigraph(DefaultWeightedEdge.class);
-        for (Section s : sections) {
-            graph.addVertex(s.getUpStationId());
-            graph.addVertex(s.getDownStationId());
-            graph.setEdgeWeight(graph.addEdge(s.getUpStationId(), s.getDownStationId()), s.getDistance());
-        }
-
-        DijkstraShortestPath dijkstraShortestPath = new DijkstraShortestPath(graph);
-        List<Long> vertexList = dijkstraShortestPath.getPath(source, target).getVertexList();
-
-        return vertexList;
     }
 
     private LineResponse createLineResponse(Line line) {

--- a/src/main/java/nextstep/subway/applicaion/LineService.java
+++ b/src/main/java/nextstep/subway/applicaion/LineService.java
@@ -76,7 +76,7 @@ public class LineService {
         validateAddSectionConditions(line, sectionRequest.getUpStationId(), sectionRequest.getDownStationId());
         updateSectionInformation(line, upStation, downStation, sectionRequest.getDistance());
 
-        line.getSections().add(new Section(line, upStation, downStation, sectionRequest.getDistance()));
+        line.addSection(new Section(line, upStation, downStation, sectionRequest.getDistance()));
     }
 
     private void updateSectionInformation(Line line,

--- a/src/main/java/nextstep/subway/applicaion/LineService.java
+++ b/src/main/java/nextstep/subway/applicaion/LineService.java
@@ -28,12 +28,13 @@ public class LineService {
 
     @Transactional
     public LineResponse saveLine(LineRequest request) {
-        Line line = lineRepository.save(new Line(request.getName(), request.getColor()));
-        if (request.getUpStationId() != null && request.getDownStationId() != null && request.getDistance() != 0) {
-            Station upStation = stationService.findById(request.getUpStationId());
-            Station downStation = stationService.findById(request.getDownStationId());
-            line.getSections().add(new Section(line, upStation, downStation, request.getDistance()));
-        }
+        Line line = lineRepository.save(
+                new Line(request.getName(), request.getColor(), request.getUpStationId(), request.getDownStationId())
+        );
+        Station upStation = stationService.findById(request.getUpStationId());
+        Station downStation = stationService.findById(request.getDownStationId());
+        line.getSections().add(new Section(line, upStation, downStation, request.getDistance()));
+
         return createLineResponse(line);
     }
 

--- a/src/main/java/nextstep/subway/applicaion/StationService.java
+++ b/src/main/java/nextstep/subway/applicaion/StationService.java
@@ -1,0 +1,49 @@
+package nextstep.subway.applicaion;
+
+import nextstep.subway.applicaion.dto.StationRequest;
+import nextstep.subway.applicaion.dto.StationResponse;
+import nextstep.subway.domain.Station;
+import nextstep.subway.domain.StationRepository;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+@Service
+@Transactional(readOnly = true)
+public class StationService {
+    private StationRepository stationRepository;
+
+    public StationService(StationRepository stationRepository) {
+        this.stationRepository = stationRepository;
+    }
+
+    @Transactional
+    public StationResponse saveStation(StationRequest stationRequest) {
+        Station station = stationRepository.save(new Station(stationRequest.getName()));
+        return createStationResponse(station);
+    }
+
+    public List<StationResponse> findAllStations() {
+        return stationRepository.findAll().stream()
+                .map(this::createStationResponse)
+                .collect(Collectors.toList());
+    }
+
+    @Transactional
+    public void deleteStationById(Long id) {
+        stationRepository.deleteById(id);
+    }
+
+    public StationResponse createStationResponse(Station station) {
+        return new StationResponse(
+                station.getId(),
+                station.getName()
+        );
+    }
+
+    public Station findById(Long id) {
+        return stationRepository.findById(id).orElseThrow(IllegalArgumentException::new);
+    }
+}

--- a/src/main/java/nextstep/subway/applicaion/dto/LineRequest.java
+++ b/src/main/java/nextstep/subway/applicaion/dto/LineRequest.java
@@ -1,0 +1,29 @@
+package nextstep.subway.applicaion.dto;
+
+public class LineRequest {
+    private String name;
+    private String color;
+    private Long upStationId;
+    private Long downStationId;
+    private int distance;
+
+    public String getName() {
+        return name;
+    }
+
+    public String getColor() {
+        return color;
+    }
+
+    public Long getUpStationId() {
+        return upStationId;
+    }
+
+    public Long getDownStationId() {
+        return downStationId;
+    }
+
+    public int getDistance() {
+        return distance;
+    }
+}

--- a/src/main/java/nextstep/subway/applicaion/dto/LineRequest.java
+++ b/src/main/java/nextstep/subway/applicaion/dto/LineRequest.java
@@ -1,11 +1,25 @@
 package nextstep.subway.applicaion.dto;
 
+import javax.validation.constraints.Min;
+import javax.validation.constraints.NotNull;
+
 public class LineRequest {
     private String name;
     private String color;
+    @NotNull
     private Long upStationId;
+    @NotNull
     private Long downStationId;
+    @Min(1)
     private int distance;
+
+    public LineRequest(String name, String color, Long upStationId, Long downStationId, int distance) {
+        this.name = name;
+        this.color = color;
+        this.upStationId = upStationId;
+        this.downStationId = downStationId;
+        this.distance = distance;
+    }
 
     public String getName() {
         return name;

--- a/src/main/java/nextstep/subway/applicaion/dto/LineResponse.java
+++ b/src/main/java/nextstep/subway/applicaion/dto/LineResponse.java
@@ -1,0 +1,34 @@
+package nextstep.subway.applicaion.dto;
+
+import java.util.List;
+
+public class LineResponse {
+    private Long id;
+    private String name;
+    private String color;
+    private List<StationResponse> stations;
+
+    public LineResponse(Long id, String name, String color, List<StationResponse> stations) {
+        this.id = id;
+        this.name = name;
+        this.color = color;
+        this.stations = stations;
+    }
+
+    public Long getId() {
+        return id;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public String getColor() {
+        return color;
+    }
+
+    public List<StationResponse> getStations() {
+        return stations;
+    }
+}
+

--- a/src/main/java/nextstep/subway/applicaion/dto/SectionRequest.java
+++ b/src/main/java/nextstep/subway/applicaion/dto/SectionRequest.java
@@ -1,0 +1,19 @@
+package nextstep.subway.applicaion.dto;
+
+public class SectionRequest {
+    private Long upStationId;
+    private Long downStationId;
+    private int distance;
+
+    public Long getUpStationId() {
+        return upStationId;
+    }
+
+    public Long getDownStationId() {
+        return downStationId;
+    }
+
+    public int getDistance() {
+        return distance;
+    }
+}

--- a/src/main/java/nextstep/subway/applicaion/dto/SectionRequest.java
+++ b/src/main/java/nextstep/subway/applicaion/dto/SectionRequest.java
@@ -5,6 +5,12 @@ public class SectionRequest {
     private Long downStationId;
     private int distance;
 
+    public SectionRequest(Long upStationId, Long downStationId, int distance) {
+        this.upStationId = upStationId;
+        this.downStationId = downStationId;
+        this.distance = distance;
+    }
+
     public Long getUpStationId() {
         return upStationId;
     }

--- a/src/main/java/nextstep/subway/applicaion/dto/StationRequest.java
+++ b/src/main/java/nextstep/subway/applicaion/dto/StationRequest.java
@@ -1,0 +1,9 @@
+package nextstep.subway.applicaion.dto;
+
+public class StationRequest {
+    private String name;
+
+    public String getName() {
+        return name;
+    }
+}

--- a/src/main/java/nextstep/subway/applicaion/dto/StationResponse.java
+++ b/src/main/java/nextstep/subway/applicaion/dto/StationResponse.java
@@ -1,0 +1,22 @@
+package nextstep.subway.applicaion.dto;
+
+public class StationResponse {
+    private Long id;
+    private String name;
+
+    public StationResponse() {
+    }
+
+    public StationResponse(Long id, String name) {
+        this.id = id;
+        this.name = name;
+    }
+
+    public Long getId() {
+        return id;
+    }
+
+    public String getName() {
+        return name;
+    }
+}

--- a/src/main/java/nextstep/subway/domain/Line.java
+++ b/src/main/java/nextstep/subway/domain/Line.java
@@ -1,0 +1,53 @@
+package nextstep.subway.domain;
+
+import javax.persistence.*;
+import java.util.ArrayList;
+import java.util.List;
+
+@Entity
+public class Line {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+    private String name;
+    private String color;
+
+    @OneToMany(mappedBy = "line", cascade = {CascadeType.PERSIST, CascadeType.MERGE}, orphanRemoval = true)
+    private List<Section> sections = new ArrayList<>();
+
+    public Line() {
+    }
+
+    public Line(String name, String color) {
+        this.name = name;
+        this.color = color;
+    }
+
+    public Long getId() {
+        return id;
+    }
+
+    public void setId(Long id) {
+        this.id = id;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public void setName(String name) {
+        this.name = name;
+    }
+
+    public String getColor() {
+        return color;
+    }
+
+    public void setColor(String color) {
+        this.color = color;
+    }
+
+    public List<Section> getSections() {
+        return sections;
+    }
+}

--- a/src/main/java/nextstep/subway/domain/Line.java
+++ b/src/main/java/nextstep/subway/domain/Line.java
@@ -27,17 +27,8 @@ public class Line {
         this.finalDownStationId = finalDownStationId;
     }
 
-    public Line(String name, String color) {
-        this.name = name;
-        this.color = color;
-    }
-
     public Long getId() {
         return id;
-    }
-
-    public void setId(Long id) {
-        this.id = id;
     }
 
     public String getName() {

--- a/src/main/java/nextstep/subway/domain/Line.java
+++ b/src/main/java/nextstep/subway/domain/Line.java
@@ -11,11 +11,20 @@ public class Line {
     private Long id;
     private String name;
     private String color;
+    private Long finalUpStationId;
+    private Long finalDownStationId;
 
     @OneToMany(mappedBy = "line", cascade = {CascadeType.PERSIST, CascadeType.MERGE}, orphanRemoval = true)
     private List<Section> sections = new ArrayList<>();
 
     public Line() {
+    }
+
+    public Line(String name, String color, Long finalUpStationId, Long finalDownStationId) {
+        this.name = name;
+        this.color = color;
+        this.finalUpStationId = finalUpStationId;
+        this.finalDownStationId = finalDownStationId;
     }
 
     public Line(String name, String color) {
@@ -47,7 +56,20 @@ public class Line {
         this.color = color;
     }
 
+    public Long getFinalUpStationId() {
+        return finalUpStationId;
+    }
+
+    public Long getFinalDownStationId() {
+        return finalDownStationId;
+    }
+
     public List<Section> getSections() {
         return sections;
+    }
+
+    public void addSection(Section section) {
+        sections.add(section);
+        section.updateLine(this);
     }
 }

--- a/src/main/java/nextstep/subway/domain/Line.java
+++ b/src/main/java/nextstep/subway/domain/Line.java
@@ -72,4 +72,12 @@ public class Line {
         sections.add(section);
         section.updateLine(this);
     }
+
+    public void updateFinalUpStationId(Long finalUpStationId) {
+        this.finalUpStationId = finalUpStationId;
+    }
+
+    public void updateFinalDownStationId(Long finalDownStationId) {
+        this.finalDownStationId = finalDownStationId;
+    }
 }

--- a/src/main/java/nextstep/subway/domain/LineRepository.java
+++ b/src/main/java/nextstep/subway/domain/LineRepository.java
@@ -1,0 +1,10 @@
+package nextstep.subway.domain;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.List;
+
+public interface LineRepository extends JpaRepository<Line, Long> {
+    @Override
+    List<Line> findAll();
+}

--- a/src/main/java/nextstep/subway/domain/Section.java
+++ b/src/main/java/nextstep/subway/domain/Section.java
@@ -1,0 +1,55 @@
+package nextstep.subway.domain;
+
+import javax.persistence.*;
+
+@Entity
+public class Section {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(cascade = CascadeType.PERSIST)
+    @JoinColumn(name = "line_id")
+    private Line line;
+
+    @ManyToOne(cascade = CascadeType.PERSIST)
+    @JoinColumn(name = "up_station_id")
+    private Station upStation;
+
+    @ManyToOne(cascade = CascadeType.PERSIST)
+    @JoinColumn(name = "down_station_id")
+    private Station downStation;
+
+    private int distance;
+
+    public Section() {
+
+    }
+
+    public Section(Line line, Station upStation, Station downStation, int distance) {
+        this.line = line;
+        this.upStation = upStation;
+        this.downStation = downStation;
+        this.distance = distance;
+    }
+
+    public Long getId() {
+        return id;
+    }
+
+    public Line getLine() {
+        return line;
+    }
+
+    public Station getUpStation() {
+        return upStation;
+    }
+
+    public Station getDownStation() {
+        return downStation;
+    }
+
+    public int getDistance() {
+        return distance;
+    }
+}

--- a/src/main/java/nextstep/subway/domain/Section.java
+++ b/src/main/java/nextstep/subway/domain/Section.java
@@ -52,4 +52,16 @@ public class Section {
     public int getDistance() {
         return distance;
     }
+
+    public void updateLine(Line line) {
+        this.line = line;
+    }
+
+    public Long getUpStationId() {
+        return upStation.getId();
+    }
+
+    public Long getDownStationId() {
+        return downStation.getId();
+    }
 }

--- a/src/main/java/nextstep/subway/domain/Section.java
+++ b/src/main/java/nextstep/subway/domain/Section.java
@@ -64,4 +64,16 @@ public class Section {
     public Long getDownStationId() {
         return downStation.getId();
     }
+
+    public void updateUpStation(Station upStation) {
+        this.upStation = upStation;
+    }
+
+    public void updateDownStation(Station downStation) {
+        this.downStation = downStation;
+    }
+
+    public void updateDistance(int distance){
+        this.distance = distance;
+    }
 }

--- a/src/main/java/nextstep/subway/domain/Station.java
+++ b/src/main/java/nextstep/subway/domain/Station.java
@@ -1,0 +1,29 @@
+package nextstep.subway.domain;
+
+import javax.persistence.Entity;
+import javax.persistence.GeneratedValue;
+import javax.persistence.GenerationType;
+import javax.persistence.Id;
+
+@Entity
+public class Station {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+    private String name;
+
+    public Station() {
+    }
+
+    public Station(String name) {
+        this.name = name;
+    }
+
+    public Long getId() {
+        return id;
+    }
+
+    public String getName() {
+        return name;
+    }
+}

--- a/src/main/java/nextstep/subway/domain/StationRepository.java
+++ b/src/main/java/nextstep/subway/domain/StationRepository.java
@@ -1,0 +1,6 @@
+package nextstep.subway.domain;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface StationRepository extends JpaRepository<Station, Long> {
+}

--- a/src/main/java/nextstep/subway/ui/ControllerExceptionHandler.java
+++ b/src/main/java/nextstep/subway/ui/ControllerExceptionHandler.java
@@ -1,0 +1,14 @@
+package nextstep.subway.ui;
+
+import org.springframework.dao.DataIntegrityViolationException;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.ControllerAdvice;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+
+@ControllerAdvice
+public class ControllerExceptionHandler {
+    @ExceptionHandler(DataIntegrityViolationException.class)
+    public ResponseEntity<Void> handleIllegalArgsException(DataIntegrityViolationException e) {
+        return ResponseEntity.badRequest().build();
+    }
+}

--- a/src/main/java/nextstep/subway/ui/LineController.java
+++ b/src/main/java/nextstep/subway/ui/LineController.java
@@ -1,0 +1,63 @@
+package nextstep.subway.ui;
+
+import nextstep.subway.applicaion.LineService;
+import nextstep.subway.applicaion.dto.LineRequest;
+import nextstep.subway.applicaion.dto.LineResponse;
+import nextstep.subway.applicaion.dto.SectionRequest;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+import java.net.URI;
+import java.util.List;
+
+@RestController
+@RequestMapping("/lines")
+public class LineController {
+    private LineService lineService;
+
+    public LineController(LineService lineService) {
+        this.lineService = lineService;
+    }
+
+    @PostMapping
+    public ResponseEntity<LineResponse> createLine(@RequestBody LineRequest lineRequest) {
+        LineResponse line = lineService.saveLine(lineRequest);
+        return ResponseEntity.created(URI.create("/lines/" + line.getId())).body(line);
+    }
+
+    @GetMapping
+    public ResponseEntity<List<LineResponse>> showLines() {
+        List<LineResponse> responses = lineService.showLines();
+        return ResponseEntity.ok().body(responses);
+    }
+
+    @GetMapping("/{id}")
+    public ResponseEntity<LineResponse> getLine(@PathVariable Long id) {
+        LineResponse lineResponse = lineService.findById(id);
+        return ResponseEntity.ok().body(lineResponse);
+    }
+
+    @PutMapping("/{id}")
+    public ResponseEntity<Void> updateLine(@PathVariable Long id, @RequestBody LineRequest lineRequest) {
+        lineService.updateLine(id, lineRequest);
+        return ResponseEntity.ok().build();
+    }
+
+    @DeleteMapping("/{id}")
+    public ResponseEntity<Void> updateLine(@PathVariable Long id) {
+        lineService.deleteLine(id);
+        return ResponseEntity.noContent().build();
+    }
+
+    @PostMapping("/{lineId}/sections")
+    public ResponseEntity<Void> addSection(@PathVariable Long lineId, @RequestBody SectionRequest sectionRequest) {
+        lineService.addSection(lineId, sectionRequest);
+        return ResponseEntity.ok().build();
+    }
+
+    @DeleteMapping("/{lineId}/sections")
+    public ResponseEntity<Void> deleteSection(@PathVariable Long lineId, @RequestParam Long stationId) {
+        lineService.deleteSection(lineId, stationId);
+        return ResponseEntity.ok().build();
+    }
+}

--- a/src/main/java/nextstep/subway/ui/LineController.java
+++ b/src/main/java/nextstep/subway/ui/LineController.java
@@ -7,6 +7,7 @@ import nextstep.subway.applicaion.dto.SectionRequest;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
+import javax.validation.Valid;
 import java.net.URI;
 import java.util.List;
 
@@ -20,7 +21,7 @@ public class LineController {
     }
 
     @PostMapping
-    public ResponseEntity<LineResponse> createLine(@RequestBody LineRequest lineRequest) {
+    public ResponseEntity<LineResponse> createLine(@RequestBody @Valid LineRequest lineRequest) {
         LineResponse line = lineService.saveLine(lineRequest);
         return ResponseEntity.created(URI.create("/lines/" + line.getId())).body(line);
     }

--- a/src/main/java/nextstep/subway/ui/StationController.java
+++ b/src/main/java/nextstep/subway/ui/StationController.java
@@ -1,0 +1,36 @@
+package nextstep.subway.ui;
+
+import nextstep.subway.applicaion.StationService;
+import nextstep.subway.applicaion.dto.StationRequest;
+import nextstep.subway.applicaion.dto.StationResponse;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+import java.net.URI;
+import java.util.List;
+
+@RestController
+public class StationController {
+    private StationService stationService;
+
+    public StationController(StationService stationService) {
+        this.stationService = stationService;
+    }
+
+    @PostMapping("/stations")
+    public ResponseEntity<StationResponse> createStation(@RequestBody StationRequest stationRequest) {
+        StationResponse station = stationService.saveStation(stationRequest);
+        return ResponseEntity.created(URI.create("/stations/" + station.getId())).body(station);
+    }
+
+    @GetMapping(value = "/stations")
+    public ResponseEntity<List<StationResponse>> showStations() {
+        return ResponseEntity.ok().body(stationService.findAllStations());
+    }
+
+    @DeleteMapping("/stations/{id}")
+    public ResponseEntity<Void> deleteStation(@PathVariable Long id) {
+        stationService.deleteStationById(id);
+        return ResponseEntity.noContent().build();
+    }
+}

--- a/src/test/java/nextstep/subway/acceptance/LineAcceptanceTest.java
+++ b/src/test/java/nextstep/subway/acceptance/LineAcceptanceTest.java
@@ -1,0 +1,122 @@
+package nextstep.subway.acceptance;
+
+import io.restassured.RestAssured;
+import io.restassured.response.ExtractableResponse;
+import io.restassured.response.Response;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import static nextstep.subway.acceptance.LineSteps.*;
+import static org.assertj.core.api.Assertions.assertThat;
+
+@DisplayName("지하철 노선 관리 기능")
+class LineAcceptanceTest extends AcceptanceTest {
+    /**
+     * When 지하철 노선을 생성하면
+     * Then 지하철 노선 목록 조회 시 생성한 노선을 찾을 수 있다
+     */
+    @DisplayName("지하철 노선 생성")
+    @Test
+    void createLine() {
+        // when
+        ExtractableResponse<Response> response = 지하철_노선_생성_요청("2호선", "green");
+
+        // then
+        assertThat(response.statusCode()).isEqualTo(HttpStatus.CREATED.value());
+        ExtractableResponse<Response> listResponse = 지하철_노선_목록_조회_요청();
+
+        assertThat(listResponse.jsonPath().getList("name")).contains("2호선");
+    }
+
+    /**
+     * Given 2개의 지하철 노선을 생성하고
+     * When 지하철 노선 목록을 조회하면
+     * Then 지하철 노선 목록 조회 시 2개의 노선을 조회할 수 있다.
+     */
+    @DisplayName("지하철 노선 목록 조회")
+    @Test
+    void getLines() {
+        // given
+        지하철_노선_생성_요청("2호선", "green");
+        지하철_노선_생성_요청("3호선", "orange");
+
+        // when
+        ExtractableResponse<Response> response = 지하철_노선_목록_조회_요청();
+
+        // then
+        assertThat(response.statusCode()).isEqualTo(HttpStatus.OK.value());
+        assertThat(response.jsonPath().getList("name")).contains("2호선", "3호선");
+    }
+
+    /**
+     * Given 지하철 노선을 생성하고
+     * When 생성한 지하철 노선을 조회하면
+     * Then 생성한 지하철 노선의 정보를 응답받을 수 있다.
+     */
+    @DisplayName("지하철 노선 조회")
+    @Test
+    void getLine() {
+        // given
+        ExtractableResponse<Response> createResponse = 지하철_노선_생성_요청("2호선", "green");
+
+        // when
+        ExtractableResponse<Response> response = 지하철_노선_조회_요청(createResponse);
+
+        // then
+        assertThat(response.statusCode()).isEqualTo(HttpStatus.OK.value());
+        assertThat(response.jsonPath().getString("name")).isEqualTo("2호선");
+    }
+
+    /**
+     * Given 지하철 노선을 생성하고
+     * When 생성한 지하철 노선을 수정하면
+     * Then 해당 지하철 노선 정보는 수정된다
+     */
+    @DisplayName("지하철 노선 수정")
+    @Test
+    void updateLine() {
+        // given
+        ExtractableResponse<Response> createResponse = 지하철_노선_생성_요청("2호선", "green");
+
+        // when
+        Map<String, String> params = new HashMap<>();
+        params.put("color", "red");
+        RestAssured
+                .given().log().all()
+                .body(params)
+                .contentType(MediaType.APPLICATION_JSON_VALUE)
+                .when().put(createResponse.header("location"))
+                .then().log().all().extract();
+
+        // then
+        ExtractableResponse<Response> response = 지하철_노선_조회_요청(createResponse);
+        assertThat(response.statusCode()).isEqualTo(HttpStatus.OK.value());
+        assertThat(response.jsonPath().getString("color")).isEqualTo("red");
+    }
+
+    /**
+     * Given 지하철 노선을 생성하고
+     * When 생성한 지하철 노선을 삭제하면
+     * Then 해당 지하철 노선 정보는 삭제된다
+     */
+    @DisplayName("지하철 노선 삭제")
+    @Test
+    void deleteLine() {
+        // given
+        ExtractableResponse<Response> createResponse = 지하철_노선_생성_요청("2호선", "green");
+
+        // when
+        ExtractableResponse<Response> response = RestAssured
+                .given().log().all()
+                .when().delete(createResponse.header("location"))
+                .then().log().all().extract();
+
+        // then
+        assertThat(response.statusCode()).isEqualTo(HttpStatus.NO_CONTENT.value());
+    }
+}

--- a/src/test/java/nextstep/subway/acceptance/LineAcceptanceTest.java
+++ b/src/test/java/nextstep/subway/acceptance/LineAcceptanceTest.java
@@ -12,6 +12,7 @@ import java.util.HashMap;
 import java.util.Map;
 
 import static nextstep.subway.acceptance.LineSteps.*;
+import static nextstep.subway.acceptance.StationSteps.지하철역_생성_요청;
 import static org.assertj.core.api.Assertions.assertThat;
 
 @DisplayName("지하철 노선 관리 기능")
@@ -24,7 +25,9 @@ class LineAcceptanceTest extends AcceptanceTest {
     @Test
     void createLine() {
         // when
-        ExtractableResponse<Response> response = 지하철_노선_생성_요청("2호선", "green");
+        Long 강남역 = 지하철역_생성_요청("강남역").jsonPath().getLong("id");
+        Long 정자역 = 지하철역_생성_요청("정자역").jsonPath().getLong("id");
+        ExtractableResponse<Response> response = 지하철_노선_생성_요청("2호선", "green", 강남역, 정자역);
 
         // then
         assertThat(response.statusCode()).isEqualTo(HttpStatus.CREATED.value());
@@ -42,8 +45,13 @@ class LineAcceptanceTest extends AcceptanceTest {
     @Test
     void getLines() {
         // given
-        지하철_노선_생성_요청("2호선", "green");
-        지하철_노선_생성_요청("3호선", "orange");
+        Long 강남역 = 지하철역_생성_요청("강남역").jsonPath().get("id");
+        Long 정자역 = 지하철역_생성_요청("정자역").jsonPath().get("id");
+        지하철_노선_생성_요청("2호선", "green", 강남역, 정자역);
+
+        Long 그린역 = 지하철역_생성_요청("그린역").jsonPath().get("id");
+        Long 슈퍼그린역 = 지하철역_생성_요청("슈퍼그린역").jsonPath().get("id");
+        지하철_노선_생성_요청("3호선", "orange", 그린역, 슈퍼그린역);
 
         // when
         ExtractableResponse<Response> response = 지하철_노선_목록_조회_요청();
@@ -62,7 +70,10 @@ class LineAcceptanceTest extends AcceptanceTest {
     @Test
     void getLine() {
         // given
-        ExtractableResponse<Response> createResponse = 지하철_노선_생성_요청("2호선", "green");
+        Long 그린역 = 지하철역_생성_요청("그린역").jsonPath().getLong("id");
+        Long 슈퍼그린역 = 지하철역_생성_요청("슈퍼그린역").jsonPath().getLong("id");
+
+        ExtractableResponse<Response> createResponse = 지하철_노선_생성_요청("2호선", "green", 그린역, 슈퍼그린역);
 
         // when
         ExtractableResponse<Response> response = 지하철_노선_조회_요청(createResponse);
@@ -81,7 +92,9 @@ class LineAcceptanceTest extends AcceptanceTest {
     @Test
     void updateLine() {
         // given
-        ExtractableResponse<Response> createResponse = 지하철_노선_생성_요청("2호선", "green");
+        Long 그린역 = 지하철역_생성_요청("그린역").jsonPath().getLong("id");
+        Long 슈퍼그린역 = 지하철역_생성_요청("슈퍼그린역").jsonPath().getLong("id");
+        ExtractableResponse<Response> createResponse = 지하철_노선_생성_요청("2호선", "green", 그린역, 슈퍼그린역);
 
         // when
         Map<String, String> params = new HashMap<>();
@@ -108,7 +121,9 @@ class LineAcceptanceTest extends AcceptanceTest {
     @Test
     void deleteLine() {
         // given
-        ExtractableResponse<Response> createResponse = 지하철_노선_생성_요청("2호선", "green");
+        Long 그린역 = 지하철역_생성_요청("그린역").jsonPath().getLong("id");
+        Long 슈퍼그린역 = 지하철역_생성_요청("슈퍼그린역").jsonPath().getLong("id");
+        ExtractableResponse<Response> createResponse = 지하철_노선_생성_요청("2호선", "green", 그린역, 슈퍼그린역);
 
         // when
         ExtractableResponse<Response> response = RestAssured

--- a/src/test/java/nextstep/subway/acceptance/LineSectionAcceptanceTest.java
+++ b/src/test/java/nextstep/subway/acceptance/LineSectionAcceptanceTest.java
@@ -1,0 +1,94 @@
+package nextstep.subway.acceptance;
+
+import io.restassured.response.ExtractableResponse;
+import io.restassured.response.Response;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.http.HttpStatus;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import static nextstep.subway.acceptance.LineSteps.*;
+import static nextstep.subway.acceptance.StationSteps.지하철역_생성_요청;
+import static org.assertj.core.api.Assertions.assertThat;
+
+@DisplayName("지하철 구간 관리 기능")
+class LineSectionAcceptanceTest extends AcceptanceTest {
+    private Long 신분당선;
+
+    private Long 강남역;
+    private Long 양재역;
+
+    /**
+     * Given 지하철역과 노선 생성을 요청 하고
+     */
+    @BeforeEach
+    public void setUp() {
+        super.setUp();
+
+        강남역 = 지하철역_생성_요청("강남역").jsonPath().getLong("id");
+        양재역 = 지하철역_생성_요청("양재역").jsonPath().getLong("id");
+
+        Map<String, String> lineCreateParams = createLineCreateParams(강남역, 양재역);
+        신분당선 = 지하철_노선_생성_요청(lineCreateParams).jsonPath().getLong("id");
+    }
+
+    /**
+     * When 지하철 노선에 새로운 구간 추가를 요청 하면
+     * Then 노선에 새로운 구간이 추가된다
+     */
+    @DisplayName("지하철 노선에 구간을 등록")
+    @Test
+    void addLineSection() {
+        // when
+        Long 정자역 = 지하철역_생성_요청("정자역").jsonPath().getLong("id");
+        지하철_노선에_지하철_구간_생성_요청(신분당선, createSectionCreateParams(양재역, 정자역));
+
+        // then
+        ExtractableResponse<Response> response = 지하철_노선_조회_요청(신분당선);
+        assertThat(response.statusCode()).isEqualTo(HttpStatus.OK.value());
+        assertThat(response.jsonPath().getList("stations.id", Long.class)).containsExactly(강남역, 양재역, 정자역);
+    }
+
+    /**
+     * Given 지하철 노선에 새로운 구간 추가를 요청 하고
+     * When 지하철 노선의 마지막 구간 제거를 요청 하면
+     * Then 노선에 구간이 제거된다
+     */
+    @DisplayName("지하철 노선에 구간을 제거")
+    @Test
+    void removeLineSection() {
+        // given
+        Long 정자역 = 지하철역_생성_요청("정자역").jsonPath().getLong("id");
+        지하철_노선에_지하철_구간_생성_요청(신분당선, createSectionCreateParams(양재역, 정자역));
+
+        // when
+        지하철_노선에_지하철_구간_제거_요청(신분당선, 정자역);
+
+        // then
+        ExtractableResponse<Response> response = 지하철_노선_조회_요청(신분당선);
+        assertThat(response.statusCode()).isEqualTo(HttpStatus.OK.value());
+        assertThat(response.jsonPath().getList("stations.id", Long.class)).containsExactly(강남역, 양재역);
+    }
+
+    private Map<String, String> createLineCreateParams(Long upStationId, Long downStationId) {
+        Map<String, String> lineCreateParams;
+        lineCreateParams = new HashMap<>();
+        lineCreateParams.put("name", "신분당선");
+        lineCreateParams.put("color", "bg-red-600");
+        lineCreateParams.put("upStationId", upStationId + "");
+        lineCreateParams.put("downStationId", downStationId + "");
+        lineCreateParams.put("distance", 10 + "");
+        return lineCreateParams;
+    }
+
+    private Map<String, String> createSectionCreateParams(Long upStationId, Long downStationId) {
+        Map<String, String> params = new HashMap<>();
+        params.put("upStationId", upStationId + "");
+        params.put("downStationId", downStationId + "");
+        params.put("distance", 6 + "");
+        return params;
+    }
+}

--- a/src/test/java/nextstep/subway/acceptance/LineSteps.java
+++ b/src/test/java/nextstep/subway/acceptance/LineSteps.java
@@ -1,0 +1,67 @@
+package nextstep.subway.acceptance;
+
+import io.restassured.RestAssured;
+import io.restassured.response.ExtractableResponse;
+import io.restassured.response.Response;
+import org.springframework.http.MediaType;
+
+import java.util.HashMap;
+import java.util.Map;
+
+public class LineSteps {
+    public static ExtractableResponse<Response> 지하철_노선_생성_요청(String name, String color) {
+        Map<String, String> params = new HashMap<>();
+        params.put("name", name);
+        params.put("color", color);
+        return RestAssured
+                .given().log().all()
+                .body(params)
+                .contentType(MediaType.APPLICATION_JSON_VALUE)
+                .when().post("/lines")
+                .then().log().all().extract();
+    }
+
+    public static ExtractableResponse<Response> 지하철_노선_목록_조회_요청() {
+        return RestAssured
+                .given().log().all()
+                .when().get("/lines")
+                .then().log().all().extract();
+    }
+
+    public static ExtractableResponse<Response> 지하철_노선_조회_요청(ExtractableResponse<Response> createResponse) {
+        return RestAssured
+                .given().log().all()
+                .when().get(createResponse.header("location"))
+                .then().log().all().extract();
+    }
+
+    public static ExtractableResponse<Response> 지하철_노선_조회_요청(Long id) {
+        return RestAssured
+                .given().log().all()
+                .when().get("/lines/{id}", id)
+                .then().log().all().extract();
+    }
+
+    public static ExtractableResponse<Response> 지하철_노선_생성_요청(Map<String, String> params) {
+        return RestAssured
+                .given().log().all()
+                .body(params)
+                .contentType(MediaType.APPLICATION_JSON_VALUE)
+                .when().post("/lines")
+                .then().log().all().extract();
+    }
+
+    public static ExtractableResponse<Response> 지하철_노선에_지하철_구간_생성_요청(Long lineId, Map<String, String> params) {
+        return RestAssured.given().log().all()
+                .contentType(MediaType.APPLICATION_JSON_VALUE)
+                .body(params)
+                .when().post("/lines/{lineId}/sections", lineId)
+                .then().log().all().extract();
+    }
+
+    public static ExtractableResponse<Response> 지하철_노선에_지하철_구간_제거_요청(Long lineId, Long stationId) {
+        return RestAssured.given().log().all()
+                .when().delete("/lines/{lineId}/sections?stationId={stationId}", lineId, stationId)
+                .then().log().all().extract();
+    }
+}

--- a/src/test/java/nextstep/subway/acceptance/LineSteps.java
+++ b/src/test/java/nextstep/subway/acceptance/LineSteps.java
@@ -9,10 +9,13 @@ import java.util.HashMap;
 import java.util.Map;
 
 public class LineSteps {
-    public static ExtractableResponse<Response> 지하철_노선_생성_요청(String name, String color) {
+    public static ExtractableResponse<Response> 지하철_노선_생성_요청(String name, String color, Long upStationId, Long downStationId) {
         Map<String, String> params = new HashMap<>();
         params.put("name", name);
         params.put("color", color);
+        params.put("upStationId", upStationId.toString());
+        params.put("downStationId", downStationId.toString());
+
         return RestAssured
                 .given().log().all()
                 .body(params)

--- a/src/test/java/nextstep/subway/acceptance/SectionAcceptanceTest.java
+++ b/src/test/java/nextstep/subway/acceptance/SectionAcceptanceTest.java
@@ -1,0 +1,94 @@
+package nextstep.subway.acceptance;
+
+import io.restassured.response.ExtractableResponse;
+import io.restassured.response.Response;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.http.HttpStatus;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import static nextstep.subway.acceptance.LineSteps.*;
+import static nextstep.subway.acceptance.StationSteps.지하철역_생성_요청;
+import static org.assertj.core.api.Assertions.assertThat;
+
+@DisplayName("지하철 구간 관리 기능")
+class SectionAcceptanceTest extends AcceptanceTest {
+    private Long 신분당선;
+
+    private Long 강남역;
+    private Long 양재역;
+
+    /**
+     * Given 지하철역과 노선 생성을 요청 하고
+     */
+    @BeforeEach
+    public void setUp() {
+        super.setUp();
+
+        강남역 = 지하철역_생성_요청("강남역").jsonPath().getLong("id");
+        양재역 = 지하철역_생성_요청("양재역").jsonPath().getLong("id");
+
+        Map<String, String> lineCreateParams = createLineCreateParams(강남역, 양재역);
+        신분당선 = 지하철_노선_생성_요청(lineCreateParams).jsonPath().getLong("id");
+    }
+
+    /**
+     * When 지하철 노선에 새로운 구간 추가를 요청 하면
+     * Then 노선에 새로운 구간이 추가된다
+     */
+    @DisplayName("지하철 노선에 구간을 등록")
+    @Test
+    void addLineSection() {
+        // when
+        Long 정자역 = 지하철역_생성_요청("정자역").jsonPath().getLong("id");
+        지하철_노선에_지하철_구간_생성_요청(신분당선, createSectionCreateParams(양재역, 정자역));
+
+        // then
+        ExtractableResponse<Response> response = 지하철_노선_조회_요청(신분당선);
+        assertThat(response.statusCode()).isEqualTo(HttpStatus.OK.value());
+        assertThat(response.jsonPath().getList("stations.id", Long.class)).containsExactly(강남역, 양재역, 정자역);
+    }
+
+    /**
+     * Given 지하철 노선에 새로운 구간 추가를 요청 하고
+     * When 지하철 노선의 마지막 구간 제거를 요청 하면
+     * Then 노선에 구간이 제거된다
+     */
+    @DisplayName("지하철 노선에 구간을 제거")
+    @Test
+    void removeLineSection() {
+        // given
+        Long 정자역 = 지하철역_생성_요청("정자역").jsonPath().getLong("id");
+        지하철_노선에_지하철_구간_생성_요청(신분당선, createSectionCreateParams(양재역, 정자역));
+
+        // when
+        지하철_노선에_지하철_구간_제거_요청(신분당선, 정자역);
+
+        // then
+        ExtractableResponse<Response> response = 지하철_노선_조회_요청(신분당선);
+        assertThat(response.statusCode()).isEqualTo(HttpStatus.OK.value());
+        assertThat(response.jsonPath().getList("stations.id", Long.class)).containsExactly(강남역, 양재역);
+    }
+
+    private Map<String, String> createLineCreateParams(Long upStationId, Long downStationId) {
+        Map<String, String> lineCreateParams;
+        lineCreateParams = new HashMap<>();
+        lineCreateParams.put("name", "신분당선");
+        lineCreateParams.put("color", "bg-red-600");
+        lineCreateParams.put("upStationId", upStationId + "");
+        lineCreateParams.put("downStationId", downStationId + "");
+        lineCreateParams.put("distance", 10 + "");
+        return lineCreateParams;
+    }
+
+    private Map<String, String> createSectionCreateParams(Long upStationId, Long downStationId) {
+        Map<String, String> params = new HashMap<>();
+        params.put("upStationId", upStationId + "");
+        params.put("downStationId", downStationId + "");
+        params.put("distance", 6 + "");
+        return params;
+    }
+}

--- a/src/test/java/nextstep/subway/acceptance/SectionAcceptanceTest.java
+++ b/src/test/java/nextstep/subway/acceptance/SectionAcceptanceTest.java
@@ -53,6 +53,27 @@ class SectionAcceptanceTest extends AcceptanceTest {
     }
 
     /**
+     * given 기존 존재하는 구간에 대해(강남역-양재역)
+     * when 한 역을 기준으로 사이에 새로운 구간을 생성 요청할 경우(강남역, 그냥역)
+     * then 새로운 구간이 사이에 생성된다(강남역-그냥역-양재역)
+     */
+    @DisplayName("지하철 구간의 역을 기준으로 새로운 구간 추가")
+    @Test
+    void addNewSectionInPreviousSection() {
+        //given
+        Long 그냥역 = 지하철역_생성_요청("그냥역").jsonPath().getLong("id");
+
+        //when
+        지하철_노선에_지하철_구간_생성_요청(신분당선, createSectionCreateParams(강남역, 그냥역, 2));
+
+        //then
+        ExtractableResponse<Response> response = 지하철_노선_조회_요청(신분당선);
+        assertThat(response.statusCode()).isEqualTo(HttpStatus.OK.value());
+        assertThat(response.jsonPath().getList("stations.id", Long.class)).containsExactly(강남역, 양재역, 그냥역);
+    }
+
+
+    /**
      * Given 지하철 노선에 새로운 구간 추가를 요청 하고
      * When 지하철 노선의 마지막 구간 제거를 요청 하면
      * Then 노선에 구간이 제거된다
@@ -89,6 +110,14 @@ class SectionAcceptanceTest extends AcceptanceTest {
         params.put("upStationId", upStationId + "");
         params.put("downStationId", downStationId + "");
         params.put("distance", 6 + "");
+        return params;
+    }
+
+    private Map<String, String> createSectionCreateParams(Long upStationId, Long downStationId, int distance) {
+        Map<String, String> params = new HashMap<>();
+        params.put("upStationId", upStationId + "");
+        params.put("downStationId", downStationId + "");
+        params.put("distance", distance + "");
         return params;
     }
 }

--- a/src/test/java/nextstep/subway/acceptance/SectionAcceptanceTest.java
+++ b/src/test/java/nextstep/subway/acceptance/SectionAcceptanceTest.java
@@ -64,14 +64,32 @@ class SectionAcceptanceTest extends AcceptanceTest {
         Long 그냥역 = 지하철역_생성_요청("그냥역").jsonPath().getLong("id");
 
         //when
-        지하철_노선에_지하철_구간_생성_요청(신분당선, createSectionCreateParams(강남역, 그냥역, 2));
+        ExtractableResponse<Response> response = 지하철_노선에_지하철_구간_생성_요청(신분당선, createSectionCreateParams(강남역, 그냥역, 2));
 
         //then
-        ExtractableResponse<Response> response = 지하철_노선_조회_요청(신분당선);
         assertThat(response.statusCode()).isEqualTo(HttpStatus.OK.value());
-        assertThat(response.jsonPath().getList("stations.id", Long.class)).containsExactly(강남역, 양재역, 그냥역);
+        ExtractableResponse<Response> 노선_조회_결과 = 지하철_노선_조회_요청(신분당선);
+        assertThat(노선_조회_결과.statusCode()).isEqualTo(HttpStatus.OK.value());
+        assertThat(노선_조회_결과.jsonPath().getList("stations.id", Long.class)).containsExactly(강남역, 양재역, 그냥역);
     }
 
+    /**
+     * given 기존 존재하는 구간에 대해(강남역-양재역)
+     * when 한 역을 기준으로 사이에 새로운 구간을 생성 요청는데(강남역, 그냥역) 거리가 기존보다 큰 경우
+     * then 새로운 구간이 사이에 생성될 수 없다
+     */
+    @DisplayName("지하철 구간의 역을 기준으로 새로운 구간 추가 시 거리가 기존보다 클 경우 실패")
+    @Test
+    void addNewSectionInPreviousSectionFail() {
+        //given
+        Long 그냥역 = 지하철역_생성_요청("그냥역").jsonPath().getLong("id");
+
+        //when
+        ExtractableResponse<Response> response = 지하철_노선에_지하철_구간_생성_요청(신분당선, createSectionCreateParams(강남역, 그냥역, 12));
+
+        //then
+        assertThat(response.statusCode()).isNotEqualTo(HttpStatus.OK.value());
+    }
 
     /**
      * Given 지하철 노선에 새로운 구간 추가를 요청 하고

--- a/src/test/java/nextstep/subway/acceptance/StationAcceptanceTest.java
+++ b/src/test/java/nextstep/subway/acceptance/StationAcceptanceTest.java
@@ -1,0 +1,92 @@
+package nextstep.subway.acceptance;
+
+import io.restassured.RestAssured;
+import io.restassured.response.ExtractableResponse;
+import io.restassured.response.Response;
+import nextstep.subway.applicaion.dto.StationResponse;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.http.HttpStatus;
+
+import java.util.List;
+
+import static nextstep.subway.acceptance.StationSteps.지하철역_생성_요청;
+import static org.assertj.core.api.Assertions.assertThat;
+
+@DisplayName("지하철역 관련 기능")
+public class StationAcceptanceTest extends AcceptanceTest {
+
+    /**
+     * When 지하철역을 생성하면
+     * Then 지하철역이 생성된다
+     * Then 지하철역 목록 조회 시 생성한 역을 찾을 수 있다
+     */
+    @DisplayName("지하철역을 생성한다.")
+    @Test
+    void createStation() {
+        // when
+        ExtractableResponse<Response> response = 지하철역_생성_요청("강남역");
+
+        // then
+        assertThat(response.statusCode()).isEqualTo(HttpStatus.CREATED.value());
+
+        // then
+        List<String> stationNames =
+                RestAssured.given().log().all()
+                        .when().get("/stations")
+                        .then().log().all()
+                        .extract().jsonPath().getList("name", String.class);
+        assertThat(stationNames).containsAnyOf("강남역");
+    }
+
+    /**
+     * Given 2개의 지하철역을 생성하고
+     * When 지하철역 목록을 조회하면
+     * Then 2개의 지하철역을 응답 받는다
+     */
+    @DisplayName("지하철역을 조회한다.")
+    @Test
+    void getStations() {
+        // given
+        지하철역_생성_요청("강남역");
+        지하철역_생성_요청("역삼역");
+
+        // when
+        ExtractableResponse<Response> stationResponse = RestAssured.given().log().all()
+                .when().get("/stations")
+                .then().log().all()
+                .extract();
+
+        // then
+        List<StationResponse> stations = stationResponse.jsonPath().getList(".", StationResponse.class);
+        assertThat(stations).hasSize(2);
+    }
+
+    /**
+     * Given 지하철역을 생성하고
+     * When 그 지하철역을 삭제하면
+     * Then 그 지하철역 목록 조회 시 생성한 역을 찾을 수 없다
+     */
+    @DisplayName("지하철역을 제거한다.")
+    @Test
+    void deleteStation() {
+        // given
+        ExtractableResponse<Response> createResponse = 지하철역_생성_요청("강남역");
+
+        // when
+        String location = createResponse.header("location");
+        RestAssured.given().log().all()
+                .when()
+                .delete(location)
+                .then().log().all()
+                .extract();
+
+        // then
+        List<String> stationNames =
+                RestAssured.given().log().all()
+                        .when().get("/stations")
+                        .then().log().all()
+                        .extract().jsonPath().getList("name", String.class);
+        assertThat(stationNames).doesNotContain("강남역");
+    }
+}

--- a/src/test/java/nextstep/subway/acceptance/StationSteps.java
+++ b/src/test/java/nextstep/subway/acceptance/StationSteps.java
@@ -1,0 +1,23 @@
+package nextstep.subway.acceptance;
+
+import io.restassured.RestAssured;
+import io.restassured.response.ExtractableResponse;
+import io.restassured.response.Response;
+import org.springframework.http.MediaType;
+
+import java.util.HashMap;
+import java.util.Map;
+
+public class StationSteps {
+    public static ExtractableResponse<Response> 지하철역_생성_요청(String name) {
+        Map<String, String> params = new HashMap<>();
+        params.put("name", name);
+        return RestAssured.given().log().all()
+                .body(params)
+                .contentType(MediaType.APPLICATION_JSON_VALUE)
+                .when()
+                .post("/stations")
+                .then().log().all()
+                .extract();
+    }
+}

--- a/src/test/java/nextstep/subway/unit/LineServiceMockTest.java
+++ b/src/test/java/nextstep/subway/unit/LineServiceMockTest.java
@@ -1,5 +1,7 @@
 package nextstep.subway.unit;
 
+import nextstep.subway.applicaion.StationService;
+import nextstep.subway.domain.LineRepository;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;

--- a/src/test/java/nextstep/subway/unit/LineServiceMockTest.java
+++ b/src/test/java/nextstep/subway/unit/LineServiceMockTest.java
@@ -15,7 +15,7 @@ public class LineServiceMockTest {
     private StationService stationService;
 
     @Test
-    void addSection() {
+    void addSectionInPreviousSection() {
         // given
         // lineRepository, stationService stub 설정을 통해 초기값 셋팅
 

--- a/src/test/java/nextstep/subway/unit/LineServiceTest.java
+++ b/src/test/java/nextstep/subway/unit/LineServiceTest.java
@@ -1,5 +1,8 @@
 package nextstep.subway.unit;
 
+import nextstep.subway.applicaion.LineService;
+import nextstep.subway.domain.LineRepository;
+import nextstep.subway.domain.StationRepository;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;

--- a/src/test/java/nextstep/subway/unit/LineServiceTest.java
+++ b/src/test/java/nextstep/subway/unit/LineServiceTest.java
@@ -19,6 +19,7 @@ import java.util.List;
 import java.util.NoSuchElementException;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 @SpringBootTest
 @Transactional
@@ -48,6 +49,35 @@ public class LineServiceTest {
         Line line = lineRepository.findById(신분당선).orElseThrow(NoSuchElementException::new);
         List<Section> sections = line.getSections();
         Assertions.assertThat(sections.size()).isEqualTo(2);
+        Assertions.assertThat(line.getFinalDownStationId()).isEqualTo(새로운_종착역);
+    }
+
+    @Test
+    @DisplayName("기존 구간의 역을 기준으로 새로운 구간 추가 시 거리가 기존보다 클 경우 테스트 실패한다")
+    void addSectionInPreviousSectionFailByDistance() {
+        // given
+        Long 강남역 = 주어진_역_이름을_바탕으로_지하철역을_생성한다("강남역");
+        Long 정자역 = 주어진_역_이름을_바탕으로_지하철역을_생성한다("정자역");
+        Long 신분당선 = 주어진_종착역을_바탕으로_신분당선_노선을_생성한다(강남역, 정자역, 10);
+
+        Long 중간역 = 주어진_역_이름을_바탕으로_지하철역을_생성한다("중간역");
+
+        // when //then
+        assertThatThrownBy(() -> lineService.addSection(신분당선, new SectionRequest(강남역, 중간역, 14)))
+                .isInstanceOf(IllegalArgumentException.class);
+    }
+
+    @Test
+    @DisplayName("새로운 구간 추가 시 구간의 상행역, 하행역이 이미 존재할 경우 실패한다")
+    void addSectionInPreviousSectionFailByStation() {
+        // given
+        Long 강남역 = 주어진_역_이름을_바탕으로_지하철역을_생성한다("강남역");
+        Long 정자역 = 주어진_역_이름을_바탕으로_지하철역을_생성한다("정자역");
+        Long 신분당선 = 주어진_종착역을_바탕으로_신분당선_노선을_생성한다(강남역, 정자역, 10);
+
+        // when //then
+        assertThatThrownBy(() -> lineService.addSection(신분당선, new SectionRequest(강남역, 정자역, 5)))
+                .isInstanceOf(IllegalArgumentException.class);
     }
 
     @Test

--- a/src/test/java/nextstep/subway/unit/LineServiceTest.java
+++ b/src/test/java/nextstep/subway/unit/LineServiceTest.java
@@ -1,12 +1,24 @@
 package nextstep.subway.unit;
 
 import nextstep.subway.applicaion.LineService;
-import nextstep.subway.domain.LineRepository;
-import nextstep.subway.domain.StationRepository;
+import nextstep.subway.applicaion.dto.LineRequest;
+import nextstep.subway.applicaion.dto.LineResponse;
+import nextstep.subway.applicaion.dto.SectionRequest;
+import nextstep.subway.domain.*;
+import org.assertj.core.api.Assertions;
+import org.jgrapht.alg.shortestpath.DijkstraShortestPath;
+import org.jgrapht.graph.DefaultWeightedEdge;
+import org.jgrapht.graph.WeightedMultigraph;
+import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+import java.util.NoSuchElementException;
+
+import static org.assertj.core.api.Assertions.assertThat;
 
 @SpringBootTest
 @Transactional
@@ -20,14 +32,115 @@ public class LineServiceTest {
     private LineService lineService;
 
     @Test
+    @DisplayName("지하철 노선에 새로운 정착역을 바탕으로 구간을 추가한다")
     void addSection() {
         // given
-        // stationRepository와 lineRepository를 활용하여 초기값 셋팅
+        Long 강남역 = 주어진_역_이름을_바탕으로_지하철역을_생성한다("강남역");
+        Long 정자역 = 주어진_역_이름을_바탕으로_지하철역을_생성한다("정자역");
+        Long 신분당선 = 주어진_종착역을_바탕으로_신분당선_노선을_생성한다(강남역, 정자역, 10);
+
+        Long 새로운_종착역 = 주어진_역_이름을_바탕으로_지하철역을_생성한다("새로운_종착역");
 
         // when
-        // lineService.addSection 호출
+        lineService.addSection(신분당선, new SectionRequest(정자역, 새로운_종착역, 5));
 
         // then
-        // line.getSections 메서드를 통해 검증
+        Line line = lineRepository.findById(신분당선).orElseThrow(NoSuchElementException::new);
+        List<Section> sections = line.getSections();
+        Assertions.assertThat(sections.size()).isEqualTo(2);
     }
+
+    @Test
+    @DisplayName("기존 구간의 역을 기준으로 새로운 구간을 추가한다")
+    void addSectionInPreviousSection() {
+        // given
+        Long 강남역 = 주어진_역_이름을_바탕으로_지하철역을_생성한다("강남역");
+        Long 정자역 = 주어진_역_이름을_바탕으로_지하철역을_생성한다("정자역");
+        Long 신분당선 = 주어진_종착역을_바탕으로_신분당선_노선을_생성한다(강남역, 정자역, 10);
+
+        Long 중간역 = 주어진_역_이름을_바탕으로_지하철역을_생성한다("중간역");
+
+        // when
+        lineService.addSection(신분당선, new SectionRequest(강남역, 중간역, 4));
+
+        // then
+        Line line = lineRepository.findById(신분당선).orElseThrow(NoSuchElementException::new);
+        List<Section> sections = line.getSections();
+        Assertions.assertThat(sections.size()).isEqualTo(2);
+        구간들이_위치에_맞게_등록되었는지_검증한다(신분당선, 강남역, 정자역, 중간역);
+    }
+
+    void 구간들이_위치에_맞게_등록되었는지_검증한다(Long lineId, Long 상행_종착역, Long 하행_종착역, Long 중간역) {
+        Line line = lineRepository.findById(lineId).orElseThrow(NoSuchElementException::new);
+        List<Long> stationIds = 주어진_노선에_속하는_구간의_역들을_순서대로_정렬한다(lineId);
+        List<Section> sections = line.getSections();
+
+        final int 상행_종착역_위치 = 0;
+        final int 하행_종착역_위치 = sections.size()-1;
+        final int 중간역_위치 = (상행_종착역_위치 + 하행_종착역_위치)/2;
+
+        Assertions.assertThat(stationIds.get(상행_종착역_위치)).isEqualTo(상행_종착역);
+        Assertions.assertThat(stationIds.get(하행_종착역_위치)).isEqualTo(하행_종착역);
+        Assertions.assertThat(stationIds.get(중간역_위치)).isEqualTo(중간역);
+    }
+
+    Long 주어진_종착역을_바탕으로_신분당선_노선을_생성한다(Long finalUpStationId, Long finalDownStationId, int distance) {
+        LineRequest lineRequest = new LineRequest("신분당선", "red", finalUpStationId, finalDownStationId, distance);
+        return 지하철_노선을_생성한다(lineRequest);
+    }
+
+    List<Long> 주어진_노선에_속하는_구간의_역들을_순서대로_정렬한다(Long lineId) {
+        Line line = lineRepository.findById(lineId).orElseThrow(NoSuchElementException::new);
+        List<Section> sections = line.getSections();
+
+        Long source = line.getFinalUpStationId();
+        Long target = line.getFinalDownStationId();
+
+        WeightedMultigraph<Long, DefaultWeightedEdge> graph = new WeightedMultigraph(DefaultWeightedEdge.class);
+        for (Section s : sections) {
+            graph.addVertex(s.getUpStationId());
+            graph.addVertex(s.getDownStationId());
+            graph.setEdgeWeight(graph.addEdge(s.getUpStationId(), s.getDownStationId()), s.getDistance());
+        }
+
+        DijkstraShortestPath dijkstraShortestPath = new DijkstraShortestPath(graph);
+        List<Long> vertexList = dijkstraShortestPath.getPath(source, target).getVertexList();
+
+        return vertexList;
+    }
+
+    Long 주어진_역_이름을_바탕으로_지하철역을_생성한다(String name) {
+        Station station = new Station(name);
+        station = stationRepository.save(station);
+
+        return station.getId();
+    }
+
+    void 지하철_노선에_구간을_추가한다(Long lineId, Long upStationId, Long downStationId, int distance) {
+        Line line = lineRepository.findById(lineId)
+                .orElseThrow(NoSuchElementException::new);
+        Station 상행역 = stationRepository.findById(upStationId)
+                .orElseThrow(NoSuchElementException::new);
+        Station 하행역 = stationRepository.findById(downStationId)
+                .orElseThrow(NoSuchElementException::new);
+
+        Section 새로운_구간 = new Section(line, 상행역, 하행역, distance);
+        line.addSection(새로운_구간);
+    }
+
+    Long 지하철_노선을_생성한다(LineRequest lineRequest) {
+        LineResponse lineResponse = lineService.saveLine(lineRequest);
+
+        return lineResponse.getId();
+    }
+
+    Long 주어진_역들을_바탕으로_구간을_생성한다(Long upStationId, Long downStationId, int distance) {
+        Station 상행역 = stationRepository.findById(upStationId)
+                .orElseThrow(NoSuchElementException::new);
+        Station 하행역 = stationRepository.findById(downStationId)
+                .orElseThrow(NoSuchElementException::new);
+        return null;
+    }
+
+
 }

--- a/src/test/java/nextstep/subway/unit/LineServiceTest.java
+++ b/src/test/java/nextstep/subway/unit/LineServiceTest.java
@@ -71,17 +71,30 @@ public class LineServiceTest {
     }
 
     void 구간들이_위치에_맞게_등록되었는지_검증한다(Long lineId, Long 상행_종착역, Long 하행_종착역, Long 중간역) {
+        List<Long> sectionIds = 주어진_노선에_속하는_구간의_역들을_순서대로_정렬한다(lineId);
+        Long 상행_종착역_중간역_구간_아이디 = sectionIds.get(0);
+        Long 중간역_하행_종착역_구간_아이디 = sectionIds.get(1);
+
+        Section 상행_종착역_중간역_구간 = 주어진_구간_아이디를_바탕으로_노선의_구간_조회(lineId, 상행_종착역_중간역_구간_아이디);
+        Section 중간역_하행_종착역_구간 = 주어진_구간_아이디를_바탕으로_노선의_구간_조회(lineId, 중간역_하행_종착역_구간_아이디);
+
+        Assertions.assertThat(상행_종착역_중간역_구간.getUpStationId()).isEqualTo(상행_종착역);
+        Assertions.assertThat(상행_종착역_중간역_구간.getDownStationId()).isEqualTo(중간역);
+        Assertions.assertThat(중간역_하행_종착역_구간.getUpStationId()).isEqualTo(중간역);
+        Assertions.assertThat(중간역_하행_종착역_구간.getDownStationId()).isEqualTo(하행_종착역);
+    }
+
+    Section 주어진_구간_아이디를_바탕으로_노선의_구간_조회(Long lineId, Long sectionId) {
         Line line = lineRepository.findById(lineId).orElseThrow(NoSuchElementException::new);
-        List<Long> stationIds = 주어진_노선에_속하는_구간의_역들을_순서대로_정렬한다(lineId);
         List<Section> sections = line.getSections();
 
-        final int 상행_종착역_위치 = 0;
-        final int 하행_종착역_위치 = sections.size()-1;
-        final int 중간역_위치 = (상행_종착역_위치 + 하행_종착역_위치)/2;
+        for (Section section : sections) {
+            if(section.getId() == sectionId) {
+                return section;
+            }
+        }
 
-        Assertions.assertThat(stationIds.get(상행_종착역_위치)).isEqualTo(상행_종착역);
-        Assertions.assertThat(stationIds.get(하행_종착역_위치)).isEqualTo(하행_종착역);
-        Assertions.assertThat(stationIds.get(중간역_위치)).isEqualTo(중간역);
+        throw new NoSuchElementException();
     }
 
     Long 주어진_종착역을_바탕으로_신분당선_노선을_생성한다(Long finalUpStationId, Long finalDownStationId, int distance) {

--- a/src/test/java/nextstep/subway/unit/LineServiceTest.java
+++ b/src/test/java/nextstep/subway/unit/LineServiceTest.java
@@ -71,30 +71,11 @@ public class LineServiceTest {
     }
 
     void 구간들이_위치에_맞게_등록되었는지_검증한다(Long lineId, Long 상행_종착역, Long 하행_종착역, Long 중간역) {
-        List<Long> sectionIds = 주어진_노선에_속하는_구간의_역들을_순서대로_정렬한다(lineId);
-        Long 상행_종착역_중간역_구간_아이디 = sectionIds.get(0);
-        Long 중간역_하행_종착역_구간_아이디 = sectionIds.get(1);
+        List<Long> stationIds = 주어진_노선에_속하는_구간의_역들을_순서대로_정렬한다(lineId);
 
-        Section 상행_종착역_중간역_구간 = 주어진_구간_아이디를_바탕으로_노선의_구간_조회(lineId, 상행_종착역_중간역_구간_아이디);
-        Section 중간역_하행_종착역_구간 = 주어진_구간_아이디를_바탕으로_노선의_구간_조회(lineId, 중간역_하행_종착역_구간_아이디);
-
-        Assertions.assertThat(상행_종착역_중간역_구간.getUpStationId()).isEqualTo(상행_종착역);
-        Assertions.assertThat(상행_종착역_중간역_구간.getDownStationId()).isEqualTo(중간역);
-        Assertions.assertThat(중간역_하행_종착역_구간.getUpStationId()).isEqualTo(중간역);
-        Assertions.assertThat(중간역_하행_종착역_구간.getDownStationId()).isEqualTo(하행_종착역);
-    }
-
-    Section 주어진_구간_아이디를_바탕으로_노선의_구간_조회(Long lineId, Long sectionId) {
-        Line line = lineRepository.findById(lineId).orElseThrow(NoSuchElementException::new);
-        List<Section> sections = line.getSections();
-
-        for (Section section : sections) {
-            if(section.getId() == sectionId) {
-                return section;
-            }
-        }
-
-        throw new NoSuchElementException();
+        Assertions.assertThat(stationIds.get(0)).isEqualTo(상행_종착역);
+        Assertions.assertThat(stationIds.get(1)).isEqualTo(중간역);
+        Assertions.assertThat(stationIds.get(2)).isEqualTo(하행_종착역);
     }
 
     Long 주어진_종착역을_바탕으로_신분당선_노선을_생성한다(Long finalUpStationId, Long finalDownStationId, int distance) {


### PR DESCRIPTION
### 구현 사항
- 초기 노선 등록시 station 정보는 필수적으로 필요하다고 가정 (논리적으로 그게 맞다고 판단하여 진행)
- 노선 등록 (새로운 상행, 하행 종착역 또는 기존 구간에 대해(변경된 스펙 가능)
- 예외 케이스 고려
- 인수테스트, 단위테스트 작성
- 노선에는 상행 종점역, 하행 종점역 정보를 가지고 있도록 변경 (노선이라는 클래스가 가지는 책임에 포함되면 좋은 멤버라고 생각하여 추가)

### 참고 사항
- 861266ab617582bbe4a8ed8bd5b89856f5e357f2 요 커밋의 인수테스트는 기능 구현하기 전에 진행되었어야한 것 같은데 작업 순서가 조금 잘못됬다고 생각하는데 혹시 어떻게 생각하실까요?
- 기존 주어진 코드의 레벨에 맞게 구현하려고 진행했습니다. (세부적인 코드 레벨에서 적용할 수 있는 것들은 고려 x)
- 따로 예외(관련 http 응답코드) 혹은 entity 관련 부분에 대해서는 최소한만으로 신경썼습니다.

기존 휴가 일정이 있었어서 pr이 늦었습니다..
강의의 내용에 집중하여 작업을 진행하고자 노력했으며 그 외의 부분은 필요 불가피한 것이 아니라면 고려하지 않았습니다.
확인해주시면 감사하겠습니다!