### PR TITLE
Step1 2주차 구간 추가 기능 구현 완료하였습니다!

### DIFF
--- a/src/main/java/nextstep/subway/domain/Line.java
+++ b/src/main/java/nextstep/subway/domain/Line.java
@@ -15,15 +15,18 @@ import lombok.NoArgsConstructor;
 
 @Entity
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
-@Getter
 public class Line {
+    @Getter
     @Embedded
     private final Sections sections = new Sections();
     @Id
+    @Getter
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
+    @Getter
     @Column(length = 25, nullable = false)
     private String name;
+    @Getter
     @Column(length = 25, nullable = false)
     private String color;
 
@@ -50,7 +53,7 @@ public class Line {
     }
 
     public void addSection(Section section) {
-        sections.addSection(section);
+        sections.addSection(section, this);
     }
 
     public void deleteSection(Station station) {

--- a/src/main/java/nextstep/subway/domain/Section.java
+++ b/src/main/java/nextstep/subway/domain/Section.java
@@ -1,5 +1,7 @@
 package nextstep.subway.domain;
 
+import java.util.Arrays;
+import java.util.List;
 import javax.persistence.Column;
 import javax.persistence.Entity;
 import javax.persistence.GeneratedValue;
@@ -8,6 +10,7 @@ import javax.persistence.Id;
 import javax.persistence.JoinColumn;
 import javax.persistence.ManyToOne;
 import javax.persistence.OneToOne;
+import javax.persistence.Transient;
 import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
@@ -46,5 +49,21 @@ public class Section {
 
     public static Section of(Line line, Long distance, Station upStation, Station downStation) {
         return Section.builder().distance(distance).line(line).upStation(upStation).downStation(downStation).build();
+    }
+
+    public boolean containsSameStations(Section otherSection){
+        return (upStation.equals(otherSection.getUpStation()) && downStation.equals(otherSection.getDownStation()));
+    }
+    public boolean containSameUpStation(Section otherSection){
+        return (upStation.equals(otherSection.getUpStation()));
+    }
+    public boolean containSameDownStation(Section otherSection){
+        return (downStation.equals(otherSection.getDownStation()));
+    }
+    private List<Station> getStations(){
+        return Arrays.asList(upStation, downStation);
+    }
+    public boolean containSameStation(Section otherSection){
+        return (getStations().contains(otherSection.getUpStation()) || getStations().contains(otherSection.getDownStation()));
     }
 }

--- a/src/main/java/nextstep/subway/domain/Sections.java
+++ b/src/main/java/nextstep/subway/domain/Sections.java
@@ -3,6 +3,8 @@ package nextstep.subway.domain;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
+import java.util.Optional;
+import java.util.stream.Collectors;
 import javax.persistence.CascadeType;
 import javax.persistence.Embeddable;
 import javax.persistence.OneToMany;
@@ -10,54 +12,117 @@ import javax.persistence.OneToMany;
 @Embeddable
 public class Sections {
 
-    @OneToMany(mappedBy = "line", cascade = CascadeType.PERSIST, orphanRemoval = true)
-    private final List<Section> sections = new ArrayList<>();
+  @OneToMany(mappedBy = "line", cascade = CascadeType.PERSIST, orphanRemoval = true)
+  private final List<Section> sections = new ArrayList<>();
 
-    public void addSection(Section section) {
-        if (sections.isEmpty()) {
-            sections.add(section);
-            return;
-        }
-        Section lastSection = sections.get(sections.size() - 1);
+  private static void compareDistance(Section section, Section registeredSection) {
+    if (registeredSection.getDistance() - section.getDistance() <= 0) {
+      throw new IllegalArgumentException("추가하려고하는 구간의 거리가 추가되는 구간의 거리보다 큽니다!!");
+    }
+  }
 
-        if (getStations().contains(section.getDownStation())) {
-            throw new IllegalStateException("하행선이 이미 추가 되어 있습니다.");
-        }
-
-        if (!lastSection.getDownStation().equals(section.getUpStation())) {
-            throw new IllegalStateException("Section에 추가할 수 있는 Station이 없습니다.");
-        }
-
-        sections.add(section);
+  public void addSection(Section section, Line line) {
+    if (sections.isEmpty()) {
+      sections.add(section);
+      return;
     }
 
-    public void deleteSection(Station downStation) {
-        if (sections.stream().count() <= 1) {
-            throw new IllegalStateException("Section에 삭제할 수 있는 Station이 없습니다.");
-        }
-        Section lastSection = getLastSection();
-        if (!lastSection.getDownStation().equals(downStation)) {
-            throw new IllegalStateException("Section에 삭제할 수 있는 Station이 없습니다.");
-        }
-        getStations().stream().filter(station -> station.equals(downStation)).findAny().ifPresent(x -> new IllegalStateException("Section에 삭제할 수 있는 Station이 없습니다."));
-        sections.remove(sections.size()-1);
+    alreadyRegisteredValidate(section);
+    notRegisteredValidate(section);
+
+    Optional<Section> upMatch = sections.stream()
+        .filter(registeredSection -> registeredSection.containSameUpStation(section))
+        .findAny();
+    Optional<Section> downMatch = sections.stream()
+        .filter(registeredSection -> registeredSection.containSameDownStation(section))
+        .findFirst();
+
+    if (upMatch.isPresent()) {
+      Section registeredSection = upMatch.get();
+      compareDistance(section, registeredSection);
+      sections.add(
+          Section.of(line, registeredSection.getDistance() - section.getDistance(),
+              section.getDownStation(), registeredSection.getDownStation()));
+      sections.remove(registeredSection);
+    }
+    if (downMatch.isPresent()) {
+      Section registeredSection = downMatch.get();
+      compareDistance(section, registeredSection);
+      sections.add(
+          Section.of(line, registeredSection.getDistance() - section.getDistance(),
+              registeredSection.getUpStation(), section.getUpStation()));
+      sections.remove(registeredSection);
+    }
+    sections.add(section);
+  }
+
+  private void alreadyRegisteredValidate(Section registeredSection) {
+    sections.stream().filter(section -> !section.containsSameStations(registeredSection))
+        .findFirst().orElseThrow(() -> new IllegalArgumentException("동일한 Section이 존재합니다."));
+  }
+
+  private void notRegisteredValidate(Section registeredSection) {
+    if (!getStations().contains(registeredSection.getUpStation()) && !getStations().contains(
+        registeredSection.getDownStation())) {
+      throw new IllegalArgumentException("등록된 Station이 해당 노선에 존재하지 않습니다.");
+    }
+  }
+
+  public void deleteSection(Station downStation) {
+    if (sections.stream().count() <= 1) {
+      throw new IllegalStateException("Section에 삭제할 수 있는 Station이 없습니다.");
+    }
+    Section lastSection = getLastSection();
+    if (!lastSection.getDownStation().equals(downStation)) {
+      throw new IllegalStateException("Section에 삭제할 수 있는 Station이 없습니다.");
+    }
+    getStations().stream().filter(station -> station.equals(downStation)).findAny()
+        .ifPresent(x -> new IllegalStateException("Section에 삭제할 수 있는 Station이 없습니다."));
+    sections.remove(sections.size() - 1);
+  }
+
+  public List<Station> getStations() {
+    if (sections.isEmpty()) {
+      return Collections.emptyList();
+    }
+    List<Station> stationList = new ArrayList<>();
+    List<Station> getDownStations = new ArrayList<>();
+    Section topSection = sections.stream().filter(section ->
+            !(getDownStations().contains(section.getUpStation()))).findFirst()
+        .orElseThrow(() -> new IllegalStateException("최상단의 상행역이 존재하지 않습니다. 확인이 필요합니다."));
+
+    stationList.add(topSection.getUpStation());
+    stationList.add(topSection.getDownStation());
+
+    while (hasNextSection(topSection)) {
+      topSection = getNextSection(topSection);
+      stationList.add(topSection.getDownStation());
     }
 
-    public List<Station> getStations() {
-        if (sections.isEmpty()) {
-            return Collections.emptyList();
-        }
-        List<Station> stationList = new ArrayList<>();
-        stationList.add(sections.get(0).getUpStation());
-        sections.forEach(section -> stationList.add(section.getDownStation()));
+    return stationList;
+  }
 
-        return stationList;
-    }
+  public boolean hasNextSection(Section startingSection) {
+    return sections.stream().anyMatch(iteratingSection ->
+        startingSection.getDownStation().equals(iteratingSection.getUpStation()));
+  }
 
-    public Section getLastSection() {
-        if (sections.size() <= 1) {
-            throw new IllegalStateException("마지막 section이 존재하지 않습니다.");
-        }
-        return sections.get(sections.size() - 1);
+  public Section getNextSection(Section startingSection) {
+    return sections.stream().filter(iteratingSection ->
+            startingSection.getDownStation().equals(iteratingSection.getUpStation())).findFirst()
+        .orElseThrow(() -> new IllegalStateException("역끼리의 연결을 확인해주세요!"));
+  }
+
+  public Section getLastSection() {
+    if (sections.size() <= 1) {
+      throw new IllegalStateException("마지막 section이 존재하지 않습니다.");
     }
+    return sections.get(sections.size() - 1);
+  }
+
+  private List<Station> getDownStations() {
+    return sections.stream().map(Section::getDownStation).collect(
+        Collectors.toList());
+  }
+
 }

--- a/src/main/java/nextstep/subway/exception/LineExceptionAdvice.java
+++ b/src/main/java/nextstep/subway/exception/LineExceptionAdvice.java
@@ -9,11 +9,12 @@ import org.springframework.web.bind.annotation.ResponseStatus;
 
 @ControllerAdvice
 public class LineExceptionAdvice {
-    @ResponseStatus(HttpStatus.CONFLICT)
-    @ExceptionHandler({NoSuchElementException.class, IllegalStateException.class})
-    ResponseEntity<ExceptionResponse> handleLineNotFound(Exception exception) {
-        return ResponseEntity.status(HttpStatus.CONFLICT).body(ExceptionResponse.from(exception));
-    }
 
+  @ResponseStatus(HttpStatus.CONFLICT)
+  @ExceptionHandler({NoSuchElementException.class, IllegalStateException.class,
+      IllegalArgumentException.class})
+  ResponseEntity<ExceptionResponse> handleLineNotFound(Exception exception) {
+    return ResponseEntity.status(HttpStatus.CONFLICT).body(ExceptionResponse.from(exception));
+  }
 
 }

--- a/src/main/resources/teardown.sql
+++ b/src/main/resources/teardown.sql
@@ -1,0 +1,5 @@
+SET REFERENTIAL_INTEGRITY FALSE;
+truncate table station;
+truncate table section;
+truncate table line;
+SET REFERENTIAL_INTEGRITY TRUE;

--- a/src/test/java/nextstep/subway/acceptance/LineAcceptanceTest.java
+++ b/src/test/java/nextstep/subway/acceptance/LineAcceptanceTest.java
@@ -1,0 +1,243 @@
+package nextstep.subway.acceptance;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static nextstep.subway.acceptance.StationAcceptanceTest.역_만들기;
+
+import io.restassured.RestAssured;
+import io.restassured.response.ExtractableResponse;
+import io.restassured.response.Response;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.web.server.LocalServerPort;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
+import org.springframework.test.context.jdbc.Sql;
+
+@DisplayName("지하철노선 관련 기능")
+@Sql("/teardown.sql")
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.DEFINED_PORT)
+public class LineAcceptanceTest {
+
+    public static final String 신분당선 = "신분당선";
+    public static final String 분당선 = "분당선";
+    public static final String 경인선 = "경인선";
+
+    public static final String BG_YELLOW_600 = "BG_YELLOW_600";
+    public static final String BG_RED_600 = "bg-red-600";
+    public static final String BG_GREEN_600 = "BG_GREEN_600";
+
+    public static final String 거리 = "10";
+    public static final String 첫째지하철역1 = "첫째지하철역";
+    public static final String 세번째지하철역1 = "세번째지하철역";
+    public static final String 두번째지하철역1 = "두번째지하철역";
+    @LocalServerPort
+    int port;
+    private ExtractableResponse<Response> 첫째지하철역;
+    private ExtractableResponse<Response> 두번째지하철역;
+    private ExtractableResponse<Response> 세번째지하철역;
+
+    private String 첫째지하철역_아이디;
+    private String 두번째지하철역_아이디;
+    private String 세번째지하철역_아이디;
+
+    @BeforeEach
+    void setUp() {
+        RestAssured.port = port;
+        // 공통 GIVEN
+        세개의_역_생성();
+    }
+
+    public void 세개의_역_생성() {
+        첫째지하철역 = 역_만들기(첫째지하철역1);
+        두번째지하철역 = 역_만들기(두번째지하철역1);
+        세번째지하철역 = 역_만들기(세번째지하철역1);
+
+        첫째지하철역_아이디 = 첫째지하철역.jsonPath().getString("id");
+        두번째지하철역_아이디 = 두번째지하철역.jsonPath().getString("id");
+        세번째지하철역_아이디 = 세번째지하철역.jsonPath().getString("id");
+    }
+
+    /**
+     * 지하철노선 생성
+     * When 지하철노선을 생성하면
+     * Then 지하철 노선 목록 조회 시 생성한 노선을 찾을 수 있다.
+     */
+    @DisplayName("지하철 노선을 생성하고 생성한 노선을 찾을 수 있다.")
+    @Test
+    void createLine() {
+        // When
+        ExtractableResponse<Response> response = 노선_만들기(신분당선, BG_RED_600, 첫째지하철역_아이디, 두번째지하철역_아이디, "10");
+
+        // Then
+        assertThat(response.statusCode()).isEqualTo(HttpStatus.CREATED.value());
+
+        // Then
+        List<String> lineNames = 모든_노선_조회();
+        assertThat(lineNames).containsAnyOf("신분당선");
+    }
+
+    /**
+     * 지하철노선 목록 조회
+     * Given 2개의 지하철 노선을 생성하고
+     * When 지하철 노선 목록을 조회하면
+     * Then 지하철 노선 목록 조회 시 2개의 노선을 조회할 수 있다.
+     */
+    @DisplayName("지하철역을 2개 생성하고 목록에서 2개의 노선을 조회할 수 있다.")
+    @Test
+    void getLineList() {
+        // Given
+        노선_만들기(신분당선, BG_RED_600, 첫째지하철역_아이디, 두번째지하철역_아이디, 거리);
+        노선_만들기(분당선, BG_GREEN_600, 첫째지하철역_아이디, 세번째지하철역_아이디, 거리);
+
+        // When
+        List<String> lineNames = 모든_노선_조회();
+
+        // Then
+        assertThat(lineNames).contains(신분당선, 분당선);
+    }
+
+    /**
+     * 지하철노선 조회
+     * Given 지하철 노선을 생성하고
+     * When 생성한 지하철 노선을 조회하면
+     * Then 생성한 지하철 노선의 정보를 응답받을 수 있다.
+     */
+
+    @DisplayName("지하철 노선을 생성하고 생성한 지하철의 노선의 정보를 응답 받을 수 있다.")
+    @Test
+    void GetLineById() {
+
+        // Given
+        ExtractableResponse<Response> lineNewBundangResponse = 노선_만들기(신분당선, BG_RED_600, 첫째지하철역_아이디, 두번째지하철역_아이디, 거리);
+        String createdId = lineNewBundangResponse.jsonPath().getString("id");
+
+        // When
+        ExtractableResponse<Response> response = 아이디_노선_조회(createdId);
+
+        // Then
+        assertThat(response.statusCode()).isEqualTo(HttpStatus.OK.value());
+        assertThat(response.jsonPath().getString("name")).isEqualTo(신분당선);
+        assertThat(response.jsonPath().getString("color")).isEqualTo(BG_RED_600);
+        assertThat(response.jsonPath().getList("stations.name")).contains(첫째지하철역1, 두번째지하철역1);
+    }
+
+    /**
+     * 지하철노선 수정
+     * Given 지하철 노선을 생성하고
+     * When 생성한 지하철 노선을 수정하면
+     * Then 해당 지하철 노선 정보는 수정된다
+     */
+    @DisplayName("지하철 노선을 생성하고 해당 지하철 노선 정보는 수정된다.")
+    @Test
+    void EditLine() {
+        // Given
+        ExtractableResponse<Response> lineNewBundangResponse = 노선_만들기(신분당선, BG_RED_600, 첫째지하철역_아이디, 두번째지하철역_아이디, 거리);
+        String createdId = lineNewBundangResponse.jsonPath().getString("id");
+
+        // When
+        ExtractableResponse<Response> response = 노선_수정(createdId, 경인선, BG_YELLOW_600);
+
+        // Then
+        assertThat(response.statusCode()).isEqualTo(HttpStatus.OK.value());
+
+        // When
+        ExtractableResponse<Response> lineKyungInResponse = 아이디_노선_조회(createdId);
+
+        //Then
+        assertThat(lineKyungInResponse.jsonPath().getString("name")).isEqualTo(경인선);
+        assertThat(lineKyungInResponse.jsonPath().getString("color")).isEqualTo(BG_YELLOW_600);
+    }
+
+    /**
+     * 지하철노선 삭제
+     * Given 지하철 노선을 생성하고
+     * When 생성한 지하철 노선을 삭제하면
+     * Then 해당 지하철 노선 정보는 삭제된다
+     */
+    @DisplayName("지하철 노선을 생성하고 해당 지하철 노선 정보는 삭제된다.")
+    @Test
+    void deleteLine() {
+        // Given
+        ExtractableResponse<Response> lineNewBundangResponse = 노선_만들기(신분당선, BG_RED_600, 첫째지하철역_아이디, 두번째지하철역_아이디, 거리);
+        String createdId = lineNewBundangResponse.jsonPath().getString("id");
+
+        // When
+        ExtractableResponse<Response> response = 노선_삭제(createdId);
+
+        // Then
+        assertThat(response.statusCode()).isEqualTo(HttpStatus.NO_CONTENT.value());
+
+        // When
+        List<String> lineNames = 모든_노선_조회();
+
+        // Then
+        assertThat(lineNames).doesNotContain(신분당선);
+    }
+
+    private static ExtractableResponse<Response> 노선_삭제(String createdId) {
+        ExtractableResponse<Response> response =
+                RestAssured.given().log().all()
+                        .contentType(MediaType.APPLICATION_JSON_VALUE)
+                        .when().delete(String.format("/lines/%s", createdId))
+                        .then().log().all()
+                        .extract();
+        return response;
+    }
+
+    private static List<String> 모든_노선_조회() {
+        List<String> lineNames =
+                RestAssured.given().log().all()
+                        .when().get("/lines")
+                        .then().log().all()
+                        .extract().jsonPath().getList("name", String.class);
+        return lineNames;
+    }
+
+    static ExtractableResponse<Response> 노선_만들기(String name, String color, String upStationId, String downStationId, String distance) {
+        Map<String, String> params = new HashMap<>();
+        params.put("name", name);
+        params.put("color", color);
+        params.put("upStationId", upStationId);
+        params.put("downStationId", downStationId);
+        params.put("distance", distance);
+
+        // when
+        ExtractableResponse<Response> response =
+                RestAssured.given().log().all()
+                        .body(params)
+                        .contentType(MediaType.APPLICATION_JSON_VALUE)
+                        .when().post("/lines")
+                        .then().log().all()
+                        .extract();
+        return response;
+    }
+
+    static ExtractableResponse<Response> 아이디_노선_조회(String id) {
+        ExtractableResponse<Response> response =
+                RestAssured.given().log().all()
+                        .contentType(MediaType.APPLICATION_JSON_VALUE)
+                        .when().get(String.format("/lines/%s", id))
+                        .then().log().all()
+                        .extract();
+        return response;
+    }
+
+    private static ExtractableResponse<Response> 노선_수정(String createdId, String name, String color) {
+        Map<String, String> params = new HashMap<>();
+        params.put("name", name);
+        params.put("color", color);
+        ExtractableResponse<Response> response =
+                RestAssured.given().log().all()
+                        .body(params)
+                        .contentType(MediaType.APPLICATION_JSON_VALUE)
+                        .when().put(String.format("/lines/%s", createdId))
+                        .then().log().all()
+                        .extract();
+        return response;
+    }
+}

--- a/src/test/java/nextstep/subway/acceptance/RestAssuredTest.java
+++ b/src/test/java/nextstep/subway/acceptance/RestAssuredTest.java
@@ -1,0 +1,29 @@
+package nextstep.subway.acceptance;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.restassured.RestAssured;
+import io.restassured.response.ExtractableResponse;
+import io.restassured.response.Response;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.http.HttpStatus;
+
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.DEFINED_PORT)
+public class RestAssuredTest {
+
+    public static final String HTTPS_GOOGLE_COM = "https://google.com";
+
+    @DisplayName("구글 페이지 접근 테스트")
+    @Test
+    void accessGoogle() {
+
+        ExtractableResponse<Response> response = RestAssured.
+                                                    given().baseUri(HTTPS_GOOGLE_COM).
+                                                    when().get().
+                                                    then().extract();
+
+        assertThat(response.statusCode()).isEqualTo(HttpStatus.OK.value());
+    }
+}

--- a/src/test/java/nextstep/subway/acceptance/SectionAcceptanceTest.java
+++ b/src/test/java/nextstep/subway/acceptance/SectionAcceptanceTest.java
@@ -97,7 +97,7 @@ public class SectionAcceptanceTest {
         첫째지하철역_아이디 = 첫째지하철역.jsonPath().getString("id");
         두번째지하철역_아이디 = 두번째지하철역.jsonPath().getString("id");
         세번째지하철역_아이디 = 세번째지하철역.jsonPath().getString("id");
-        네번째지하철역_아이디 = 세번째지하철역.jsonPath().getString("id");
+        네번째지하철역_아이디 = 네번째지하철역.jsonPath().getString("id");
     }
 
     /**
@@ -136,25 +136,6 @@ public class SectionAcceptanceTest {
 
         // WHEN
         ExtractableResponse<Response> response = 구간_추가("1", 네번째지하철역_아이디, 두번째지하철역_아이디, "10");
-
-        // THEN
-        assertThat(response.statusCode()).isEqualTo(HttpStatus.CONFLICT.value());
-    }
-
-    /**
-     * Given 1개의 지하철 노선을 생성하고 1개의 중복되지 않은 지하철 구간을 등록하고
-     * When 지하철 구간 중 등록되어있는 하행역을 등록한다.
-     * Then 구간 등록에 실패한다.
-     */
-    @DisplayName("1개의 구간을 등록하고 등록되어있는 역을 등록한다.")
-    @Test
-    void addTwoSectionToLineAgainstRule() {
-        // GIVEN
-        첫번째노선 = 노선_만들기(신분당선, BG_RED_600, 두번째지하철역_아이디, 첫째지하철역_아이디, 거리);
-        첫째노선_아이디 = 첫번째노선.jsonPath().getString("id");
-
-        // WHEN
-        ExtractableResponse<Response> response = 구간_추가(첫째노선_아이디, 첫째지하철역_아이디, 두번째지하철역_아이디, "10");
 
         // THEN
         assertThat(response.statusCode()).isEqualTo(HttpStatus.CONFLICT.value());
@@ -240,31 +221,37 @@ public class SectionAcceptanceTest {
 
     @DisplayName("구간 추가 인수 테스트")
     @Nested
-    class FailingSectionAddTest {
+    class SectionAddTest {
         /**
          * Given 1개의 지하철 노선을 생성하고 한개의 구간을 생성하고
          * When 지하철 구간을 첫번째 하행역 기준으로 생성한다.
          * Then 구간 등록에 성공한다.
+         *
+         * When 지하철 구간에 대한 역을 조회했을 때,
+         * Then 구간 순서대로 역이 조회된다.
          */
         @DisplayName("1개의 구간을 등록하고 역 사이에 새로운 역을 등록한다. ")
         @Test
         void addSectionToLineInBetweenSectionsFromUpStation() {
             // GIVEN
             첫번째노선 = 노선_만들기(신분당선, BG_RED_600, 두번째지하철역_아이디, 첫째지하철역_아이디, 거리);
+
             첫째노선_아이디 = 첫번째노선.jsonPath().getString("id");
             // WHEN
-            ExtractableResponse<Response> response = 구간_추가(첫째노선_아이디, 첫째지하철역_아이디, 두번째지하철역_아이디, "10");
-            ExtractableResponse<Response> addResponse = 구간_추가(첫째노선_아이디, 두번째지하철역_아이디, 세번째지하철역_아이디, "2");
+            ExtractableResponse<Response> addResponse = 구간_추가(첫째노선_아이디, 세번째지하철역_아이디, 첫째지하철역_아이디, "2");
             // THEN
-            assertThat(addResponse.statusCode()).isEqualTo(HttpStatus.OK.value());
+            assertThat(addResponse.statusCode()).isEqualTo(HttpStatus.CREATED.value());
 
             List<String> stations = addResponse.jsonPath().getList("stations.name");
-            assertThat(stations).containsExactly(두번째지하철역이름, 세번째지하철역_아이디, 첫째지하철역_아이디, 두번째지하철역_아이디);
+            assertThat(stations).containsExactly(두번째지하철역이름, 세번째지하철역이름, 첫째지하철역이름);
         }
         /**
          * Given 1개의 지하철 노선을 생성하고 한개의 구간을 생성하고
-         * When 지하철 구간을 두번째 상행역 기준으로 생성한다.
+         * When 지하철 구간을 첫번째 상행역 기준으로 생성한다.
          * Then 구간 등록에 성공한다.
+         *
+         * When 지하철 구간에 대한 역을 조회했을 때,
+         * Then 구간 순서대로 역이 조회된다.
          */
         @DisplayName("1개의 구간을 등록하고 역 사이에 새로운 역을 등록한다. ")
         @Test
@@ -273,13 +260,14 @@ public class SectionAcceptanceTest {
             첫번째노선 = 노선_만들기(신분당선, BG_RED_600, 두번째지하철역_아이디, 첫째지하철역_아이디, 거리);
             첫째노선_아이디 = 첫번째노선.jsonPath().getString("id");
             // WHEN
-            ExtractableResponse<Response> response = 구간_추가(첫째노선_아이디, 첫째지하철역_아이디, 두번째지하철역_아이디, "6");
-            ExtractableResponse<Response> addResponse = 구간_추가(첫째노선_아이디, 네번째지하철역_아이디, 두번째지하철역_아이디, "2");
+            ExtractableResponse<Response> addResponse = 구간_추가(첫째노선_아이디, 두번째지하철역_아이디, 네번째지하철역_아이디, "2");
             // THEN
-            assertThat(addResponse.statusCode()).isEqualTo(HttpStatus.OK.value());
+            assertThat(addResponse.statusCode()).isEqualTo(HttpStatus.CREATED.value());
 
             List<String> stations = addResponse.jsonPath().getList("stations.name");
-            assertThat(stations).containsExactly(두번째지하철역이름, 세번째지하철역_아이디, 첫째지하철역_아이디, 두번째지하철역_아이디);
+            assertThat(stations).containsExactly(두번째지하철역이름, 네번째지하철역이름, 첫째지하철역이름);
+
+
         }
         /**
          * Given 1개의 지하철 노선을 생성하고 한개의 구간을 생성하고
@@ -307,10 +295,10 @@ public class SectionAcceptanceTest {
         @Test
         void addSectionToLineThrowAlreadyRegisteredError() {
             // GIVEN
-            첫번째노선 = 노선_만들기(신분당선, BG_RED_600, 두번째지하철역_아이디, 첫째지하철역_아이디, 거리);
+            첫번째노선 = 노선_만들기(신분당선, BG_RED_600, 두번째지하철역_아이디, 첫째지하철역_아이디, "5");
             첫째노선_아이디 = 첫번째노선.jsonPath().getString("id");
             // WHEN
-            ExtractableResponse<Response> response = 구간_추가(첫째노선_아이디, 세번째지하철역_아이디, 네번째지하철역_아이디, "5");
+            ExtractableResponse<Response> response = 구간_추가(첫째노선_아이디, 두번째지하철역_아이디, 네번째지하철역_아이디, "5");
             // THEN
             assertThat(response.statusCode()).isEqualTo(HttpStatus.CONFLICT.value());
         }

--- a/src/test/java/nextstep/subway/acceptance/SectionAcceptanceTest.java
+++ b/src/test/java/nextstep/subway/acceptance/SectionAcceptanceTest.java
@@ -264,10 +264,9 @@ public class SectionAcceptanceTest {
             // THEN
             assertThat(addResponse.statusCode()).isEqualTo(HttpStatus.CREATED.value());
 
-            List<String> stations = addResponse.jsonPath().getList("stations.name");
+            ExtractableResponse<Response> response = 아이디_노선_조회(첫째노선_아이디);
+            List<String> stations = response.jsonPath().getList("stations.name");
             assertThat(stations).containsExactly(두번째지하철역이름, 네번째지하철역이름, 첫째지하철역이름);
-
-
         }
         /**
          * Given 1개의 지하철 노선을 생성하고 한개의 구간을 생성하고

--- a/src/test/java/nextstep/subway/acceptance/SectionAcceptanceTest.java
+++ b/src/test/java/nextstep/subway/acceptance/SectionAcceptanceTest.java
@@ -1,0 +1,256 @@
+package nextstep.subway.acceptance;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static nextstep.subway.acceptance.LineAcceptanceTest.노선_만들기;
+import static nextstep.subway.acceptance.LineAcceptanceTest.아이디_노선_조회;
+import static nextstep.subway.acceptance.StationAcceptanceTest.역_만들기;
+
+import io.restassured.RestAssured;
+import io.restassured.response.ExtractableResponse;
+import io.restassured.response.Response;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.web.server.LocalServerPort;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
+import org.springframework.test.context.jdbc.Sql;
+
+@DisplayName("지하철 구간 관련 기능")
+@Sql("/teardown.sql")
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.DEFINED_PORT)
+public class SectionAcceptanceTest {
+    public static final String 신분당선 = "신분당선";
+    public static final String 분당선 = "분당선";
+    public static final String 경인선 = "경인선";
+
+    public static final String BG_YELLOW_600 = "BG_YELLOW_600";
+    public static final String BG_RED_600 = "bg-red-600";
+    public static final String BG_GREEN_600 = "BG_GREEN_600";
+
+    public static final String 거리 = "10";
+    public static final String 첫째지하철역이름 = "첫째지하철역";
+    public static final String 세번째지하철역이름 = "세번째지하철역";
+    public static final String 두번째지하철역이름 = "두번째지하철역";
+    public static final String 네번째지하철역이름 = "네번째지하철역";
+    private static String 첫째지하철역_아이디;
+    private static String 두번째지하철역_아이디;
+    private static String 세번째지하철역_아이디;
+    private static String 네번째지하철역_아이디;
+    private static String 첫째노선_아이디;
+    private static String 둘째노선_아이디;
+    @LocalServerPort
+    int port;
+    private ExtractableResponse<Response> 첫째지하철역;
+    private ExtractableResponse<Response> 두번째지하철역;
+    private ExtractableResponse<Response> 세번째지하철역;
+    private ExtractableResponse<Response> 네번째지하철역;
+    private ExtractableResponse<Response> 첫번째노선;
+    private ExtractableResponse<Response> 두번째노선;
+
+    private static ExtractableResponse<Response> 구간_추가(String lineId, String upStationId, String downStationId, String distance) {
+        Map<String, String> params = new HashMap<>();
+        params.put("upStationId", upStationId);
+        params.put("downStationId", downStationId);
+        params.put("distance", distance);
+
+        ExtractableResponse<Response> response =
+                RestAssured.given().log().all()
+                        .body(params)
+                        .contentType(MediaType.APPLICATION_JSON_VALUE)
+                        .when().post(String.format("/lines/%s/sections", lineId))
+                        .then().log().all()
+                        .extract();
+        return response;
+    }
+
+    private static ExtractableResponse<Response> 구간_제거(String lineId, String stationId) {
+
+        ExtractableResponse<Response> response =
+                RestAssured.given().log().all()
+                        .contentType(MediaType.APPLICATION_JSON_VALUE)
+                        .when().delete("/lines/{lindId}/sections?stationId={stationId}", lineId, stationId)
+                        .then().log().all()
+                        .extract();
+        return response;
+    }
+
+    @BeforeEach
+    public void setUpPort() {
+        RestAssured.port = port;
+        네개의_역_생성();
+
+    }
+
+    public void 네개의_역_생성() {
+        첫째지하철역 = 역_만들기(첫째지하철역이름);
+        두번째지하철역 = 역_만들기(두번째지하철역이름);
+        세번째지하철역 = 역_만들기(세번째지하철역이름);
+        네번째지하철역 = 역_만들기(네번째지하철역이름);
+
+        첫째지하철역_아이디 = 첫째지하철역.jsonPath().getString("id");
+        두번째지하철역_아이디 = 두번째지하철역.jsonPath().getString("id");
+        세번째지하철역_아이디 = 세번째지하철역.jsonPath().getString("id");
+        네번째지하철역_아이디 = 세번째지하철역.jsonPath().getString("id");
+    }
+
+    /**
+     * Given 1개의 지하철 노선을 생성하고
+     * When 2개의 중복되지 않은 지하철 구간을 등록하면 (등록되는 노선은 하행 종점역이다.)
+     * Then 지하철 노선 목록 조회 시 추가된 구간의 하행역이 노선에 추가되어있다.
+     */
+    @DisplayName("1개의 구간을 노선에 추가한다.")
+    @Test
+    void addSectionToLineByRule() {
+        // GIVEN
+        첫번째노선 = 노선_만들기(신분당선, BG_RED_600, 두번째지하철역_아이디, 첫째지하철역_아이디, 거리);
+        첫째노선_아이디 = 첫번째노선.jsonPath().getString("id");
+
+        // WHEN
+        ExtractableResponse<Response> response = 구간_추가(첫째노선_아이디, 첫째지하철역_아이디, 세번째지하철역_아이디, "10");
+
+        // THEN
+        assertThat(response.statusCode()).isEqualTo(HttpStatus.CREATED.value());
+
+        // THEN
+        ExtractableResponse<Response> getLineResponse = 아이디_노선_조회(첫째노선_아이디);
+        List<String> stations = getLineResponse.jsonPath().getList("stations.name");
+        assertThat(stations).containsExactly(두번째지하철역이름, 첫째지하철역이름, 세번째지하철역이름);
+    }
+
+    /**
+     * Given 0개의 지하철 노선을 생성하고
+     * When 지하철 구간을 추가할때
+     * Then 구간 등록에 실패한다.
+     */
+    @DisplayName("노선에 대한 구간을 생성 할때, 구간이 존재 하지 않을 경우")
+    @Test
+    void addSectionFromNotExistingLineThrowNoSuchElementError() {
+        // GIVEN
+
+        // WHEN
+        ExtractableResponse<Response> response = 구간_추가("1", 네번째지하철역_아이디, 두번째지하철역_아이디, "10");
+
+        // THEN
+        assertThat(response.statusCode()).isEqualTo(HttpStatus.CONFLICT.value());
+    }
+
+    /**
+     * Given 1개의 지하철 노선을 생성하고 1개의 중복되지 않은 지하철 구간을 등록하고
+     * When 지하철 구간 중 등록되어있는 하행역을 등록한다.
+     * Then 구간 등록에 실패한다.
+     */
+    @DisplayName("1개의 구간을 등록하고 등록되어있는 역을 등록한다.")
+    @Test
+    void addTwoSectionToLineAgainstRule() {
+        // GIVEN
+        첫번째노선 = 노선_만들기(신분당선, BG_RED_600, 두번째지하철역_아이디, 첫째지하철역_아이디, 거리);
+        첫째노선_아이디 = 첫번째노선.jsonPath().getString("id");
+
+        // WHEN
+        ExtractableResponse<Response> response = 구간_추가(첫째노선_아이디, 첫째지하철역_아이디, 두번째지하철역_아이디, "10");
+
+        // THEN
+        assertThat(response.statusCode()).isEqualTo(HttpStatus.CONFLICT.value());
+    }
+
+    /**
+     * Given 1개의 지하철 노선을 생성하고
+     * When 지하철 구간을 등록할때 등록 구간의 상행역이 하행 종점역이 아닐때를 등록한다
+     * Then 구간 등록에 실패한다.
+     */
+    @DisplayName("1개의 구간을 등록하고 하행 종점역이 아닌 노선을 등록한다. ")
+    @Test
+    void addSectionToLineThrowAlreadyRegisteredError() {
+        // GIVEN
+        첫번째노선 = 노선_만들기(신분당선, BG_RED_600, 두번째지하철역_아이디, 첫째지하철역_아이디, 거리);
+        첫째노선_아이디 = 첫번째노선.jsonPath().getString("id");
+        // WHEN
+        ExtractableResponse<Response> response = 구간_추가(첫째노선_아이디, 세번째지하철역_아이디, 네번째지하철역_아이디, "10");
+        // THEN
+        assertThat(response.statusCode()).isEqualTo(HttpStatus.CONFLICT.value());
+    }
+
+    /**
+     * Given 1개의 지하철 노선을 생성하고 1개의 구간을 추가했을 때,
+     * When 하행 노선을 제거한다.
+     * Then 지하철 하행역이 전 구간의 하행역으로 변화한다.
+     * Then 지하철 역이 3개에서 2개로 변화된다.
+     */
+    @DisplayName("하행 구간을 제거하면 구간의 역 리스트가 변경된다.")
+    @Test
+    void deleteSectionFromLine() {
+        // GIVEN
+        첫번째노선 = 노선_만들기(신분당선, BG_RED_600, 두번째지하철역_아이디, 첫째지하철역_아이디, 거리);
+        첫째노선_아이디 = 첫번째노선.jsonPath().getString("id");
+
+        // WHEN
+        구간_추가(첫째노선_아이디, 첫째지하철역_아이디, 네번째지하철역_아이디, "10");
+        구간_제거(첫째노선_아이디, 네번째지하철역_아이디);
+
+        // THEN
+        ExtractableResponse<Response> response = 아이디_노선_조회(첫째노선_아이디);
+        assertThat(response.jsonPath().getList("stations.name")).contains(첫째지하철역이름, 두번째지하철역이름);
+
+    }
+
+    /**
+     * Given 1개의 지하철 노선을 생성하고
+     * When 지하철 구간을 제거할때 제거 구간이 하행 종점역이 아닐 때를 등록한다
+     * Then 구간 등록에 실패한다.
+     */
+    @DisplayName("구간을 제거할때 제거 구간이 하행 종점역이 아닐때 에러를 표기한다.")
+    @Test
+    void deleteSectionFromLineAgainstRule() {
+        // GIVEN
+        첫번째노선 = 노선_만들기(신분당선, BG_RED_600, 두번째지하철역_아이디, 첫째지하철역_아이디, 거리);
+        첫째노선_아이디 = 첫번째노선.jsonPath().getString("id");
+        구간_추가(첫째노선_아이디, 첫째지하철역_아이디, 세번째지하철역_아이디, "10");
+        // WHEN
+        ExtractableResponse<Response> response = 구간_제거(첫째노선_아이디, 첫째지하철역_아이디);
+
+        // THEN
+        assertThat(response.statusCode()).isEqualTo(HttpStatus.CONFLICT.value());
+    }
+
+    /**
+     * Given 1개의 지하철 노선을 생성하고
+     * When 지하철 구간을 제거할때 제거 구간이 하나만 있을 때를 등록한다
+     * Then 구간 등록에 실패한다.
+     * +
+     */
+    @DisplayName("구간을 제거 할때, 제거 구간이 하나만 있을때 에러를 표기한다")
+    @Test
+    void deleteSectionFromLineThrowOnlyElementError() {
+        // GIVEN
+        첫번째노선 = 노선_만들기(신분당선, BG_RED_600, 두번째지하철역_아이디, 첫째지하철역_아이디, 거리);
+        첫째노선_아이디 = 첫번째노선.jsonPath().getString("id");
+        // WHEN
+        ExtractableResponse<Response> response = 구간_제거(첫째노선_아이디, 첫째지하철역_아이디);
+
+        // THEN
+        assertThat(response.statusCode()).isEqualTo(HttpStatus.CONFLICT.value());
+    }
+
+    /**
+     * Given 0개의 지하철 노선을 생성하고
+     * When 지하철 구간을 제거할때
+     * Then 구간 제거에 실패한다.
+     */
+    @DisplayName("노선에 대한 구간을 제거 할때, 구간이 존재 하지 않을 경우")
+    @Test
+    void deleteSectionFromNotExistingLineThrowNoSuchElementError() {
+        // GIVEN
+
+        // WHEN
+        ExtractableResponse<Response> response = 구간_제거("1", 첫째지하철역_아이디);
+
+        // THEN
+        assertThat(response.statusCode()).isEqualTo(HttpStatus.CONFLICT.value());
+    }
+
+}

--- a/src/test/java/nextstep/subway/acceptance/StationAcceptanceTest.java
+++ b/src/test/java/nextstep/subway/acceptance/StationAcceptanceTest.java
@@ -1,0 +1,130 @@
+package nextstep.subway.acceptance;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.restassured.RestAssured;
+import io.restassured.response.ExtractableResponse;
+import io.restassured.response.Response;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.web.server.LocalServerPort;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
+import org.springframework.test.context.jdbc.Sql;
+
+@DisplayName("지하철역 관련 기능")
+@Sql("/teardown.sql")
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.DEFINED_PORT)
+public class StationAcceptanceTest {
+
+    public static final String 강남역 = "강남역";
+    public static final String 양재역 = "양재역";
+    @LocalServerPort
+    int port;
+
+    @BeforeEach
+    public void setUpPort(){
+        RestAssured.port = port;
+    }
+    /**
+     * When 지하철역을 생성하면
+     * Then 지하철역이 생성된다
+     * Then 지하철역 목록 조회 시 생성한 역을 찾을 수 있다
+     */
+    @DisplayName("지하철역을 생성한다.")
+    @Test
+    void createStation() {
+        // when
+        ExtractableResponse<Response> response = 역_만들기(강남역);
+
+        // then
+        assertThat(response.statusCode()).isEqualTo(HttpStatus.CREATED.value());
+
+        // then
+        List<String> stationNames =
+                RestAssured.given().log().all()
+                        .when().get("/stations")
+                        .then().log().all()
+                        .extract().jsonPath().getList("name", String.class);
+        assertThat(stationNames).containsAnyOf("강남역");
+    }
+
+    /**
+     * Given 2개의 지하철역을 생성하고
+     * When 지하철역 목록을 조회하면
+     * Then 2개의 지하철역을 응답 받는다
+     */
+    // TODO: 지하철역 목록 조회 인수 테스트 메서드 생성
+    @DisplayName("지하철역을 생성하고 지하철 역을 조회한다.")
+    @Test
+    void createStationAndGetStation() {
+        // Given
+        역_만들기(강남역);
+        역_만들기(양재역);
+
+        // When
+        ExtractableResponse<Response> responseStations = 지하철역_조회하기();
+
+        // Then
+        assertThat(responseStations.jsonPath().getList(".").stream().count()).isEqualTo(2);
+    }
+
+    /**
+     * Given 지하철역을 생성하고
+     * When 그 지하철역을 삭제하면
+     * Then 그 지하철역 목록 조회 시 생성한 역을 찾을 수 없다
+     */
+    // TODO: 지하철역 제거 인수 테스트 메서드 생성
+    @DisplayName("지하철역을 생성하고 삭제하면 지하철 목록에 지하철역이 없다.")
+    @Test
+    void createStationAndDeleteStationAndGetStationList() {
+        // Given
+        ExtractableResponse<Response> responseStationGangnam = 역_만들기(강남역);
+        String createdId = responseStationGangnam.jsonPath().getString("id");
+
+        // When
+        역_삭제하기(createdId);
+
+        // Then
+        ExtractableResponse<Response> responseStations = 지하철역_조회하기();
+        assertThat(responseStations.jsonPath().getList("name")).doesNotContain(강남역);
+    }
+    protected static ExtractableResponse<Response> 역_만들기(String stationName) {
+        Map<String, String> params = new HashMap<>();
+        params.put("name", stationName);
+
+        ExtractableResponse<Response> response =
+            RestAssured.given().log().all()
+                .body(params)
+                .contentType(MediaType.APPLICATION_JSON_VALUE)
+                .when().post("/stations")
+                .then().log().all()
+                .extract();
+        return response;
+    }
+
+    private static ExtractableResponse<Response> 역_삭제하기(String id) {
+        ExtractableResponse<Response> response =
+            RestAssured.given().log().all()
+                .contentType(MediaType.APPLICATION_JSON_VALUE)
+                .when().delete(String.format("/stations/%s",id))
+                .then().log().all()
+                .extract();
+        return response;
+    }
+    private static ExtractableResponse<Response> 지하철역_조회하기() {
+
+        ExtractableResponse<Response> response =
+            RestAssured.given().log().all()
+                .contentType(MediaType.APPLICATION_JSON_VALUE)
+                .when().get("/stations")
+                .then().log().all()
+                .extract();
+        return response;
+    }
+}

--- a/src/test/java/nextstep/subway/unit/LineServiceTest.java
+++ b/src/test/java/nextstep/subway/unit/LineServiceTest.java
@@ -42,8 +42,9 @@ public class LineServiceTest {
         // when
         lineService.addSection(lineResponse.getId(), SectionRequest.builder().distance(10L).upStationId(2L).downStationId(3L).build());
         // then
-        Optional<Line> line = lineRepository.findById(lineResponse.getId());
-        assertThat(line.get().getSections().getStations().stream().map(station -> station.getName()).collect(
+        Line line = lineRepository.findById(lineResponse.getId()).orElseThrow(()-> new IllegalArgumentException("테스트에 노선 찾기 실패"));
+        assertThat(line.getSections().getStations().stream().map(station -> station.getName()).collect(
             Collectors.toList())).containsExactly("첫번째역","두번째역","세번째역");
+        // 여기 줄줄이 delimiter law 어겼음
     }
 }

--- a/src/test/java/nextstep/subway/unit/LineServiceTest.java
+++ b/src/test/java/nextstep/subway/unit/LineServiceTest.java
@@ -43,7 +43,7 @@ public class LineServiceTest {
         lineService.addSection(lineResponse.getId(), SectionRequest.builder().distance(10L).upStationId(2L).downStationId(3L).build());
         // then
         Line line = lineRepository.findById(lineResponse.getId()).orElseThrow(()-> new IllegalArgumentException("테스트에 노선 찾기 실패"));
-        assertThat(line.getSections().getStations().stream().map(station -> station.getName()).collect(
+        assertThat(line.getStations().stream().map(station -> station.getName()).collect(
             Collectors.toList())).containsExactly("첫번째역","두번째역","세번째역");
         // 여기 줄줄이 delimiter law 어겼음
     }

--- a/src/test/java/nextstep/subway/unit/LineTest.java
+++ b/src/test/java/nextstep/subway/unit/LineTest.java
@@ -1,53 +1,140 @@
 package nextstep.subway.unit;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.ThrowableAssert.catchThrowable;
 
+import java.util.stream.Collectors;
 import nextstep.subway.domain.Line;
 import nextstep.subway.domain.Section;
 import nextstep.subway.domain.Station;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 
 class LineTest {
-    private Station 첫번째역;
-    private Station 두번째역;
-    private Station 세번째역;
-    private Line 첫번째노선;
-    @BeforeEach
-    public void setup(){
-        첫번째역 = new Station(1L,"첫번째역");
-        두번째역 = new Station(2L,"두번째역");
-        세번째역 = new Station(3L,"세번째역");
-        첫번째노선 = Line.of("첫번째노선","BLUE", 첫번째역, 두번째역, 10L);
-    }
-    @DisplayName("도메인(Line): 새로운 구간을 추가")
+
+  private Station 첫번째역;
+  private Station 두번째역;
+  private Station 세번째역;
+  private Station 네번째역;
+  private Line 첫번째노선;
+
+  @BeforeEach
+  public void setup() {
+    첫번째역 = new Station(1L, "첫번째역");
+    두번째역 = new Station(2L, "두번째역");
+    세번째역 = new Station(3L, "세번째역");
+    네번째역 = new Station(4L, "네번째역");
+    첫번째노선 = Line.of("첫번째노선", "BLUE", 첫번째역, 두번째역, 10L);
+  }
+
+  @DisplayName("도메인(Line): 새로운 구간을 추가")
+  @Test
+  void addSection() {
+    //When
+    첫번째노선.addSection(Section.of(첫번째노선, 10L, 두번째역, 세번째역));
+    Section section = 첫번째노선.getSections().getLastSection();
+    //Then
+    assertThat(section.getDistance()).isEqualTo(10L);
+    assertThat(section.getUpStation()).isEqualTo(두번째역);
+    assertThat(section.getDownStation()).isEqualTo(세번째역);
+  }
+
+  @DisplayName("도메인(Line): 노선에 속해있는 역들에 대한 조회")
+  @Test
+  void getStations() {
+    //When
+    첫번째노선.addSection(Section.of(첫번째노선, 10L, 두번째역, 세번째역));
+    //Then
+    assertThat(첫번째노선.getStations()).containsExactly(첫번째역, 두번째역, 세번째역);
+  }
+
+  @DisplayName("도메인(Line): 구간의 마지막 역을 삭제")
+  @Test
+  void removeSection() {
+    //Given
+    첫번째노선.addSection(Section.of(첫번째노선, 10L, 두번째역, 세번째역));
+    //When
+    첫번째노선.deleteSection(세번째역);
+    //Then
+    assertThat(첫번째노선.getStations().stream().map(station -> station.getName())).containsExactly(
+        첫번째역.getName(), 두번째역.getName());
+  }
+
+  @Nested
+  @DisplayName("성공 케이스: 도메인 (Line): 새로운 구간 추가할 때")
+  class SuccessfulSectionAddingTest {
+
+    @DisplayName("존재하는 구간중 상행역에 구간을 추가합니다. (기존 구간보다 추가하는 거리가 적을 때)")
     @Test
-    void addSection() {
-        //When
-        첫번째노선.addSection(Section.of(첫번째노선, 10L, 두번째역, 세번째역));
-        Section section = 첫번째노선.getSections().getLastSection();
-        //Then
-        assertThat(section.getDistance()).isEqualTo(10L);
-        assertThat(section.getUpStation()).isEqualTo(두번째역);
-        assertThat(section.getDownStation()).isEqualTo(세번째역);
+    void addSectionOnUpStation() {
+      //When
+      첫번째노선.addSection(Section.of(첫번째노선, 4L, 세번째역, 두번째역));
+      Section section = 첫번째노선.getSections().getLastSection();
+
+      //Then
+      assertThat(section.getDistance()).isEqualTo(4L);
+      assertThat(section.getUpStation()).isEqualTo(세번째역);
+      assertThat(section.getDownStation()).isEqualTo(두번째역);
+      assertThat(첫번째노선.getStations().stream().map(station -> station.getName()).collect(
+          Collectors.toList())).containsExactly("첫번째역","세번째역","두번째역");
     }
-    @DisplayName("도메인(Line): 노선에 속해있는 역들에 대한 조회")
+
+    @DisplayName("존재하는 구간중 하행역에 구간을 추가합니다. (기존 구간보다 추가하는 거리가 적을 때)")
     @Test
-    void getStations() {
-        //When
-        첫번째노선.addSection(Section.of(첫번째노선, 10L, 두번째역, 세번째역));
-        //Then
-        assertThat(첫번째노선.getStations()).containsExactly(첫번째역, 두번째역, 세번째역);
+    void addSectionOnDownStation() {
+      //When
+      첫번째노선.addSection(Section.of(첫번째노선, 4L, 두번째역, 세번째역));
+      Section section = 첫번째노선.getSections().getLastSection();
+
+      //Then
+      assertThat(section.getDistance()).isEqualTo(4L);
+      assertThat(section.getUpStation()).isEqualTo(두번째역);
+      assertThat(section.getDownStation()).isEqualTo(세번째역);
+      assertThat(첫번째노선.getStations().stream().map(station -> station.getName()).collect(
+      Collectors.toList())).containsExactly("첫번째역","두번째역","세번째역");
     }
-    @DisplayName("도메인(Line): 구간의 마지막 역을 삭제")
+  }
+
+  @Nested
+  @DisplayName("오류 케이스: 도메인 (Line): 새로운 구간 추가할 때")
+  class FailedSectionAddingTest {
+
+    @DisplayName("존재하는 구간중 상행역에 구간을 추가합니다. (기존 구간보다 추가하는 거리가 클 때)")
     @Test
-    void removeSection() {
-        //Given
-        첫번째노선.addSection(Section.of(첫번째노선, 10L, 두번째역, 세번째역));
-        //When
-        첫번째노선.deleteSection(세번째역);
-        //Then
-        assertThat(첫번째노선.getStations().stream().map(station -> station.getName())).containsExactly(첫번째역.getName(), 두번째역.getName());
+    void addSectionOnUpStationInvalidDistance() {
+      //When
+      Throwable thrown = catchThrowable(() -> { 첫번째노선.addSection(Section.of(첫번째노선, 10L, 첫번째역, 두번째역)); });
+      //Then
+      assertThat(thrown).isInstanceOf(IllegalArgumentException.class);
     }
+
+    @DisplayName("존재하는 구간중 하행역에 구간을 추가합니다. (기존 구간보다 추가하는 거리가 클 때)")
+    @Test
+    void addSectionInvalidDistance() {
+      //When
+      Throwable thrown = catchThrowable(() -> { 첫번째노선.addSection(Section.of(첫번째노선, 12L, 세번째역, 두번째역)); });
+      //Then
+      assertThat(thrown).isInstanceOf(IllegalArgumentException.class);
+    }
+
+    @DisplayName("존재하는 구간중 상행역에 구간을 추가합니다. (기존 동일 구간이 존재할 때)")
+    @Test
+    void addSectionAlreadyExistingSection() {
+      //When
+      Throwable thrown = catchThrowable(() -> { 첫번째노선.addSection(Section.of(첫번째노선, 5L, 첫번째역, 두번째역)); });
+      //Then
+      assertThat(thrown).isInstanceOf(IllegalArgumentException.class);
+    }
+
+    @DisplayName("존재하는 구간중 하행역에 구간을 추가합니다. (추가하는 구간의 역이 존재하지 않을 때)")
+    @Test
+    void addSectionWithNotExistingStations() {
+      //When
+      Throwable thrown = catchThrowable(() -> { 첫번째노선.addSection(Section.of(첫번째노선, 10L, 세번째역, 네번째역)); });
+      //Then
+      assertThat(thrown).isInstanceOf(IllegalArgumentException.class);
+    }
+  }
 }


### PR DESCRIPTION
안녕하세요!~ 리뷰어님 드디어 완료했습니다... 후우.. 리뷰 부탁드리겠습니다!
### 구현사항

- [x] 구간 추가에 대한 인수테스트 구현
   - 역 사이에 새로운 역을 등록할 경우
   - 새로운 역을 상행 종점으로 등록할 경우
   - 새로운 역을 하행 종점으로 등록할 경우
   - 노선 조회시 응답되는 역 목록 수정
   - 역 사이에 새로운 역을 등록할 경우 기존 역 사이 길이보다 크거나 같으면 등록을 할 수 없음
   - 상행역과 하행역이 이미 노선에 모두 등록되어 있다면 추가할 수 없음
   - 상행역과 하행역 둘 중 하나도 포함되어있지 않으면 추가할 수 없음

- [x] 구간 추가에 대한 유닛 테스트 구현
- [x] 1차 피드백에서 말씀하신 Line class에 있는 Lombok Getter를 field로 옮겼습니다.
- [x] 1차 피드백에서 말씀하신 delimiter의 법칙 위반사항 (line.getSections.getStations()) 수정
- [x] distance 관련 오류 사항 및 존재하지 않는 station 관련 오류 검증
- [x] Section add 이후에 Line 에 대한 list 순서 검증 완료

### 어려웠던 점
1. 역 리스트 조회 부분에서 순서에 맞게 역 리스트 조회하는 부분
   - index 집어 넣었다가 -> 다시 index 없이 구현
3. 중간 구간에 구간을 추가하면서 생기는 순서 문제 부분
   - index 제거후에 하행역 매칭방식으로 구현
### 느낀 점
도메인 로직으로 비즈니스 로직을 내리면 수정사항이 생길 떄 아름답게 도메인 로직만 고치는 경험을 할 수 있었습니다!

