### PR TITLE
🚀 2단계: 지하철 구간 제거 기능 개선

### DIFF
--- a/src/main/java/nextstep/subway/global/error/code/ErrorCode.java
+++ b/src/main/java/nextstep/subway/global/error/code/ErrorCode.java
@@ -12,7 +12,6 @@ public enum ErrorCode {
 
     INVALID_DISTANCE("기존 역 사이 길이보다 크거나 같으면 등록을 할 수 없다."),
     ALREADY_REGISTERED_SECTION("이미 등록되어있는 노선입니다."),
-    IS_NOT_LAST_LINE_SECTION("지하철 노선의 마지막 구간이 아닙니다."),
     UNREGISTERED_STATION("지하철 노선에 등록되어 있지 않은 역입니다."),
     STAND_ALONE_LINE_SECTION("지하철 노선에 구간이 1개만 존재할 경우 삭제할 수 없습니다.");
 

--- a/src/main/java/nextstep/subway/line/entity/Line.java
+++ b/src/main/java/nextstep/subway/line/entity/Line.java
@@ -45,8 +45,7 @@ public class Line {
                             .distance(distance)
                             .build()
                     );
-                }},
-                distance
+                }}
         );
     }
 

--- a/src/main/java/nextstep/subway/section/entity/Sections.java
+++ b/src/main/java/nextstep/subway/section/entity/Sections.java
@@ -26,7 +26,7 @@ public class Sections {
     @CollectionTable(name = "section", joinColumns = @JoinColumn(name = "line_id"))
     private List<Section> sections = new ArrayList<>();
 
-    private static int INVALID_INDEX = -1;
+    private static final int INVALID_INDEX = -1;
 
     public void addSection(Section section) {
         if (sections.isEmpty()) {

--- a/src/test/java/nextstep/subway/unit/LineServiceMockTest.java
+++ b/src/test/java/nextstep/subway/unit/LineServiceMockTest.java
@@ -71,14 +71,18 @@ public class LineServiceMockTest {
     }
 
     @Test
-    @DisplayName("지하철 노선의 하행 종점역에 구간을 추가한다.")
-    void addLastLineSection() {
+    @DisplayName("지하철 노선의 상행 종점역이 하행역인 구간을 추가한다.")
+    void addFirstLineSection() {
         // given
-        given(stationRepository.findById(강남역.getId())).willReturn(Optional.of(강남역));
-        given(stationRepository.findById(신촌역.getId())).willReturn(Optional.of(신촌역));
+        given(stationRepository.findById(신도림역.getId())).willReturn(Optional.of(신도림역));
+        given(stationRepository.findById(까치산역.getId())).willReturn(Optional.of(까치산역));
         given(lineRepository.findById(이호선.getId())).willReturn(Optional.of(이호선));
 
-        SaveLineSectionRequestDto saveLineSectionRequestDto = 이호선에_강남역이_하행_종점역인_구간을_생성한다(신촌역.getId());
+        SaveLineSectionRequestDto saveLineSectionRequestDto = SaveLineSectionRequestDto.builder()
+                .upStationId(신도림역.getId())
+                .downStationId(까치산역.getId())
+                .distance(5)
+                .build();
 
         // when
         LineResponseDto responseDto = lineService.saveLineSection(이호선.getId(), saveLineSectionRequestDto);
@@ -90,9 +94,9 @@ public class LineServiceMockTest {
                 .collect(Collectors.toList());
 
         assertThat(등록된_지하철역_아이디_목록).containsExactly(
+                신도림역.getId(),
                 까치산역.getId(),
-                신촌역.getId(),
-                강남역.getId()
+                신촌역.getId()
         );
     }
 
@@ -124,18 +128,14 @@ public class LineServiceMockTest {
     }
 
     @Test
-    @DisplayName("지하철 노선의 상행 종점역이 하행역인 구간을 추가한다.")
-    void addFirstLineSection() {
+    @DisplayName("지하철 노선의 하행 종점역에 구간을 추가한다.")
+    void addLastLineSection() {
         // given
-        given(stationRepository.findById(신도림역.getId())).willReturn(Optional.of(신도림역));
-        given(stationRepository.findById(까치산역.getId())).willReturn(Optional.of(까치산역));
+        given(stationRepository.findById(강남역.getId())).willReturn(Optional.of(강남역));
+        given(stationRepository.findById(신촌역.getId())).willReturn(Optional.of(신촌역));
         given(lineRepository.findById(이호선.getId())).willReturn(Optional.of(이호선));
 
-        SaveLineSectionRequestDto saveLineSectionRequestDto = SaveLineSectionRequestDto.builder()
-                .upStationId(신도림역.getId())
-                .downStationId(까치산역.getId())
-                .distance(5)
-                .build();
+        SaveLineSectionRequestDto saveLineSectionRequestDto = 이호선에_강남역이_하행_종점역인_구간을_생성한다(신촌역.getId());
 
         // when
         LineResponseDto responseDto = lineService.saveLineSection(이호선.getId(), saveLineSectionRequestDto);
@@ -147,9 +147,9 @@ public class LineServiceMockTest {
                 .collect(Collectors.toList());
 
         assertThat(등록된_지하철역_아이디_목록).containsExactly(
-                신도림역.getId(),
                 까치산역.getId(),
-                신촌역.getId()
+                신촌역.getId(),
+                강남역.getId()
         );
     }
 
@@ -224,8 +224,56 @@ public class LineServiceMockTest {
     }
 
     @Test
-    @DisplayName("노선의 마지막 구간을 삭제한다.")
-    void deleteSection() {
+    @DisplayName("노선의 상행 종점역을 삭제한다.")
+    void deleteUpStation() {
+        // given
+        given(stationRepository.findById(강남역.getId())).willReturn(Optional.of(강남역));
+        given(stationRepository.findById(신촌역.getId())).willReturn(Optional.of(신촌역));
+        given(lineRepository.findById(이호선.getId())).willReturn(Optional.of(이호선));
+        SaveLineSectionRequestDto saveLineSectionRequestDto = 이호선에_강남역이_하행_종점역인_구간을_생성한다(신촌역.getId());
+        LineResponseDto responseDto = lineService.saveLineSection(이호선.getId(), saveLineSectionRequestDto);
+
+        // when
+        Long 노선의_상행_종점역_아이디 = 지하철_노선의_성행_종점역_아이디를_찾는다(responseDto);
+        lineService.deleteLineSectionByStationId(이호선.getId(), 노선의_상행_종점역_아이디);
+
+        // then
+        List<Long> 노선에_등록된_역_아이디_목록 = 이호선.getSections()
+                .getAllStations()
+                .stream()
+                .map(Station::getId)
+                .collect(Collectors.toList());
+
+        assertThat(노선에_등록된_역_아이디_목록).doesNotContain(노선의_상행_종점역_아이디);
+    }
+
+    @Test
+    @DisplayName("노선의 중간역을 삭제한다.")
+    void deleteMiddleStation() {
+        // given
+        given(stationRepository.findById(강남역.getId())).willReturn(Optional.of(강남역));
+        given(stationRepository.findById(신촌역.getId())).willReturn(Optional.of(신촌역));
+        given(lineRepository.findById(이호선.getId())).willReturn(Optional.of(이호선));
+        SaveLineSectionRequestDto saveLineSectionRequestDto = 이호선에_강남역이_하행_종점역인_구간을_생성한다(신촌역.getId());
+        lineService.saveLineSection(이호선.getId(), saveLineSectionRequestDto);
+
+        // when
+        Long 노선의_중간역_아이디 = saveLineSectionRequestDto.getUpStationId();
+        lineService.deleteLineSectionByStationId(이호선.getId(), 노선의_중간역_아이디);
+
+        // then
+        List<Long> 노선에_등록된_역_아이디_목록 = 이호선.getSections()
+                .getAllStations()
+                .stream()
+                .map(Station::getId)
+                .collect(Collectors.toList());
+
+        assertThat(노선에_등록된_역_아이디_목록).doesNotContain(노선의_중간역_아이디);
+    }
+
+    @Test
+    @DisplayName("노선의 하행 종점역을 삭제한다.")
+    void deleteDownStation() {
         // given
         given(stationRepository.findById(강남역.getId())).willReturn(Optional.of(강남역));
         given(stationRepository.findById(신촌역.getId())).willReturn(Optional.of(신촌역));
@@ -287,6 +335,12 @@ public class LineServiceMockTest {
                 .downStationId(신도림역.getId())
                 .distance(distance)
                 .build();
+    }
+
+    private Long 지하철_노선의_성행_종점역_아이디를_찾는다(LineResponseDto lineResponseDto) {
+        return lineResponseDto.getStations()
+                .get(0)
+                .getId();
     }
 
     private Long 지하철_노선의_하행_종점역_아이디를_찾는다(Line line) {

--- a/src/test/java/nextstep/subway/unit/LineServiceTest.java
+++ b/src/test/java/nextstep/subway/unit/LineServiceTest.java
@@ -66,28 +66,28 @@ public class LineServiceTest {
     }
 
     @Test
-    @DisplayName("지하철 노선의 하행 종점역에 구간을 추가한다.")
-    void addLastLineSection() {
-        // when: 신사역 - 판교역 노선에 판교역 - 광교역 노선을 추가
-        SaveLineSectionRequestDto 판교역_광교역_노선 = SaveLineSectionRequestDto.builder()
-                .upStationId(판교역.getId())
-                .downStationId(광교역.getId())
-                .distance(5)
+    @DisplayName("지하철 노선의 상행 종점역이 하행역인 구간을 추가한다.")
+    void addFirstLineSection() {
+        // when: 신사역 - 판교역 노선에 강남역 - 신사역 노선을 추가
+        SaveLineSectionRequestDto 강남역_신사역_노선 = SaveLineSectionRequestDto.builder()
+                .upStationId(강남역.getId())
+                .downStationId(신사역.getId())
+                .distance(15)
                 .build();
 
-        LineResponseDto lineResponseDto = lineService.saveLineSection(신분당선.getId(), 판교역_광교역_노선);
+        LineResponseDto lineResponseDto = lineService.saveLineSection(신분당선.getId(), 강남역_신사역_노선);
 
-        // then: 신사역 - 판교역 - 광교역이 조회
+        // then: 강남역 - 신사역 - 판교역이 조회
         List<Long> 등록된_지하철역_아이디_목록 = lineResponseDto.getStations()
                 .stream()
                 .map(StationResponseDto::getId)
                 .collect(Collectors.toList());
 
         assertThat(등록된_지하철역_아이디_목록).containsExactly(
-                        신사역.getId(),
-                        판교역.getId(),
-                        광교역.getId()
-                );
+                강남역.getId(),
+                신사역.getId(),
+                판교역.getId()
+        );
     }
 
     @Test
@@ -116,28 +116,28 @@ public class LineServiceTest {
     }
 
     @Test
-    @DisplayName("지하철 노선의 상행 종점역이 하행역인 구간을 추가한다.")
-    void addFirstLineSection() {
-        // when: 신사역 - 판교역 노선에 강남역 - 신사역 노선을 추가
-        SaveLineSectionRequestDto 강남역_신사역_노선 = SaveLineSectionRequestDto.builder()
-                .upStationId(강남역.getId())
-                .downStationId(신사역.getId())
-                .distance(15)
+    @DisplayName("지하철 노선의 하행 종점역에 구간을 추가한다.")
+    void addLastLineSection() {
+        // when: 신사역 - 판교역 노선에 판교역 - 광교역 노선을 추가
+        SaveLineSectionRequestDto 판교역_광교역_노선 = SaveLineSectionRequestDto.builder()
+                .upStationId(판교역.getId())
+                .downStationId(광교역.getId())
+                .distance(5)
                 .build();
 
-        LineResponseDto lineResponseDto = lineService.saveLineSection(신분당선.getId(), 강남역_신사역_노선);
+        LineResponseDto lineResponseDto = lineService.saveLineSection(신분당선.getId(), 판교역_광교역_노선);
 
-        // then: 강남역 - 신사역 - 판교역이 조회
+        // then: 신사역 - 판교역 - 광교역이 조회
         List<Long> 등록된_지하철역_아이디_목록 = lineResponseDto.getStations()
                 .stream()
                 .map(StationResponseDto::getId)
                 .collect(Collectors.toList());
 
         assertThat(등록된_지하철역_아이디_목록).containsExactly(
-                강남역.getId(),
-                신사역.getId(),
-                판교역.getId()
-        );
+                        신사역.getId(),
+                        판교역.getId(),
+                        광교역.getId()
+                );
     }
 
     @Test
@@ -205,8 +205,60 @@ public class LineServiceTest {
     }
 
     @Test
-    @DisplayName("노선의 마지막 구간을 삭제한다.")
-    void deleteSection() {
+    @DisplayName("노선의 상행 종점역을 삭제한다.")
+    void deleteUpStation() {
+        // given
+        SaveLineSectionRequestDto 광교역이_하행_종점역인_구간 = SaveLineSectionRequestDto.builder()
+                .upStationId(노선의_하행_종점역_아이디를_찾는다(신분당선))
+                .downStationId(광교역.getId())
+                .distance(13)
+                .build();
+
+        LineResponseDto lineResponseDto = lineService.saveLineSection(신분당선.getId(), 광교역이_하행_종점역인_구간);
+
+        // when
+        Long 노선의_상행_종점역_아이디 = 노선의_상행_종점역_아이디를_찾는다(lineResponseDto);
+        lineService.deleteLineSectionByStationId(신분당선.getId(), 노선의_상행_종점역_아이디);
+
+        // then
+        List<Long> 노선에_등록된_역_아이디_목록 = lineService.findLineById(lineResponseDto.getId())
+                .getStations()
+                .stream()
+                .map(StationResponseDto::getId)
+                .collect(Collectors.toList());
+
+        assertThat(노선에_등록된_역_아이디_목록).doesNotContain(노선의_상행_종점역_아이디);
+    }
+
+    @Test
+    @DisplayName("노선의 중간역을 삭제한다.")
+    void deleteMiddleStation() {
+        // given
+        SaveLineSectionRequestDto 광교역이_하행_종점역인_구간 = SaveLineSectionRequestDto.builder()
+                .upStationId(노선의_하행_종점역_아이디를_찾는다(신분당선))
+                .downStationId(광교역.getId())
+                .distance(13)
+                .build();
+
+        LineResponseDto lineResponseDto = lineService.saveLineSection(신분당선.getId(), 광교역이_하행_종점역인_구간);
+
+        // when
+        Long 노선의_중간역_아이디 = 광교역이_하행_종점역인_구간.getUpStationId();
+        lineService.deleteLineSectionByStationId(신분당선.getId(), 노선의_중간역_아이디);
+
+        // then
+        List<Long> 노선에_등록된_역_아이디_목록 = lineService.findLineById(lineResponseDto.getId())
+                .getStations()
+                .stream()
+                .map(StationResponseDto::getId)
+                .collect(Collectors.toList());
+
+        assertThat(노선에_등록된_역_아이디_목록).doesNotContain(노선의_중간역_아이디);
+    }
+
+    @Test
+    @DisplayName("노선의 하행 종점역을 삭제한다.")
+    void deleteDownStation() {
         // given
         SaveLineSectionRequestDto 광교역이_하행_종점역인_구간 = SaveLineSectionRequestDto.builder()
                 .upStationId(노선의_하행_종점역_아이디를_찾는다(신분당선))
@@ -246,6 +298,12 @@ public class LineServiceTest {
         assertThatThrownBy(() -> lineService.deleteLineSectionByStationId(신분당선.getId(), 판교역.getId()))
                 .isInstanceOf(InvalidLineSectionException.class)
                 .hasMessageContaining(ErrorCode.STAND_ALONE_LINE_SECTION.getMessage());
+    }
+
+    private long 노선의_상행_종점역_아이디를_찾는다(LineResponseDto lineResponseDto) {
+        return lineResponseDto.getStations()
+                .get(0)
+                .getId();
     }
 
     private Long 노선의_하행_종점역_아이디를_찾는다(Line line) {

--- a/src/test/java/nextstep/subway/unit/LineTest.java
+++ b/src/test/java/nextstep/subway/unit/LineTest.java
@@ -143,6 +143,44 @@ class LineTest {
     }
 
     @Test
+    @DisplayName("지하철 노선의 첫번째 구간을 삭제한다.")
+    void removeFirstSection() {
+        // given
+        Section 판교역_광교역_구간 = new Section(판교역, 광교역, 5);
+        sections.addSection(판교역_광교역_구간);
+
+        // when
+        sections.deleteSectionByStationId(강남역.getId());
+
+        // then
+        List<Station> 노선에_등록된_역_목록 = sections.getAllStations();
+
+        assertAll(
+                () -> assertThat(노선에_등록된_역_목록).doesNotContain(강남역),
+                () -> assertThat(sections.getTotalDistance()).isEqualTo(5)
+        );
+    }
+
+    @Test
+    @DisplayName("지하철 노선의 중간 구간을 삭제한다.")
+    void removeMiddleSection() {
+        // given
+        Section 판교역_광교역_구간 = new Section(판교역, 광교역, 5);
+        sections.addSection(판교역_광교역_구간);
+
+        // when
+        sections.deleteSectionByStationId(판교역.getId());
+
+        // then
+        List<Station> 노선에_등록된_역_목록 = sections.getAllStations();
+
+        assertAll(
+                () -> assertThat(노선에_등록된_역_목록).doesNotContain(광교역),
+                () -> assertThat(sections.getTotalDistance()).isEqualTo(28)
+        );
+    }
+
+    @Test
     @DisplayName("지하철의 노선의 마지막 구간을 삭제한다.")
     void removeSection() {
         // given
@@ -159,19 +197,6 @@ class LineTest {
                 () -> assertThat(노선에_등록된_역_목록).doesNotContain(광교역),
                 () -> assertThat(sections.getTotalDistance()).isEqualTo(23)
         );
-    }
-
-    @Test
-    @DisplayName("지하철 노선의 중간 구간을 삭제한다.")
-    void removeMiddleSection() {
-        // given
-        Section 판교역_광교역_구간 = new Section(판교역, 광교역, 5);
-        sections.addSection(판교역_광교역_구간);
-
-        // when & then
-        assertThatThrownBy(() -> sections.deleteSectionByStationId(판교역.getId()))
-                .isInstanceOf(InvalidLineSectionException.class)
-                .hasMessageContaining(ErrorCode.IS_NOT_LAST_LINE_SECTION.getMessage());
     }
 
     @Test

--- a/src/test/java/nextstep/subway/unit/LineTest.java
+++ b/src/test/java/nextstep/subway/unit/LineTest.java
@@ -150,13 +150,13 @@ class LineTest {
         sections.addSection(판교역_광교역_구간);
 
         // when
-        sections.deleteSectionByStationId(강남역.getId());
+        sections.deleteSectionByStationId(신사역.getId());
 
         // then
         List<Station> 노선에_등록된_역_목록 = sections.getAllStations();
 
         assertAll(
-                () -> assertThat(노선에_등록된_역_목록).doesNotContain(강남역),
+                () -> assertThat(노선에_등록된_역_목록).doesNotContain(신사역),
                 () -> assertThat(sections.getTotalDistance()).isEqualTo(5)
         );
     }
@@ -175,7 +175,7 @@ class LineTest {
         List<Station> 노선에_등록된_역_목록 = sections.getAllStations();
 
         assertAll(
-                () -> assertThat(노선에_등록된_역_목록).doesNotContain(광교역),
+                () -> assertThat(노선에_등록된_역_목록).doesNotContain(판교역),
                 () -> assertThat(sections.getTotalDistance()).isEqualTo(28)
         );
     }


### PR DESCRIPTION
안녕하세요!
리뷰 부탁드립니다 🙏

# 1단계 코멘트에 따른 개선 사항
- [x] 조건문안의 내용을 메서드화하기
- [x] 매직 넘버 상수화
- [x] `Sections`에 `totalDistance` 프로퍼티 삭제

# 기능 요구사항
- [x] 요구사항 설명에서 제공되는 추가된 요구사항을 기반으로 지하철 구간 관리 기능 리팩터링
- [x] 추가된 요구사항을 정의한 인수 조건 도출
- [x] 인수 조건을 검증하는 인수 테스트 작성
- [x] 예외 케이스에 대한 검증

# 요구사항 설명

- [x] 구간 삭제에 대한 제약 사항 변경 구현
  - [x] 기존에는 마지막 역 삭제만 가능했는데 위치에 상관 없이 삭제가 가능하도록 수정
  - [x] 종점이 제거될 경우 다음으로 오던 역이 종점이 됨
  - [x] 중간역이 제거될 경우 재배치를 함
    - [x] 노선에 A - B - C 역이 연결되어 있을 때 B역을 제거할 경우 A - C로 재배치 됨
    - [x] 거리는 두 구간의 거리의 합으로 정함

## 예외케이스
- [x] 구간이 하나인 노선에서 마지막 구간을 제거할 때 제거할 수 없음
- [x] 노선에 등록되어있지 않은 역을 제거할 때 제거할 수 없음
