### PR TITLE
2단계 - 지하철 구간 제거 기능 개선

### DIFF
--- a/src/main/java/nextstep/subway/applicaion/LineService.java
+++ b/src/main/java/nextstep/subway/applicaion/LineService.java
@@ -159,42 +159,6 @@ public class LineService {
         Line line = lineRepository.findById(lineId).orElseThrow(IllegalArgumentException::new);
         Station station = stationService.findById(stationId);
 
-        line.validateSectionDeleteRequest(station);
-
-        List<Section> sections = line.getSections();
-        List<Section> filteredSections = sections.stream()
-                .filter(
-                        s -> s.checkBelongingStationId(stationId)
-                ).collect(Collectors.toList());
-
-        //중간에 위치한 경우
-        if(filteredSections.size() > 1) {
-            Section first, second;
-
-            if(filteredSections.get(0).getUpStationId() == stationId) {
-                first = filteredSections.get(1);
-                second = filteredSections.get(0);
-            } else {
-                first = filteredSections.get(0);
-                second = filteredSections.get(1);
-            }
-
-            first.updateDownStation(second.getDownStation());
-            first.updateDistance(first.getDistance() + second.getDistance());
-
-            line.deleteSection(second);
-
-            return;
-        }
-
-        //상행 종착 구간에 위치한 경우
-        if (filteredSections.get(0).getUpStationId() == stationId) {
-            line.updateFinalUpStationId(filteredSections.get(0).getDownStationId());
-        } else {
-            // 하행 종착 구간에 위치한 경우
-            line.updateFinalDownStationId(filteredSections.get(0).getUpStationId());
-        }
-
-        line.deleteSection(filteredSections.get(0));
+        line.deleteSection(station);
     }
 }

--- a/src/main/java/nextstep/subway/applicaion/LineService.java
+++ b/src/main/java/nextstep/subway/applicaion/LineService.java
@@ -164,7 +164,7 @@ public class LineService {
         List<Section> sections = line.getSections();
         List<Section> filteredSections = sections.stream()
                 .filter(
-                        s -> (s.getUpStationId() == stationId) || (s.getDownStationId() == stationId)
+                        s -> s.checkBelongingStationId(stationId)
                 ).collect(Collectors.toList());
 
         //중간에 위치한 경우

--- a/src/main/java/nextstep/subway/domain/Line.java
+++ b/src/main/java/nextstep/subway/domain/Line.java
@@ -50,8 +50,54 @@ public class Line {
         this.color = color;
     }
 
-    public void deleteSection(Section section) {
-        sections.remove(section);
+    public void deleteSection(Station station) {
+        validateSectionDeleteRequest(station);
+
+        List<Section> filteredSections = sections.stream()
+                .filter(
+                        s -> s.checkBelongingStationId(station.getId())
+                ).collect(Collectors.toList());
+
+        //중간에 위치한 경우
+        if (deleteMiddlePositionSection(station, filteredSections)) {
+            return;
+        }
+
+        //상행 종착 구간에 위치한 경우
+        deleteLastPositionSection(station, filteredSections);
+    }
+
+    private void deleteLastPositionSection(Station station, List<Section> filteredSections) {
+        if (filteredSections.get(0).getUpStationId() == station.getId()) {
+            updateFinalUpStationId(filteredSections.get(0).getDownStationId());
+        } else {
+            // 하행 종착 구간에 위치한 경우
+            updateFinalDownStationId(filteredSections.get(0).getUpStationId());
+        }
+
+        sections.remove(filteredSections.get(0));
+    }
+
+    private boolean deleteMiddlePositionSection(Station station, List<Section> filteredSections) {
+        if(filteredSections.size() > 1) {
+            Section first, second;
+
+            if(filteredSections.get(0).getUpStationId() == station.getId()) {
+                first = filteredSections.get(1);
+                second = filteredSections.get(0);
+            } else {
+                first = filteredSections.get(0);
+                second = filteredSections.get(1);
+            }
+
+            first.updateDownStation(second.getDownStation());
+            first.updateDistance(first.getDistance() + second.getDistance());
+
+            sections.remove(second);
+
+            return true;
+        }
+        return false;
     }
 
     public Long getFinalUpStationId() {

--- a/src/main/java/nextstep/subway/domain/Line.java
+++ b/src/main/java/nextstep/subway/domain/Line.java
@@ -3,6 +3,9 @@ package nextstep.subway.domain;
 import javax.persistence.*;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Set;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
 @Entity
 public class Line {
@@ -74,5 +77,41 @@ public class Line {
 
     public void updateFinalDownStationId(Long finalDownStationId) {
         this.finalDownStationId = finalDownStationId;
+    }
+
+    public void validateAddSectionConditions(Long newUpStationId, Long newDownStationId) {
+        Set<Long> stationIds = getSectionContainStationsSet();
+
+        if (stationIds.contains(newUpStationId) && stationIds.contains(newDownStationId)) {
+            throw new IllegalArgumentException();
+        }
+
+        if (!stationIds.contains(newUpStationId) && !stationIds.contains(newDownStationId)) {
+            throw new IllegalArgumentException();
+        }
+    }
+
+    public void validateSectionDeleteRequest(Station targetStation) {
+        if (sections.size() <= 1) {
+            throw new UnsupportedOperationException();
+        }
+
+        Set<Long> sectionContainStationsSet = getSectionContainStationsSet();
+        if (!sectionContainStationsSet.contains(targetStation.getId())) {
+            throw new IllegalArgumentException();
+        }
+    }
+
+    private Set<Long> getSectionContainStationsSet() {
+        List<Long> sectionUpStationIds = sections.stream()
+                .map(s -> s.getUpStationId())
+                .collect(Collectors.toList());
+        List<Long> sectionDownStationIds = sections.stream()
+                .map(s -> s.getDownStationId())
+                .collect(Collectors.toList());
+
+        return Stream.of(sectionUpStationIds, sectionDownStationIds)
+                .flatMap(x -> x.stream())
+                .collect(Collectors.toSet());
     }
 }

--- a/src/main/java/nextstep/subway/domain/Line.java
+++ b/src/main/java/nextstep/subway/domain/Line.java
@@ -47,6 +47,10 @@ public class Line {
         this.color = color;
     }
 
+    public void deleteSection(Section section) {
+        sections.remove(section);
+    }
+
     public Long getFinalUpStationId() {
         return finalUpStationId;
     }

--- a/src/main/java/nextstep/subway/domain/Section.java
+++ b/src/main/java/nextstep/subway/domain/Section.java
@@ -76,4 +76,8 @@ public class Section {
     public void updateDistance(int distance){
         this.distance = distance;
     }
+
+    public boolean checkBelongingStationId(Long stationId) {
+        return (getUpStationId() == stationId) || (getDownStationId() == stationId);
+    }
 }

--- a/src/test/java/nextstep/subway/acceptance/LineSectionAcceptanceTest.java
+++ b/src/test/java/nextstep/subway/acceptance/LineSectionAcceptanceTest.java
@@ -87,14 +87,11 @@ class LineSectionAcceptanceTest extends AcceptanceTest {
     void 중간역_삭제_후_재배치까지_정상적인지_검증한다(ExtractableResponse<Response> response,
                                    Long targetUpStationId,
                                    Long targetDownStationId) {
-        assertThat(response.statusCode()).isNotEqualTo(HttpStatus.OK.value());
+        assertThat(response.statusCode()).isEqualTo(HttpStatus.OK.value());
         ExtractableResponse<Response> 노선_조회_결과 = 지하철_노선_조회_요청(신분당선);
-        List<Long> 구간_아이디_리스트 = 노선_조회_결과.jsonPath().getList("stations.id", Long.class);
-        assertThat(구간_아이디_리스트.size()).isEqualTo(1);
-        assertThat(구간_아이디_리스트).containsExactly(targetUpStationId, targetDownStationId);
-        int 거리 = 노선_조회_결과.jsonPath().getInt("stations.distance");
-        int 기존_구간_합산_거리 = 16;
-        assertThat(거리).isEqualTo(기존_구간_합산_거리);
+        List<Long> 역_아이디_리스트 = 노선_조회_결과.jsonPath().getList("stations.id", Long.class);
+        assertThat(역_아이디_리스트.size()).isEqualTo(2);
+        assertThat(역_아이디_리스트).containsExactly(targetUpStationId, targetDownStationId);
     }
 
     /**

--- a/src/test/java/nextstep/subway/acceptance/LineSteps.java
+++ b/src/test/java/nextstep/subway/acceptance/LineSteps.java
@@ -15,6 +15,7 @@ public class LineSteps {
         params.put("color", color);
         params.put("upStationId", upStationId.toString());
         params.put("downStationId", downStationId.toString());
+        params.put("distance", "10");
 
         return RestAssured
                 .given().log().all()


### PR DESCRIPTION
### 구현 사항
- 한 구간만 남았을 경우 삭제 실패
- 중간에 위치한 구간을 제거할 경우 합침
- 마지막 구간을 제거할 경우 line의 종착역 정보 update
- 인수테스트 작성


### 참고 사항
- 시간 복잡도 및 공간 복잡도는 고려하지 않았습니다.
- 요구사항에 주어진 로직 외에 다른 부분들은 고려하지 않았습니다. 
(위 두 사항들 모두 현재 다른 일정들과 조율하면서 어쩔 수 없이 타협 본 부분이지만 관련 좋은 코멘트를 남겨주시면 흡수하도록 노력하겠습니다!)