### PR TITLE
🚀 3단계: 경로 조회 기능

### DIFF
--- a/src/main/java/nextstep/subway/global/error/code/ErrorCode.java
+++ b/src/main/java/nextstep/subway/global/error/code/ErrorCode.java
@@ -13,7 +13,10 @@ public enum ErrorCode {
     INVALID_DISTANCE("기존 역 사이 길이보다 크거나 같으면 등록을 할 수 없다."),
     ALREADY_REGISTERED_SECTION("이미 등록되어있는 노선입니다."),
     UNREGISTERED_STATION("지하철 노선에 등록되어 있지 않은 역입니다."),
-    STAND_ALONE_LINE_SECTION("지하철 노선에 구간이 1개만 존재할 경우 삭제할 수 없습니다.");
+    STAND_ALONE_LINE_SECTION("지하철 노선에 구간이 1개만 존재할 경우 삭제할 수 없습니다."),
+
+    SAME_DEPARTURE_AND_ARRIVAL_STATIONS("출발역과 도착역이 같을 수 없습니다."),
+    UNLINKED_DEPARTURE_AND_ARRIVAL_STATIONS("출발역과 도착역이 연결되어 있지 않습니다.");
 
     private String message;
 

--- a/src/main/java/nextstep/subway/global/error/exception/InvalidPathException.java
+++ b/src/main/java/nextstep/subway/global/error/exception/InvalidPathException.java
@@ -1,0 +1,12 @@
+package nextstep.subway.global.error.exception;
+
+import nextstep.subway.global.error.code.ErrorCode;
+import org.springframework.http.HttpStatus;
+
+public class InvalidPathException extends BusinessException {
+
+    public InvalidPathException(ErrorCode errorCode) {
+        super(HttpStatus.BAD_REQUEST.value(), errorCode.getMessage());
+    }
+
+}

--- a/src/main/java/nextstep/subway/line/controller/LineController.java
+++ b/src/main/java/nextstep/subway/line/controller/LineController.java
@@ -1,10 +1,10 @@
 package nextstep.subway.line.controller;
 
 import lombok.RequiredArgsConstructor;
-import nextstep.subway.line.dto.request.SaveLineRequestDto;
-import nextstep.subway.line.dto.request.SaveLineSectionRequestDto;
-import nextstep.subway.line.dto.request.UpdateLineRequestDto;
-import nextstep.subway.line.dto.response.LineResponseDto;
+import nextstep.subway.line.dto.request.SaveLineRequest;
+import nextstep.subway.line.dto.request.SaveLineSectionRequest;
+import nextstep.subway.line.dto.request.UpdateLineRequest;
+import nextstep.subway.line.dto.response.LineResponse;
 import nextstep.subway.line.service.LineService;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
@@ -20,8 +20,8 @@ public class LineController {
     private final LineService lineService;
 
     @PostMapping("/lines")
-    public ResponseEntity<LineResponseDto> createLine(@RequestBody @Valid SaveLineRequestDto lineRequest) {
-        LineResponseDto line = lineService.saveLine(lineRequest);
+    public ResponseEntity<LineResponse> createLine(@RequestBody @Valid SaveLineRequest lineRequest) {
+        LineResponse line = lineService.saveLine(lineRequest);
 
         return ResponseEntity
                 .created(URI.create(String.format("/lines/%d", line.getId())))
@@ -29,19 +29,19 @@ public class LineController {
     }
 
     @GetMapping("/lines")
-    public ResponseEntity<List<LineResponseDto>> showLines() {
+    public ResponseEntity<List<LineResponse>> showLines() {
         return ResponseEntity.ok(lineService.findAllLines());
     }
 
     @GetMapping("/lines/{id}")
-    public ResponseEntity<LineResponseDto> showLine(@PathVariable Long id) {
+    public ResponseEntity<LineResponse> showLine(@PathVariable Long id) {
         return ResponseEntity.ok(lineService.findLineById(id));
     }
 
     @PutMapping("/lines/{id}")
     public ResponseEntity<Void> updateLine(
             @PathVariable Long id,
-            @RequestBody @Valid UpdateLineRequestDto lineRequest) {
+            @RequestBody @Valid UpdateLineRequest lineRequest) {
         lineService.updateLine(id, lineRequest);
         return ResponseEntity
                 .ok()
@@ -57,10 +57,10 @@ public class LineController {
     }
 
     @PostMapping("/lines/{lineId}/sections")
-    public ResponseEntity<LineResponseDto> saveLineSection(
+    public ResponseEntity<LineResponse> saveLineSection(
             @PathVariable Long lineId,
-            @RequestBody @Valid SaveLineSectionRequestDto lineSectionRequest) {
-        LineResponseDto line = lineService.saveLineSection(lineId, lineSectionRequest);
+            @RequestBody @Valid SaveLineSectionRequest lineSectionRequest) {
+        LineResponse line = lineService.saveLineSection(lineId, lineSectionRequest);
 
         return ResponseEntity
                 .created(URI.create(String.format("/lines/%d", line.getId())))

--- a/src/main/java/nextstep/subway/line/dto/request/SaveLineRequest.java
+++ b/src/main/java/nextstep/subway/line/dto/request/SaveLineRequest.java
@@ -1,19 +1,19 @@
 package nextstep.subway.line.dto.request;
 
-import lombok.AllArgsConstructor;
-import lombok.Builder;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
+import lombok.*;
 import nextstep.subway.line.entity.Line;
+import nextstep.subway.station.entity.Station;
 
+import javax.validation.constraints.Min;
 import javax.validation.constraints.NotBlank;
+import javax.validation.constraints.NotNull;
 import javax.validation.constraints.Size;
 
 @Builder
 @NoArgsConstructor
 @AllArgsConstructor
 @Getter
-public class UpdateLineRequestDto {
+public class SaveLineRequest {
 
     @NotBlank(message = "지하철 노선 이름은 빈칸일 수 없습니다.")
     @Size(max = 20, message = "지하철역 이름은 20자 이내여야 합니다.")
@@ -23,10 +23,23 @@ public class UpdateLineRequestDto {
     @Size(max = 7, message = "지하철 노선 색깔은 7자 이내여야 합니다.")
     private String color;
 
-    public Line toEntity() {
+    @NotNull
+    private Long upStationId;
+
+    @NotNull
+    private Long downStationId;
+
+    @NotNull
+    @Min(value = 1, message = "구간 거리는 1 이상이어야 합니다.")
+    private Integer distance;
+
+    public Line toEntity(Station upStation, Station downStation) {
         return Line.builder()
                 .name(name)
                 .color(color)
+                .upStation(upStation)
+                .downStation(downStation)
+                .distance(distance)
                 .build();
     }
 

--- a/src/main/java/nextstep/subway/line/dto/request/SaveLineSectionRequest.java
+++ b/src/main/java/nextstep/subway/line/dto/request/SaveLineSectionRequest.java
@@ -12,7 +12,7 @@ import javax.validation.constraints.NotNull;
 @NoArgsConstructor
 @AllArgsConstructor
 @Getter
-public class SaveLineSectionRequestDto {
+public class SaveLineSectionRequest {
 
     @NotNull
     private Long upStationId;

--- a/src/main/java/nextstep/subway/line/dto/request/UpdateLineRequest.java
+++ b/src/main/java/nextstep/subway/line/dto/request/UpdateLineRequest.java
@@ -1,19 +1,19 @@
 package nextstep.subway.line.dto.request;
 
-import lombok.*;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
 import nextstep.subway.line.entity.Line;
-import nextstep.subway.station.entity.Station;
 
-import javax.validation.constraints.Min;
 import javax.validation.constraints.NotBlank;
-import javax.validation.constraints.NotNull;
 import javax.validation.constraints.Size;
 
 @Builder
 @NoArgsConstructor
 @AllArgsConstructor
 @Getter
-public class SaveLineRequestDto {
+public class UpdateLineRequest {
 
     @NotBlank(message = "지하철 노선 이름은 빈칸일 수 없습니다.")
     @Size(max = 20, message = "지하철역 이름은 20자 이내여야 합니다.")
@@ -23,23 +23,10 @@ public class SaveLineRequestDto {
     @Size(max = 7, message = "지하철 노선 색깔은 7자 이내여야 합니다.")
     private String color;
 
-    @NotNull
-    private Long upStationId;
-
-    @NotNull
-    private Long downStationId;
-
-    @NotNull
-    @Min(value = 1, message = "구간 거리는 1 이상이어야 합니다.")
-    private Integer distance;
-
-    public Line toEntity(Station upStation, Station downStation) {
+    public Line toEntity() {
         return Line.builder()
                 .name(name)
                 .color(color)
-                .upStation(upStation)
-                .downStation(downStation)
-                .distance(distance)
                 .build();
     }
 

--- a/src/main/java/nextstep/subway/line/dto/response/LineResponse.java
+++ b/src/main/java/nextstep/subway/line/dto/response/LineResponse.java
@@ -3,14 +3,14 @@ package nextstep.subway.line.dto.response;
 import lombok.Builder;
 import lombok.Getter;
 import nextstep.subway.line.entity.Line;
-import nextstep.subway.station.dto.response.StationResponseDto;
+import nextstep.subway.station.dto.response.StationResponse;
 
 import java.util.List;
 import java.util.stream.Collectors;
 
 @Builder
 @Getter
-public class LineResponseDto {
+public class LineResponse {
 
     private Long id;
 
@@ -18,10 +18,10 @@ public class LineResponseDto {
 
     private String color;
 
-    private List<StationResponseDto> stations;
+    private List<StationResponse> stations;
 
-    public static LineResponseDto of(Line line) {
-        return LineResponseDto.builder()
+    public static LineResponse of(Line line) {
+        return LineResponse.builder()
                 .id(line.getId())
                 .name(line.getName())
                 .color(line.getColor())
@@ -29,7 +29,7 @@ public class LineResponseDto {
                         .getSections()
                         .getAllStations()
                         .stream()
-                        .map(StationResponseDto::of)
+                        .map(StationResponse::of)
                         .collect(Collectors.toList()))
                 .build();
     }

--- a/src/main/java/nextstep/subway/line/service/LineService.java
+++ b/src/main/java/nextstep/subway/line/service/LineService.java
@@ -2,10 +2,10 @@ package nextstep.subway.line.service;
 
 import lombok.RequiredArgsConstructor;
 import nextstep.subway.line.adapters.persistence.LineJpaAdapter;
-import nextstep.subway.line.dto.request.SaveLineRequestDto;
-import nextstep.subway.line.dto.request.SaveLineSectionRequestDto;
-import nextstep.subway.line.dto.request.UpdateLineRequestDto;
-import nextstep.subway.line.dto.response.LineResponseDto;
+import nextstep.subway.line.dto.request.SaveLineRequest;
+import nextstep.subway.line.dto.request.SaveLineSectionRequest;
+import nextstep.subway.line.dto.request.UpdateLineRequest;
+import nextstep.subway.line.dto.response.LineResponse;
 import nextstep.subway.line.entity.Line;
 import nextstep.subway.section.entity.Section;
 import nextstep.subway.station.adapters.persistence.StationJpaAdapter;
@@ -26,27 +26,27 @@ public class LineService {
     private final LineJpaAdapter lineJpaAdapter;
 
     @Transactional
-    public LineResponseDto saveLine(SaveLineRequestDto lineRequest) {
+    public LineResponse saveLine(SaveLineRequest lineRequest) {
         Station upStation = stationJpaAdapter.findById(lineRequest.getUpStationId());
         Station downStation = stationJpaAdapter.findById(lineRequest.getDownStationId());
 
         Line line = lineJpaAdapter.save(lineRequest.toEntity(upStation, downStation));
-        return LineResponseDto.of(line);
+        return LineResponse.of(line);
     }
 
-    public List<LineResponseDto> findAllLines() {
+    public List<LineResponse> findAllLines() {
         return lineJpaAdapter.findAll()
                 .stream()
-                .map(LineResponseDto::of)
+                .map(LineResponse::of)
                 .collect(Collectors.toList());
     }
 
-    public LineResponseDto findLineById(Long id) {
-        return LineResponseDto.of(lineJpaAdapter.findById(id));
+    public LineResponse findLineById(Long id) {
+        return LineResponse.of(lineJpaAdapter.findById(id));
     }
 
     @Transactional
-    public void updateLine(Long id, UpdateLineRequestDto lineRequest) {
+    public void updateLine(Long id, UpdateLineRequest lineRequest) {
         Line targetLine = lineJpaAdapter.findById(id);
         targetLine.updateLine(lineRequest.toEntity());
     }
@@ -57,7 +57,7 @@ public class LineService {
     }
 
     @Transactional
-    public LineResponseDto saveLineSection(Long lineId, SaveLineSectionRequestDto lineSectionRequest) {
+    public LineResponse saveLineSection(Long lineId, SaveLineSectionRequest lineSectionRequest) {
         Station upStation = stationJpaAdapter.findById(lineSectionRequest.getUpStationId());
         Station downStation = stationJpaAdapter.findById(lineSectionRequest.getDownStationId());
 
@@ -69,7 +69,7 @@ public class LineService {
                 .build();
         targetLine.addSection(section);
 
-        return LineResponseDto.of(targetLine);
+        return LineResponse.of(targetLine);
     }
 
     @Transactional

--- a/src/main/java/nextstep/subway/path/controller/PathController.java
+++ b/src/main/java/nextstep/subway/path/controller/PathController.java
@@ -1,0 +1,26 @@
+package nextstep.subway.path.controller;
+
+import lombok.RequiredArgsConstructor;
+import nextstep.subway.path.dto.request.PathRequest;
+import nextstep.subway.path.dto.response.PathResponse;
+import nextstep.subway.path.service.PathService;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import javax.validation.Valid;
+
+@RequiredArgsConstructor
+@RestController
+public class PathController {
+
+    private final PathService pathService;
+
+    @GetMapping("/paths")
+    public ResponseEntity<PathResponse> showShortestDistance(@Valid PathRequest pathRequest) {
+        PathResponse pathResponse = pathService.getShortestDistance(pathRequest);
+
+        return ResponseEntity.ok(pathResponse);
+    }
+
+}

--- a/src/main/java/nextstep/subway/path/dto/request/PathRequest.java
+++ b/src/main/java/nextstep/subway/path/dto/request/PathRequest.java
@@ -1,4 +1,22 @@
 package nextstep.subway.path.dto.request;
 
+import lombok.Getter;
+import lombok.Setter;
+
+import javax.validation.constraints.NotNull;
+
+@Getter
+@Setter
 public class PathRequest {
+
+    @NotNull(message = "출발역은 반드시 입력해야 합니다.")
+    private Long source;
+
+    @NotNull(message = "도착역은 반드시 입력해야 합니다.")
+    private Long target;
+
+    public boolean isSameSourceAndTarget() {
+        return source.equals(target);
+    }
+
 }

--- a/src/main/java/nextstep/subway/path/dto/request/PathRequest.java
+++ b/src/main/java/nextstep/subway/path/dto/request/PathRequest.java
@@ -1,0 +1,4 @@
+package nextstep.subway.path.dto.request;
+
+public class PathRequest {
+}

--- a/src/main/java/nextstep/subway/path/dto/request/PathRequest.java
+++ b/src/main/java/nextstep/subway/path/dto/request/PathRequest.java
@@ -1,12 +1,12 @@
 package nextstep.subway.path.dto.request;
 
-import lombok.Getter;
-import lombok.Setter;
+import lombok.*;
 
 import javax.validation.constraints.NotNull;
 
 @Getter
 @Setter
+@Builder
 public class PathRequest {
 
     @NotNull(message = "출발역은 반드시 입력해야 합니다.")

--- a/src/main/java/nextstep/subway/path/dto/response/PathResponse.java
+++ b/src/main/java/nextstep/subway/path/dto/response/PathResponse.java
@@ -1,0 +1,15 @@
+package nextstep.subway.path.dto.response;
+
+import lombok.Getter;
+import nextstep.subway.station.dto.response.StationResponse;
+
+import java.util.List;
+
+@Getter
+public class PathResponse {
+
+    List<StationResponse> stations;
+
+    Integer distance;
+
+}

--- a/src/main/java/nextstep/subway/path/dto/response/PathResponse.java
+++ b/src/main/java/nextstep/subway/path/dto/response/PathResponse.java
@@ -1,15 +1,33 @@
 package nextstep.subway.path.dto.response;
 
+import lombok.Builder;
 import lombok.Getter;
 import nextstep.subway.station.dto.response.StationResponse;
+import nextstep.subway.station.entity.Station;
+import org.jgrapht.GraphPath;
+import org.jgrapht.graph.DefaultWeightedEdge;
 
 import java.util.List;
+import java.util.stream.Collectors;
 
+@Builder
 @Getter
 public class PathResponse {
 
     List<StationResponse> stations;
 
     Integer distance;
+
+    public static PathResponse of(GraphPath<Station, DefaultWeightedEdge> path) {
+        List<StationResponse> stations = path.getVertexList()
+                .stream()
+                .map(StationResponse::of)
+                .collect(Collectors.toList());
+
+        return PathResponse.builder()
+                .stations(stations)
+                .distance((int) path.getWeight())
+                .build();
+    }
 
 }

--- a/src/main/java/nextstep/subway/path/service/PathService.java
+++ b/src/main/java/nextstep/subway/path/service/PathService.java
@@ -1,0 +1,54 @@
+package nextstep.subway.path.service;
+
+import lombok.RequiredArgsConstructor;
+import nextstep.subway.global.error.code.ErrorCode;
+import nextstep.subway.global.error.exception.InvalidPathException;
+import nextstep.subway.line.adapters.persistence.LineJpaAdapter;
+import nextstep.subway.line.entity.Line;
+import nextstep.subway.path.dto.request.PathRequest;
+import nextstep.subway.path.dto.response.PathResponse;
+import nextstep.subway.path.utils.ShortestPathHelper;
+import nextstep.subway.section.entity.Section;
+import nextstep.subway.station.adapters.persistence.StationJpaAdapter;
+import nextstep.subway.station.entity.Station;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class PathService {
+
+    private final StationJpaAdapter stationJpaAdapter;
+
+    private final LineJpaAdapter lineJpaAdapter;
+
+    public PathResponse getShortestDistance(PathRequest pathRequest) {
+        if (pathRequest.isSameSourceAndTarget()) {
+            throw new InvalidPathException(ErrorCode.SAME_DEPARTURE_AND_ARRIVAL_STATIONS);
+        }
+
+        Station source = stationJpaAdapter.findById(pathRequest.getSource());
+        Station target = stationJpaAdapter.findById(pathRequest.getTarget());
+
+        List<Station> stations = stationJpaAdapter.findAll();
+        List<Section> sections = lineJpaAdapter.findAll()
+                .stream()
+                .map(Line::getSections)
+                .flatMap(lineSections -> lineSections.getSections().stream())
+                .collect(Collectors.toList());
+
+        ShortestPathHelper shortestPathHelper = ShortestPathHelper.builder()
+                .stations(stations)
+                .sections(sections)
+                .source(source)
+                .target(target)
+                .build();
+
+        return PathResponse.of(shortestPathHelper.getPath());
+    }
+
+}

--- a/src/main/java/nextstep/subway/path/utils/ShortestPathHelper.java
+++ b/src/main/java/nextstep/subway/path/utils/ShortestPathHelper.java
@@ -1,0 +1,54 @@
+package nextstep.subway.path.utils;
+
+import lombok.Builder;
+import nextstep.subway.global.error.code.ErrorCode;
+import nextstep.subway.global.error.exception.InvalidPathException;
+import nextstep.subway.section.entity.Section;
+import nextstep.subway.station.entity.Station;
+import org.jgrapht.GraphPath;
+import org.jgrapht.alg.shortestpath.DijkstraShortestPath;
+import org.jgrapht.graph.DefaultWeightedEdge;
+import org.jgrapht.graph.WeightedMultigraph;
+
+import java.util.List;
+import java.util.Optional;
+
+public class ShortestPathHelper {
+
+    private final WeightedMultigraph<Station, DefaultWeightedEdge> graph = new WeightedMultigraph<>(DefaultWeightedEdge.class);
+
+    private final Station source;
+
+    private final Station target;
+
+    @Builder
+    public ShortestPathHelper(
+            List<Station> stations,
+            List<Section> sections,
+            Station source,
+            Station target
+    ) {
+        setVertexes(stations);
+        setEdges(sections);
+        this.source = source;
+        this.target = target;
+    }
+
+    public GraphPath<Station, DefaultWeightedEdge> getPath() {
+        DijkstraShortestPath<Station, DefaultWeightedEdge> dijkstraShortestPath = new DijkstraShortestPath<>(graph);
+        return Optional.ofNullable(dijkstraShortestPath.getPath(source, target))
+                .orElseThrow(() -> new InvalidPathException(ErrorCode.UNLINKED_DEPARTURE_AND_ARRIVAL_STATIONS));
+    }
+
+    private void setVertexes(List<Station> stations) {
+        stations.forEach(graph::addVertex);
+    }
+
+    private void setEdges(List<Section> sections) {
+        sections.forEach(section -> {
+            DefaultWeightedEdge edge = graph.addEdge(section.getUpStation(), section.getDownStation());
+            graph.setEdgeWeight(edge, section.getDistance());
+        });
+    }
+
+}

--- a/src/main/java/nextstep/subway/section/entity/Section.java
+++ b/src/main/java/nextstep/subway/section/entity/Section.java
@@ -6,6 +6,7 @@ import nextstep.subway.station.entity.Station;
 import javax.persistence.Embeddable;
 import javax.persistence.ManyToOne;
 
+@ToString
 @Builder
 @Getter
 @Embeddable

--- a/src/main/java/nextstep/subway/section/entity/Sections.java
+++ b/src/main/java/nextstep/subway/section/entity/Sections.java
@@ -50,11 +50,7 @@ public class Sections {
     }
 
     public void deleteSectionByStationId(Long stationId) {
-        List<Long> allStationIds = getAllStations()
-                .stream()
-                .map(Station::getId)
-                .collect(Collectors.toList());
-        if (!allStationIds.contains(stationId)) {
+        if (!containsStation(stationId)) {
             throw new InvalidLineSectionException(ErrorCode.UNREGISTERED_STATION);
         }
 
@@ -225,6 +221,15 @@ public class Sections {
         }
 
         return stations.get(index);
+    }
+
+    private boolean containsStation(Long stationId) {
+        List<Long> allStationIds = getAllStations()
+                .stream()
+                .map(Station::getId)
+                .collect(Collectors.toList());
+
+        return allStationIds.contains(stationId);
     }
 
     private boolean isUpStation(Long stationId) {

--- a/src/main/java/nextstep/subway/station/controller/StationController.java
+++ b/src/main/java/nextstep/subway/station/controller/StationController.java
@@ -1,8 +1,8 @@
 package nextstep.subway.station.controller;
 
 import lombok.RequiredArgsConstructor;
-import nextstep.subway.station.dto.request.SaveStationRequestDto;
-import nextstep.subway.station.dto.response.StationResponseDto;
+import nextstep.subway.station.dto.request.SaveStationRequest;
+import nextstep.subway.station.dto.response.StationResponse;
 import nextstep.subway.station.service.StationService;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
@@ -17,15 +17,15 @@ public class StationController {
     private final StationService stationService;
 
     @PostMapping("/stations")
-    public ResponseEntity<StationResponseDto> createStation(@RequestBody @Valid SaveStationRequestDto stationRequest) {
-        StationResponseDto station = stationService.saveStation(stationRequest);
+    public ResponseEntity<StationResponse> createStation(@RequestBody @Valid SaveStationRequest stationRequest) {
+        StationResponse station = stationService.saveStation(stationRequest);
         return ResponseEntity
                 .created(URI.create(String.format("/stations/%d", station.getId())))
                 .body(station);
     }
 
     @GetMapping(value = "/stations")
-    public ResponseEntity<List<StationResponseDto>> showStations() {
+    public ResponseEntity<List<StationResponse>> showStations() {
         return ResponseEntity.ok(stationService.findAllStations());
     }
 

--- a/src/main/java/nextstep/subway/station/dto/request/SaveStationRequest.java
+++ b/src/main/java/nextstep/subway/station/dto/request/SaveStationRequest.java
@@ -14,7 +14,7 @@ import javax.validation.constraints.Size;
 @NoArgsConstructor
 @AllArgsConstructor
 @Getter
-public class SaveStationRequestDto {
+public class SaveStationRequest {
 
     @NotBlank(message = "지하철역 이름은 빈칸일 수 없습니다.")
     @Size(max = 20, message = "지하철역 이름은 20자 이내여야 합니다.")

--- a/src/main/java/nextstep/subway/station/dto/response/StationResponse.java
+++ b/src/main/java/nextstep/subway/station/dto/response/StationResponse.java
@@ -6,14 +6,14 @@ import nextstep.subway.station.entity.Station;
 
 @Builder
 @Getter
-public class StationResponseDto {
+public class StationResponse {
 
     private Long id;
 
     private String name;
 
-    public static StationResponseDto of(Station station) {
-        return StationResponseDto.builder()
+    public static StationResponse of(Station station) {
+        return StationResponse.builder()
                 .id(station.getId())
                 .name(station.getName())
                 .build();

--- a/src/main/java/nextstep/subway/station/service/StationService.java
+++ b/src/main/java/nextstep/subway/station/service/StationService.java
@@ -2,8 +2,8 @@ package nextstep.subway.station.service;
 
 import lombok.RequiredArgsConstructor;
 import nextstep.subway.station.adapters.persistence.StationJpaAdapter;
-import nextstep.subway.station.dto.request.SaveStationRequestDto;
-import nextstep.subway.station.dto.response.StationResponseDto;
+import nextstep.subway.station.dto.request.SaveStationRequest;
+import nextstep.subway.station.dto.response.StationResponse;
 import nextstep.subway.station.entity.Station;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -18,15 +18,15 @@ public class StationService {
     private final StationJpaAdapter stationJpaAdapter;
 
     @Transactional
-    public StationResponseDto saveStation(SaveStationRequestDto stationRequest) {
+    public StationResponse saveStation(SaveStationRequest stationRequest) {
         Station station = stationJpaAdapter.save(stationRequest.toEntity());
-        return StationResponseDto.of(station);
+        return StationResponse.of(station);
     }
 
-    public List<StationResponseDto> findAllStations() {
+    public List<StationResponse> findAllStations() {
         return stationJpaAdapter.findAll()
                 .stream()
-                .map(StationResponseDto::of)
+                .map(StationResponse::of)
                 .collect(Collectors.toList());
     }
 

--- a/src/test/java/nextstep/subway/acceptance/constants/Endpoint.java
+++ b/src/test/java/nextstep/subway/acceptance/constants/Endpoint.java
@@ -3,7 +3,9 @@ package nextstep.subway.acceptance.constants;
 public enum Endpoint {
 
     STATION_BASE_URL("/stations"),
-    LINE_BASE_URL("/lines");
+    LINE_BASE_URL("/lines"),
+
+    PATH_BASE_URL("/paths");
 
     private final String url;
 

--- a/src/test/java/nextstep/subway/acceptance/line/LineAcceptanceTest.java
+++ b/src/test/java/nextstep/subway/acceptance/line/LineAcceptanceTest.java
@@ -4,7 +4,7 @@ import io.restassured.RestAssured;
 import io.restassured.response.ExtractableResponse;
 import io.restassured.response.Response;
 import nextstep.subway.acceptance.constants.Endpoint;
-import nextstep.subway.acceptance.station.StationFixture;
+import nextstep.subway.fixture.StationFixture;
 import nextstep.subway.line.dto.request.SaveLineRequestDto;
 import nextstep.subway.line.dto.request.UpdateLineRequestDto;
 import nextstep.subway.station.dto.request.SaveStationRequestDto;

--- a/src/test/java/nextstep/subway/acceptance/line/LineAcceptanceTest.java
+++ b/src/test/java/nextstep/subway/acceptance/line/LineAcceptanceTest.java
@@ -6,9 +6,8 @@ import io.restassured.response.Response;
 import nextstep.subway.acceptance.step.LineAcceptanceStep;
 import nextstep.subway.acceptance.step.StationAcceptanceStep;
 import nextstep.subway.fixture.StationFixture;
-import nextstep.subway.line.dto.request.SaveLineRequestDto;
-import nextstep.subway.line.dto.request.UpdateLineRequestDto;
-import nextstep.subway.station.dto.response.StationResponseDto;
+import nextstep.subway.line.dto.request.SaveLineRequest;
+import nextstep.subway.line.dto.request.UpdateLineRequest;
 import nextstep.subway.support.AcceptanceTest;
 import nextstep.subway.support.AssertUtils;
 import nextstep.subway.support.DatabaseCleanup;
@@ -33,6 +32,8 @@ public class LineAcceptanceTest {
     @LocalServerPort
     private int port;
 
+    private static final String STATION_ID_KEY = "id";
+
     private static final String LINE_ID_KEY = "id";
 
     private static final String LINE_NAME_KEY = "name";
@@ -55,18 +56,10 @@ public class LineAcceptanceTest {
         }
         databaseCleanUp.execute();
 
-        this.신사역_아이디 = StationAcceptanceStep.지하철역_생성을_요청한다(StationFixture.신사역)
-                .as(StationResponseDto.class)
-                .getId();
-        this.광교역_아이디 = StationAcceptanceStep.지하철역_생성을_요청한다(StationFixture.광교역)
-                .as(StationResponseDto.class)
-                .getId();
-        this.청량리역_아이디 = StationAcceptanceStep.지하철역_생성을_요청한다(StationFixture.청량리역)
-                .as(StationResponseDto.class)
-                .getId();
-        this.춘천역_아이디 = StationAcceptanceStep.지하철역_생성을_요청한다(StationFixture.춘천역)
-                .as(StationResponseDto.class)
-                .getId();
+        this.신사역_아이디 = StationAcceptanceStep.지하철역_생성을_요청한다(StationFixture.신사역).jsonPath().getLong(STATION_ID_KEY);
+        this.광교역_아이디 = StationAcceptanceStep.지하철역_생성을_요청한다(StationFixture.광교역).jsonPath().getLong(STATION_ID_KEY);
+        this.청량리역_아이디 = StationAcceptanceStep.지하철역_생성을_요청한다(StationFixture.청량리역).jsonPath().getLong(STATION_ID_KEY);
+        this.춘천역_아이디 = StationAcceptanceStep.지하철역_생성을_요청한다(StationFixture.춘천역).jsonPath().getLong(STATION_ID_KEY);
     }
 
     /**
@@ -79,7 +72,7 @@ public class LineAcceptanceTest {
     @Test
     void createLine() {
         // when
-        SaveLineRequestDto 신분당선 = 신분당선을_생성한다(신사역_아이디, 광교역_아이디);
+        SaveLineRequest 신분당선 = 신분당선을_생성한다(신사역_아이디, 광교역_아이디);
         LineAcceptanceStep.지하철_노선_생성을_요청한다(신분당선);
 
         // then
@@ -104,8 +97,8 @@ public class LineAcceptanceTest {
     @Test
     void readLines() {
         // given
-        SaveLineRequestDto 신분당선 = 신분당선을_생성한다(신사역_아이디, 광교역_아이디);
-        SaveLineRequestDto 경춘선 = 경춘선을_생성한다(청량리역_아이디, 춘천역_아이디);
+        SaveLineRequest 신분당선 = 신분당선을_생성한다(신사역_아이디, 광교역_아이디);
+        SaveLineRequest 경춘선 = 경춘선을_생성한다(청량리역_아이디, 춘천역_아이디);
         Stream.of(신분당선, 경춘선).forEach(LineAcceptanceStep::지하철_노선_생성을_요청한다);
 
         // when
@@ -128,7 +121,7 @@ public class LineAcceptanceTest {
     @Test
     void readLine() {
         // given
-        SaveLineRequestDto 경춘선 = 경춘선을_생성한다(청량리역_아이디, 춘천역_아이디);
+        SaveLineRequest 경춘선 = 경춘선을_생성한다(청량리역_아이디, 춘천역_아이디);
         Long 저장된_노선_아이디 = LineAcceptanceStep.지하철_노선_생성을_요청한다(경춘선)
                 .jsonPath()
                 .getLong(LINE_ID_KEY);
@@ -153,7 +146,7 @@ public class LineAcceptanceTest {
     @Test
     void updateLine() {
         // given
-        SaveLineRequestDto 신분당선 = 신분당선을_생성한다(신사역_아이디, 광교역_아이디);
+        SaveLineRequest 신분당선 = 신분당선을_생성한다(신사역_아이디, 광교역_아이디);
         Long 저장된_노선의_아이디 = LineAcceptanceStep.지하철_노선_생성을_요청한다(신분당선)
                 .jsonPath()
                 .getLong(LINE_ID_KEY);
@@ -184,7 +177,7 @@ public class LineAcceptanceTest {
     @Test
     void deleteLine() {
         // given
-        SaveLineRequestDto 경춘선 = 경춘선을_생성한다(청량리역_아이디, 춘천역_아이디);
+        SaveLineRequest 경춘선 = 경춘선을_생성한다(청량리역_아이디, 춘천역_아이디);
         Long 저장된_노선의_아이디 = LineAcceptanceStep.지하철_노선_생성을_요청한다(경춘선)
                 .jsonPath()
                 .getLong(LINE_ID_KEY);
@@ -204,8 +197,8 @@ public class LineAcceptanceTest {
         );
     }
 
-    private SaveLineRequestDto 신분당선을_생성한다(Long upStationId, Long downStationId) {
-        return SaveLineRequestDto.builder()
+    private SaveLineRequest 신분당선을_생성한다(Long upStationId, Long downStationId) {
+        return SaveLineRequest.builder()
                 .name("신분당선")
                 .color("#f5222d")
                 .distance(15)
@@ -214,8 +207,8 @@ public class LineAcceptanceTest {
                 .build();
     }
 
-    private SaveLineRequestDto 경춘선을_생성한다(Long upStationId, Long downStationId) {
-        return SaveLineRequestDto.builder()
+    private SaveLineRequest 경춘선을_생성한다(Long upStationId, Long downStationId) {
+        return SaveLineRequest.builder()
                 .name("경춘선")
                 .color("#13c2c2")
                 .distance(25)
@@ -224,7 +217,7 @@ public class LineAcceptanceTest {
                 .build();
     }
 
-    private final UpdateLineRequestDto 수정한_신분당선 = UpdateLineRequestDto.builder()
+    private final UpdateLineRequest 수정한_신분당선 = UpdateLineRequest.builder()
                     .name("수정한 신분당선")
                     .color("#cf1322")
                     .build();

--- a/src/test/java/nextstep/subway/acceptance/line/LineSectionAcceptanceTest.java
+++ b/src/test/java/nextstep/subway/acceptance/line/LineSectionAcceptanceTest.java
@@ -92,18 +92,12 @@ public class LineSectionAcceptanceTest {
         ExtractableResponse<Response> saveLineSectionResponse = saveLineSection(강남역_신사역_구간);
 
         // then
-        assertAll(
-                () -> assertThat(saveLineSectionResponse.statusCode()).isEqualTo(HttpStatus.CREATED.value()),
-                () -> {
-                    LineResponseDto 추가한_지하철_구간 = saveLineSectionResponse.as(LineResponseDto.class);
+        LineResponseDto 지하철_노선 = saveLineSectionResponse.as(LineResponseDto.class);
+        List<Long> 등록된_지하철역_아이디_목록 = 지하철노선에_등록된_지하철역_아이디_목록을_가져온다(지하철_노선);
 
-                    assertThat(
-                            추가한_지하철_구간.getStations()
-                                    .stream()
-                                    .map(StationResponseDto::getId)
-                                    .collect(Collectors.toList())
-                    ).containsExactly(강남역_아이디, 신사역_아이디, 판교역_아이디);
-                }
+        assertAll(
+                () -> assertThatStatusCode(saveLineSectionResponse, HttpStatus.CREATED),
+                () -> assertThat(등록된_지하철역_아이디_목록).containsExactly(강남역_아이디, 신사역_아이디, 판교역_아이디)
         );
     }
 
@@ -126,18 +120,12 @@ public class LineSectionAcceptanceTest {
         ExtractableResponse<Response> saveLineSectionResponse = saveLineSection(신사역_강남역_구간);
 
         // then
-        assertAll(
-                () -> assertThat(saveLineSectionResponse.statusCode()).isEqualTo(HttpStatus.CREATED.value()),
-                () -> {
-                    LineResponseDto 추가한_지하철_구간 = saveLineSectionResponse.as(LineResponseDto.class);
+        LineResponseDto 지하철_노선 = saveLineSectionResponse.as(LineResponseDto.class);
+        List<Long> 등록된_지하철역_아이디_목록 = 지하철노선에_등록된_지하철역_아이디_목록을_가져온다(지하철_노선);
 
-                    assertThat(
-                            추가한_지하철_구간.getStations()
-                                    .stream()
-                                    .map(StationResponseDto::getId)
-                                    .collect(Collectors.toList())
-                    ).containsExactly(신사역_아이디, 강남역_아이디, 판교역_아이디);
-                }
+        assertAll(
+                () -> assertThatStatusCode(saveLineSectionResponse, HttpStatus.CREATED),
+                () -> assertThat(등록된_지하철역_아이디_목록).containsExactly(신사역_아이디, 강남역_아이디, 판교역_아이디)
         );
     }
 
@@ -160,18 +148,12 @@ public class LineSectionAcceptanceTest {
         ExtractableResponse<Response> saveLineSectionResponse = saveLineSection(판교역_광교역_구간);
 
         // then
-        assertAll(
-                () -> assertThat(saveLineSectionResponse.statusCode()).isEqualTo(HttpStatus.CREATED.value()),
-                () -> {
-                    LineResponseDto 추가한_지하철_구간 = saveLineSectionResponse.as(LineResponseDto.class);
+        LineResponseDto 지하철_노선 = saveLineSectionResponse.as(LineResponseDto.class);
+        List<Long> 등록된_지하철역_아이디_목록 = 지하철노선에_등록된_지하철역_아이디_목록을_가져온다(지하철_노선);
 
-                    assertThat(
-                            추가한_지하철_구간.getStations()
-                                .stream()
-                                .map(StationResponseDto::getId)
-                                .collect(Collectors.toList())
-                    ).containsExactly(신사역_아이디, 판교역_아이디, 광교역_아이디);
-                }
+        assertAll(
+                () -> assertThatStatusCode(saveLineSectionResponse, HttpStatus.CREATED),
+                () -> assertThat(등록된_지하철역_아이디_목록).containsExactly(신사역_아이디, 판교역_아이디, 광교역_아이디)
         );
 
     }
@@ -199,20 +181,12 @@ public class LineSectionAcceptanceTest {
                 deleteLineSectionByStationId(신분당선의_상행_종점역_아이디);
 
         // then
-        assertAll(
-                () -> assertThat(deleteLineSectionByStationIdResponse.statusCode())
-                        .isEqualTo(HttpStatus.NO_CONTENT.value()),
-                () -> {
-                    List<Long> stationIds = RestAssuredClient.get(
-                                    String.format("%s/%d", LINE_BASE_URL, 신분당선.getId()))
-                            .jsonPath()
-                            .getList("stations", StationResponseDto.class)
-                            .stream()
-                            .map(StationResponseDto::getId)
-                            .collect(Collectors.toList());
+        ExtractableResponse<Response> 삭제_후_신분당선 = getLineByLineId(신분당선.getId());
+        List<Long> stationIds = 지하철노선에_등록된_지하철역_아이디_목록을_가져온다(삭제_후_신분당선);
 
-                    assertThat(stationIds).doesNotContain(신분당선의_상행_종점역_아이디);
-                }
+        assertAll(
+                () -> assertThatStatusCode(deleteLineSectionByStationIdResponse, HttpStatus.NO_CONTENT),
+                () -> assertThat(stationIds).doesNotContain(신분당선의_상행_종점역_아이디)
         );
     }
 
@@ -234,20 +208,12 @@ public class LineSectionAcceptanceTest {
         ExtractableResponse<Response> deleteLineSectionByStationIdResponse = deleteLineSectionByStationId(판교역_아이디);
 
         // then
-        assertAll(
-                () -> assertThat(deleteLineSectionByStationIdResponse.statusCode())
-                        .isEqualTo(HttpStatus.NO_CONTENT.value()),
-                () -> {
-                    List<Long> stationIds = RestAssuredClient.get(
-                                    String.format("%s/%d", LINE_BASE_URL, 신분당선.getId()))
-                            .jsonPath()
-                            .getList("stations", StationResponseDto.class)
-                            .stream()
-                            .map(StationResponseDto::getId)
-                            .collect(Collectors.toList());
+        ExtractableResponse<Response> 삭제_후_신분당선 = getLineByLineId(신분당선.getId());
+        List<Long> stationIds = 지하철노선에_등록된_지하철역_아이디_목록을_가져온다(삭제_후_신분당선);
 
-                    assertThat(stationIds).doesNotContain(판교역_아이디);
-                }
+        assertAll(
+                () -> assertThatStatusCode(deleteLineSectionByStationIdResponse, HttpStatus.NO_CONTENT),
+                () -> assertThat(stationIds).doesNotContain(판교역_아이디)
         );
     }
 
@@ -272,20 +238,12 @@ public class LineSectionAcceptanceTest {
                 deleteLineSectionByStationId(광교역이_하행_종점역인_구간.getDownStationId());
 
         // then
-        assertAll(
-                () -> assertThat(deleteLineSectionByStationIdResponse.statusCode())
-                        .isEqualTo(HttpStatus.NO_CONTENT.value()),
-                () -> {
-                    List<Long> stationIds = RestAssuredClient.get(
-                                    String.format("%s/%d", LINE_BASE_URL, 신분당선.getId()))
-                            .jsonPath()
-                            .getList("stations", StationResponseDto.class)
-                            .stream()
-                            .map(StationResponseDto::getId)
-                            .collect(Collectors.toList());
+        ExtractableResponse<Response> 삭제_후_신분당선 = getLineByLineId(신분당선.getId());
+        List<Long> stationIds = 지하철노선에_등록된_지하철역_아이디_목록을_가져온다(삭제_후_신분당선);
 
-                    assertThat(stationIds).doesNotContain(광교역이_하행_종점역인_구간.getDownStationId());
-                }
+        assertAll(
+                () -> assertThatStatusCode(deleteLineSectionByStationIdResponse, HttpStatus.NO_CONTENT),
+                () -> assertThat(stationIds).doesNotContain(광교역이_하행_종점역인_구간.getDownStationId())
         );
     }
 
@@ -311,13 +269,8 @@ public class LineSectionAcceptanceTest {
 
         // then
         assertAll(
-                () -> assertThat(deleteLineSectionByStationIdResponse.statusCode())
-                        .isEqualTo(HttpStatus.BAD_REQUEST.value()),
-                () -> assertThat(
-                        deleteLineSectionByStationIdResponse
-                                .jsonPath()
-                                .getList(ERROR_MESSAGES_KEY, String.class))
-                        .containsAnyOf(ErrorCode.UNREGISTERED_STATION.getMessage())
+                () -> assertThatStatusCode(deleteLineSectionByStationIdResponse, HttpStatus.BAD_REQUEST),
+                () -> assertThatErrorMessage(deleteLineSectionByStationIdResponse, ErrorCode.UNREGISTERED_STATION)
         );
     }
 
@@ -336,13 +289,8 @@ public class LineSectionAcceptanceTest {
 
         // then
         assertAll(
-                () -> assertThat(deleteLineSectionByStationIdResponse.statusCode())
-                        .isEqualTo(HttpStatus.BAD_REQUEST.value()),
-                () -> assertThat(
-                        deleteLineSectionByStationIdResponse
-                                .jsonPath()
-                                .getList(ERROR_MESSAGES_KEY, String.class))
-                        .containsAnyOf(ErrorCode.STAND_ALONE_LINE_SECTION.getMessage())
+                () -> assertThatStatusCode(deleteLineSectionByStationIdResponse, HttpStatus.BAD_REQUEST),
+                () -> assertThatErrorMessage(deleteLineSectionByStationIdResponse, ErrorCode.STAND_ALONE_LINE_SECTION)
         );
     }
 
@@ -373,6 +321,19 @@ public class LineSectionAcceptanceTest {
     private LineResponseDto saveLine(SaveLineRequestDto line) {
         return RestAssuredClient.post(LINE_BASE_URL, line)
                 .as(LineResponseDto.class);
+    }
+
+    /**
+     * <pre>
+     * 지하철 노선 id로
+     * 지하철 노선을 조회하는 API를 호출하는 함수
+     * </pre>
+     *
+     * @param lineId
+     * @return ExtractableResponse
+     */
+    private ExtractableResponse<Response> getLineByLineId(Long lineId) {
+        return RestAssuredClient.get(String.format("%s/%d", LINE_BASE_URL, lineId));
     }
 
     /**
@@ -408,6 +369,46 @@ public class LineSectionAcceptanceTest {
         );
     }
 
+    /**
+     * <pre>
+     * 응답코드에 대한 검증
+     * </pre>
+     *
+     * @param response
+     * @param status
+     */
+    private void assertThatStatusCode(ExtractableResponse<Response> response, HttpStatus status) {
+        assertThat(response.statusCode()).isEqualTo(status.value());
+    }
+
+    /**
+     * <pre>
+     * 에러메시지에 대한 검증
+     * </pre>
+     *
+     * @param response
+     * @param errorCode
+     */
+    private void assertThatErrorMessage(ExtractableResponse<Response> response, ErrorCode errorCode) {
+        assertThat(response.jsonPath().getList(ERROR_MESSAGES_KEY, String.class))
+                .containsAnyOf(errorCode.getMessage());
+    }
+
+    private List<Long> 지하철노선에_등록된_지하철역_아이디_목록을_가져온다(LineResponseDto lineResponseDto) {
+        return lineResponseDto.getStations()
+                .stream()
+                .map(StationResponseDto::getId)
+                .collect(Collectors.toList());
+    }
+
+    private List<Long> 지하철노선에_등록된_지하철역_아이디_목록을_가져온다(ExtractableResponse<Response> response) {
+        return response
+                .jsonPath()
+                .getList("stations", StationResponseDto.class)
+                .stream()
+                .map(StationResponseDto::getId)
+                .collect(Collectors.toList());
+    }
 
     private SaveLineSectionRequestDto 광교역이_하행_종점역인_구간을_생성한다(Long upStationId) {
         return SaveLineSectionRequestDto.builder()

--- a/src/test/java/nextstep/subway/acceptance/line/LineSectionAcceptanceTest.java
+++ b/src/test/java/nextstep/subway/acceptance/line/LineSectionAcceptanceTest.java
@@ -4,7 +4,7 @@ import io.restassured.RestAssured;
 import io.restassured.response.ExtractableResponse;
 import io.restassured.response.Response;
 import nextstep.subway.acceptance.constants.Endpoint;
-import nextstep.subway.acceptance.station.StationFixture;
+import nextstep.subway.fixture.StationFixture;
 import nextstep.subway.global.error.code.ErrorCode;
 import nextstep.subway.line.dto.request.SaveLineRequestDto;
 import nextstep.subway.line.dto.request.SaveLineSectionRequestDto;

--- a/src/test/java/nextstep/subway/acceptance/line/LineSectionAcceptanceTest.java
+++ b/src/test/java/nextstep/subway/acceptance/line/LineSectionAcceptanceTest.java
@@ -3,16 +3,15 @@ package nextstep.subway.acceptance.line;
 import io.restassured.RestAssured;
 import io.restassured.response.ExtractableResponse;
 import io.restassured.response.Response;
-import nextstep.subway.acceptance.constants.Endpoint;
 import nextstep.subway.acceptance.step.LineAcceptanceStep;
 import nextstep.subway.acceptance.step.LineSectionAcceptanceStep;
 import nextstep.subway.acceptance.step.StationAcceptanceStep;
 import nextstep.subway.fixture.StationFixture;
 import nextstep.subway.global.error.code.ErrorCode;
-import nextstep.subway.line.dto.request.SaveLineRequestDto;
-import nextstep.subway.line.dto.request.SaveLineSectionRequestDto;
-import nextstep.subway.line.dto.response.LineResponseDto;
-import nextstep.subway.station.dto.response.StationResponseDto;
+import nextstep.subway.line.dto.request.SaveLineRequest;
+import nextstep.subway.line.dto.request.SaveLineSectionRequest;
+import nextstep.subway.line.dto.response.LineResponse;
+import nextstep.subway.station.dto.response.StationResponse;
 import nextstep.subway.support.AcceptanceTest;
 import nextstep.subway.support.AssertUtils;
 import nextstep.subway.support.DatabaseCleanup;
@@ -37,6 +36,8 @@ public class LineSectionAcceptanceTest {
     @LocalServerPort
     private int port;
 
+    private static final String STATION_ID_KEY = "id";
+
     private Long 신사역_아이디;
 
     private Long 강남역_아이디;
@@ -45,7 +46,7 @@ public class LineSectionAcceptanceTest {
 
     private Long 광교역_아이디;
 
-    private LineResponseDto 신분당선;
+    private LineResponse 신분당선;
 
     @Autowired
     private DatabaseCleanup databaseCleanup;
@@ -57,27 +58,19 @@ public class LineSectionAcceptanceTest {
         }
         databaseCleanup.execute();
 
-        this.신사역_아이디 = StationAcceptanceStep.지하철역_생성을_요청한다(StationFixture.신사역)
-                .as(StationResponseDto.class)
-                .getId();
-        this.강남역_아이디 = StationAcceptanceStep.지하철역_생성을_요청한다(StationFixture.강남역)
-                .as(StationResponseDto.class)
-                .getId();
-        this.판교역_아이디 = StationAcceptanceStep.지하철역_생성을_요청한다(StationFixture.판교역)
-                .as(StationResponseDto.class)
-                .getId();
-        this.광교역_아이디 = StationAcceptanceStep.지하철역_생성을_요청한다(StationFixture.광교역)
-                .as(StationResponseDto.class)
-                .getId();
+        this.신사역_아이디 = StationAcceptanceStep.지하철역_생성을_요청한다(StationFixture.신사역).jsonPath().getLong(STATION_ID_KEY);
+        this.강남역_아이디 = StationAcceptanceStep.지하철역_생성을_요청한다(StationFixture.강남역).jsonPath().getLong(STATION_ID_KEY);
+        this.판교역_아이디 = StationAcceptanceStep.지하철역_생성을_요청한다(StationFixture.판교역).jsonPath().getLong(STATION_ID_KEY);
+        this.광교역_아이디 = StationAcceptanceStep.지하철역_생성을_요청한다(StationFixture.광교역).jsonPath().getLong(STATION_ID_KEY);
 
-        SaveLineRequestDto 저장할_신분당선 = SaveLineRequestDto.builder()
+        SaveLineRequest 저장할_신분당선 = SaveLineRequest.builder()
                 .name("신분당선")
                 .color("#f5222d")
                 .distance(7)
                 .upStationId(this.신사역_아이디)
                 .downStationId(this.판교역_아이디)
                 .build();
-        this.신분당선 = LineAcceptanceStep.지하철_노선_생성을_요청한다(저장할_신분당선).as(LineResponseDto.class);
+        this.신분당선 = LineAcceptanceStep.지하철_노선_생성을_요청한다(저장할_신분당선).as(LineResponse.class);
     }
 
     /**
@@ -91,7 +84,7 @@ public class LineSectionAcceptanceTest {
     @Test
     void addFirstLineSection() {
         // when
-        SaveLineSectionRequestDto 강남역_신사역_구간 = SaveLineSectionRequestDto.builder()
+        SaveLineSectionRequest 강남역_신사역_구간 = SaveLineSectionRequest.builder()
                 .upStationId(강남역_아이디)
                 .downStationId(신사역_아이디)
                 .distance(3)
@@ -100,7 +93,7 @@ public class LineSectionAcceptanceTest {
                 LineSectionAcceptanceStep.지하철_구간_생성을_요청한다(강남역_신사역_구간, 신분당선.getId());
 
         // then
-        LineResponseDto 지하철_노선 = 지하쳘_구간_생성_응답.as(LineResponseDto.class);
+        LineResponse 지하철_노선 = 지하쳘_구간_생성_응답.as(LineResponse.class);
         List<Long> 등록된_지하철역_아이디_목록 = 지하철노선에_등록된_지하철역_아이디_목록을_가져온다(지하철_노선);
 
         assertAll(
@@ -120,7 +113,7 @@ public class LineSectionAcceptanceTest {
     @Test
     void addMiddleLineSection() {
         // when
-        SaveLineSectionRequestDto 신사역_강남역_구간 = SaveLineSectionRequestDto.builder()
+        SaveLineSectionRequest 신사역_강남역_구간 = SaveLineSectionRequest.builder()
                 .upStationId(신사역_아이디)
                 .downStationId(강남역_아이디)
                 .distance(3)
@@ -129,7 +122,7 @@ public class LineSectionAcceptanceTest {
                 LineSectionAcceptanceStep.지하철_구간_생성을_요청한다(신사역_강남역_구간, 신분당선.getId());
 
         // then
-        LineResponseDto 지하철_노선 = 지하쳘_노선_생성_응답.as(LineResponseDto.class);
+        LineResponse 지하철_노선 = 지하쳘_노선_생성_응답.as(LineResponse.class);
         List<Long> 등록된_지하철역_아이디_목록 = 지하철노선에_등록된_지하철역_아이디_목록을_가져온다(지하철_노선);
 
         assertAll(
@@ -149,7 +142,7 @@ public class LineSectionAcceptanceTest {
     @Test
     void addLastLineSection() {
         // when
-        SaveLineSectionRequestDto 판교역_광교역_구간 = SaveLineSectionRequestDto.builder()
+        SaveLineSectionRequest 판교역_광교역_구간 = SaveLineSectionRequest.builder()
                 .upStationId(판교역_아이디)
                 .downStationId(광교역_아이디)
                 .distance(8)
@@ -158,7 +151,7 @@ public class LineSectionAcceptanceTest {
                 LineSectionAcceptanceStep.지하철_구간_생성을_요청한다(판교역_광교역_구간, 신분당선.getId());
 
         // then
-        LineResponseDto 지하철_노선 = 지하쳘_노선_생성_응답.as(LineResponseDto.class);
+        LineResponse 지하철_노선 = 지하쳘_노선_생성_응답.as(LineResponse.class);
         List<Long> 등록된_지하철역_아이디_목록 = 지하철노선에_등록된_지하철역_아이디_목록을_가져온다(지하철_노선);
 
         assertAll(
@@ -179,12 +172,12 @@ public class LineSectionAcceptanceTest {
     @Test
     void deleteFirstLineSection() {
         // given
-        SaveLineSectionRequestDto 광교역이_하행_종점역인_구간 = 광교역이_하행_종점역인_구간을_생성한다(
+        SaveLineSectionRequest 광교역이_하행_종점역인_구간 = 광교역이_하행_종점역인_구간을_생성한다(
                 지하철_노선의_하행_종점역_아이디를_찾는다(신분당선)
         );
-        LineResponseDto 광교역이_하행_종점역으로_추가된_신분당선 =
+        LineResponse 광교역이_하행_종점역으로_추가된_신분당선 =
                 LineSectionAcceptanceStep.지하철_구간_생성을_요청한다(광교역이_하행_종점역인_구간, 신분당선.getId())
-                .as(LineResponseDto.class);
+                .as(LineResponse.class);
 
         // when
         Long 신분당선의_상행_종점역_아이디 = 지하철_노선의_상행_종점역_아이디를_찾는다(광교역이_하행_종점역으로_추가된_신분당선);
@@ -212,7 +205,7 @@ public class LineSectionAcceptanceTest {
     @Test
     void deleteMiddleLineSection() {
         // given
-        SaveLineSectionRequestDto 광교역이_하행_종점역인_구간 = 광교역이_하행_종점역인_구간을_생성한다(판교역_아이디);
+        SaveLineSectionRequest 광교역이_하행_종점역인_구간 = 광교역이_하행_종점역인_구간을_생성한다(판교역_아이디);
         LineSectionAcceptanceStep.지하철_구간_생성을_요청한다(광교역이_하행_종점역인_구간, 신분당선.getId());
 
         // when
@@ -240,7 +233,7 @@ public class LineSectionAcceptanceTest {
     @Test
     void deleteLastLineSection() {
         // given
-        SaveLineSectionRequestDto 광교역이_하행_종점역인_구간 = 광교역이_하행_종점역인_구간을_생성한다(
+        SaveLineSectionRequest 광교역이_하행_종점역인_구간 = 광교역이_하행_종점역인_구간을_생성한다(
                 지하철_노선의_하행_종점역_아이디를_찾는다(신분당선)
         );
         LineSectionAcceptanceStep.지하철_구간_생성을_요청한다(광교역이_하행_종점역인_구간, 신분당선.getId());
@@ -270,7 +263,7 @@ public class LineSectionAcceptanceTest {
     @Test
     void deleteNotExistLineSection() {
         // given
-        SaveLineSectionRequestDto 광교역이_하행_종점역인_구간 = 광교역이_하행_종점역인_구간을_생성한다(
+        SaveLineSectionRequest 광교역이_하행_종점역인_구간 = 광교역이_하행_종점역인_구간을_생성한다(
                 지하철_노선의_하행_종점역_아이디를_찾는다(신분당선)
         );
         LineSectionAcceptanceStep.지하철_구간_생성을_요청한다(광교역이_하행_종점역인_구간, 신분당선.getId());
@@ -306,39 +299,39 @@ public class LineSectionAcceptanceTest {
         );
     }
 
-    private List<Long> 지하철노선에_등록된_지하철역_아이디_목록을_가져온다(LineResponseDto lineResponseDto) {
+    private List<Long> 지하철노선에_등록된_지하철역_아이디_목록을_가져온다(LineResponse lineResponseDto) {
         return lineResponseDto.getStations()
                 .stream()
-                .map(StationResponseDto::getId)
+                .map(StationResponse::getId)
                 .collect(Collectors.toList());
     }
 
     private List<Long> 지하철노선에_등록된_지하철역_아이디_목록을_가져온다(ExtractableResponse<Response> response) {
         return response
                 .jsonPath()
-                .getList("stations", StationResponseDto.class)
+                .getList("stations", StationResponse.class)
                 .stream()
-                .map(StationResponseDto::getId)
+                .map(StationResponse::getId)
                 .collect(Collectors.toList());
     }
 
-    private SaveLineSectionRequestDto 광교역이_하행_종점역인_구간을_생성한다(Long upStationId) {
-        return SaveLineSectionRequestDto.builder()
+    private SaveLineSectionRequest 광교역이_하행_종점역인_구간을_생성한다(Long upStationId) {
+        return SaveLineSectionRequest.builder()
                 .upStationId(upStationId)
                 .downStationId(this.광교역_아이디)
                 .distance(8)
                 .build();
     }
 
-    private Long 지하철_노선의_상행_종점역_아이디를_찾는다(LineResponseDto lineResponseDto) {
-        List<StationResponseDto> stations = lineResponseDto.getStations();
+    private Long 지하철_노선의_상행_종점역_아이디를_찾는다(LineResponse lineResponseDto) {
+        List<StationResponse> stations = lineResponseDto.getStations();
         return stations
                 .get(0)
                 .getId();
     }
 
-    private Long 지하철_노선의_하행_종점역_아이디를_찾는다(LineResponseDto lineResponseDto) {
-        List<StationResponseDto> stations = lineResponseDto.getStations();
+    private Long 지하철_노선의_하행_종점역_아이디를_찾는다(LineResponse lineResponseDto) {
+        List<StationResponse> stations = lineResponseDto.getStations();
         int lastIndex = stations.size() - 1;
         return stations
                 .get(lastIndex)

--- a/src/test/java/nextstep/subway/acceptance/path/PathAcceptanceTest.java
+++ b/src/test/java/nextstep/subway/acceptance/path/PathAcceptanceTest.java
@@ -64,7 +64,7 @@ public class PathAcceptanceTest {
      * |                              |
      * *3호선(2)*                      *신분당선(10)*
      * |                              |
-     * 남부터미널역  --- *3호선(3)* --- 양재
+     * 남부터미널역  --- *3호선(3)* --- 양재역
      * </pre>
      */
     @BeforeEach
@@ -171,7 +171,7 @@ public class PathAcceptanceTest {
      * Then 조회에 실패한다.
      * </pre>
      */
-    @DisplayName("출발역과 도착역이 같은 경로를 조회한다.")
+    @DisplayName("출발역과 도착역이 연결이 되어 있지 않은 경우에 경로를 조회한다.")
     @Test
     void getUnlinkedDepartureAndArrivalStations() {
         // when

--- a/src/test/java/nextstep/subway/acceptance/path/PathAcceptanceTest.java
+++ b/src/test/java/nextstep/subway/acceptance/path/PathAcceptanceTest.java
@@ -1,14 +1,34 @@
 package nextstep.subway.acceptance.path;
 
 import io.restassured.RestAssured;
+import io.restassured.response.ExtractableResponse;
+import io.restassured.response.Response;
+import nextstep.subway.acceptance.step.LineAcceptanceStep;
+import nextstep.subway.acceptance.step.LineSectionAcceptanceStep;
+import nextstep.subway.acceptance.step.PathAcceptanceStep;
+import nextstep.subway.acceptance.step.StationAcceptanceStep;
+import nextstep.subway.fixture.StationFixture;
+import nextstep.subway.global.error.code.ErrorCode;
+import nextstep.subway.line.dto.request.SaveLineRequest;
+import nextstep.subway.line.dto.request.SaveLineSectionRequest;
+import nextstep.subway.path.dto.response.PathResponse;
+import nextstep.subway.station.dto.response.StationResponse;
 import nextstep.subway.support.AcceptanceTest;
+import nextstep.subway.support.AssertUtils;
 import nextstep.subway.support.DatabaseCleanup;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.web.server.LocalServerPort;
+import org.springframework.http.HttpStatus;
+
+import java.util.List;
+import java.util.stream.Collectors;
 
 import static io.restassured.RestAssured.UNDEFINED_PORT;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertAll;
 
 @DisplayName("지하철 경로 조회 기능")
 @AcceptanceTest
@@ -17,30 +37,185 @@ public class PathAcceptanceTest {
     @LocalServerPort
     private int port;
 
+    private static final String STATION_ID_KEY = "id";
+
+    private static final String LINE_ID_KEY = "id";
+
+    private Long 교대역;
+
+    private Long 강남역;
+
+    private Long 양재역;
+
+    private Long 남부터미널역;
+
+    private Long 판교역;
+
+    private Long 삼호선;
+
     @Autowired
     private DatabaseCleanup databaseCleanup;
 
-    private Long 신사역_아이디;
-
-    private Long 강남역_아이디;
-
-    private Long 판교역_아이디;
-
-    private Long 광교역_아이디;
-
+    /**
+     * <pre>
+     * 청량리역
+     *
+     * 교대역    --- *2호선(10)* ---   강남역
+     * |                              |
+     * *3호선(2)*                      *신분당선(10)*
+     * |                              |
+     * 남부터미널역  --- *3호선(3)* --- 양재
+     * </pre>
+     */
     @BeforeEach
     void setUp() {
         if (RestAssured.port == UNDEFINED_PORT) {
             RestAssured.port = port;
         }
         databaseCleanup.execute();
+
+        this.교대역 = StationAcceptanceStep.지하철역_생성을_요청한다(StationFixture.교대역).jsonPath().getLong(STATION_ID_KEY);
+        this.강남역 = StationAcceptanceStep.지하철역_생성을_요청한다(StationFixture.강남역).jsonPath().getLong(STATION_ID_KEY);
+        this.양재역 = StationAcceptanceStep.지하철역_생성을_요청한다(StationFixture.양재역).jsonPath().getLong(STATION_ID_KEY);
+        this.남부터미널역 = StationAcceptanceStep.지하철역_생성을_요청한다(StationFixture.남부터미널역).jsonPath().getLong(STATION_ID_KEY);
+        this.판교역 = StationAcceptanceStep.지하철역_생성을_요청한다(StationFixture.판교역).jsonPath().getLong(STATION_ID_KEY);
+
+        SaveLineRequest 생성할_이호선 = SaveLineRequest.builder()
+                .name("2호선")
+                .color("#52c41a")
+                .upStationId(교대역)
+                .downStationId(강남역)
+                .distance(10)
+                .build();
+        SaveLineRequest 생성할_신분당선 = SaveLineRequest.builder()
+                .name("신분당선")
+                .color("#f5222d")
+                .upStationId(강남역)
+                .downStationId(양재역)
+                .distance(10)
+                .build();
+        SaveLineRequest 생성할_삼호선 = SaveLineRequest.builder()
+                .name("3호선")
+                .color("#fa8c16")
+                .upStationId(교대역)
+                .downStationId(남부터미널역)
+                .distance(2)
+                .build();
+        LineAcceptanceStep.지하철_노선_생성을_요청한다(생성할_이호선)
+                .jsonPath()
+                .getLong(LINE_ID_KEY);
+        LineAcceptanceStep.지하철_노선_생성을_요청한다(생성할_신분당선)
+                .jsonPath()
+                .getLong(LINE_ID_KEY);
+        this.삼호선 = LineAcceptanceStep.지하철_노선_생성을_요청한다(생성할_삼호선)
+                .jsonPath()
+                .getLong(LINE_ID_KEY);
+
+        SaveLineSectionRequest 삼호선에_생성할_구간 = SaveLineSectionRequest.builder()
+                .upStationId(남부터미널역)
+                .downStationId(양재역)
+                .distance(3)
+                .build();
+        LineSectionAcceptanceStep.지하철_구간_생성을_요청한다(삼호선에_생성할_구간, 삼호선);
     }
 
     /**
      * <pre>
-     *
+     * When 교대역 - 양재역의 최단 거리 경로를 조회하면
+     * Then 교대역 - 남부터미널역 - 양재역의 경로가 조회된다.
+     * Then 5m 거리가 조회된다.
      * </pre>
      */
+    @DisplayName("최단 거리 경로를 조회한다.")
+    @Test
+    void getShortestDistance() {
+        // when
+        PathResponse 최단_거리_경로_조회_응답 = PathAcceptanceStep.최단_거리_경로_조회를_요청한다(교대역, 양재역)
+                .as(PathResponse.class);
 
+        // then
+        List<Long> 최단_거리_경로에_존재하는_역_아이디_목록 =  최단_거리_경로_조회_응답.getStations()
+                .stream()
+                .map(StationResponse::getId)
+                .collect(Collectors.toList());
 
+        Integer 최단_거리 = 최단_거리_경로_조회_응답.getDistance();
+
+        assertAll(
+                () -> assertThat(최단_거리_경로에_존재하는_역_아이디_목록).containsExactly(교대역, 남부터미널역, 양재역),
+                () -> assertThat(최단_거리).isEqualTo(5)
+        );
+    }
+
+    /**
+     * <pre>
+     * When 강남역 - 강남역의 최단 거리 경로를 조회하면
+     * Then 조회에 실패한다.
+     * </pre>
+     */
+    @DisplayName("출발역과 도착역이 같은 경로를 조회한다.")
+    @Test
+    void getSameDepartureAndArrivalStations() {
+        // when
+        ExtractableResponse<Response> 최단_거리_경로_조회_응답 = PathAcceptanceStep.최단_거리_경로_조회를_요청한다(강남역, 강남역);
+
+        assertAll(
+                () -> AssertUtils.assertThatStatusCode(최단_거리_경로_조회_응답, HttpStatus.BAD_REQUEST),
+                () -> AssertUtils.assertThatErrorMessage(최단_거리_경로_조회_응답, ErrorCode.SAME_DEPARTURE_AND_ARRIVAL_STATIONS)
+        );
+    }
+
+    /**
+     * <pre>
+     * When 강남역 - 판교역(연결되어 있지 않음)의 최단 거리 경로를 조회하면
+     * Then 조회에 실패한다.
+     * </pre>
+     */
+    @DisplayName("출발역과 도착역이 같은 경로를 조회한다.")
+    @Test
+    void getUnlinkedDepartureAndArrivalStations() {
+        // when
+        ExtractableResponse<Response> 최단_거리_경로_조회_응답 = PathAcceptanceStep.최단_거리_경로_조회를_요청한다(강남역, 판교역);
+
+        assertAll(
+                () -> AssertUtils.assertThatStatusCode(최단_거리_경로_조회_응답, HttpStatus.BAD_REQUEST),
+                () -> AssertUtils.assertThatErrorMessage(최단_거리_경로_조회_응답, ErrorCode.UNLINKED_DEPARTURE_AND_ARRIVAL_STATIONS)
+        );
+    }
+
+    /**
+     * <pre>
+     * When 존재하지 않은 역 - 양재역의 최단 거리 경로를 조회하면
+     * Then 조회에 실패한다.
+     * </pre>
+     */
+    @DisplayName("등록되어 있지 않은 역이 출발역인 최단 경로를 조회한다.")
+    @Test
+    void getShortestDistanceWhenNotExistDepartureStation() {
+        // when
+        ExtractableResponse<Response> 최단_거리_경로_조회_응답 = PathAcceptanceStep.최단_거리_경로_조회를_요청한다(0L, 판교역);
+
+        assertAll(
+                () -> AssertUtils.assertThatStatusCode(최단_거리_경로_조회_응답, HttpStatus.BAD_REQUEST),
+                () -> AssertUtils.assertThatErrorMessage(최단_거리_경로_조회_응답, ErrorCode.NOT_EXIST_STATION)
+        );
+    }
+
+    /**
+     * <pre>
+     * When 남부터미널역 - 존재하지 않은 역의 최단 거리 경로를 조회하면
+     * Then 조회에 실패한다.
+     * </pre>
+     */
+    @DisplayName("등록되어 있지 않은 역이 도착역인 최단 경로를 조회한다.")
+    @Test
+    void getShortestDistanceWhenNotExistArrivalStation() {
+        // when
+        ExtractableResponse<Response> 최단_거리_경로_조회_응답 = PathAcceptanceStep.최단_거리_경로_조회를_요청한다(남부터미널역, 0L);
+
+        assertAll(
+                () -> AssertUtils.assertThatStatusCode(최단_거리_경로_조회_응답, HttpStatus.BAD_REQUEST),
+                () -> AssertUtils.assertThatErrorMessage(최단_거리_경로_조회_응답, ErrorCode.NOT_EXIST_STATION)
+        );
+    }
 }

--- a/src/test/java/nextstep/subway/acceptance/path/PathAcceptanceTest.java
+++ b/src/test/java/nextstep/subway/acceptance/path/PathAcceptanceTest.java
@@ -1,0 +1,46 @@
+package nextstep.subway.acceptance.path;
+
+import io.restassured.RestAssured;
+import nextstep.subway.support.AcceptanceTest;
+import nextstep.subway.support.DatabaseCleanup;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.web.server.LocalServerPort;
+
+import static io.restassured.RestAssured.UNDEFINED_PORT;
+
+@DisplayName("지하철 경로 조회 기능")
+@AcceptanceTest
+public class PathAcceptanceTest {
+
+    @LocalServerPort
+    private int port;
+
+    @Autowired
+    private DatabaseCleanup databaseCleanup;
+
+    private Long 신사역_아이디;
+
+    private Long 강남역_아이디;
+
+    private Long 판교역_아이디;
+
+    private Long 광교역_아이디;
+
+    @BeforeEach
+    void setUp() {
+        if (RestAssured.port == UNDEFINED_PORT) {
+            RestAssured.port = port;
+        }
+        databaseCleanup.execute();
+    }
+
+    /**
+     * <pre>
+     *
+     * </pre>
+     */
+
+
+}

--- a/src/test/java/nextstep/subway/acceptance/station/StationAcceptanceTest.java
+++ b/src/test/java/nextstep/subway/acceptance/station/StationAcceptanceTest.java
@@ -4,6 +4,7 @@ import io.restassured.RestAssured;
 import io.restassured.response.ExtractableResponse;
 import io.restassured.response.Response;
 import nextstep.subway.acceptance.constants.Endpoint;
+import nextstep.subway.fixture.StationFixture;
 import nextstep.subway.station.dto.request.SaveStationRequestDto;
 import nextstep.subway.support.AcceptanceTest;
 import nextstep.subway.support.DatabaseCleanup;

--- a/src/test/java/nextstep/subway/acceptance/station/StationAcceptanceTest.java
+++ b/src/test/java/nextstep/subway/acceptance/station/StationAcceptanceTest.java
@@ -5,7 +5,7 @@ import io.restassured.response.ExtractableResponse;
 import io.restassured.response.Response;
 import nextstep.subway.acceptance.step.StationAcceptanceStep;
 import nextstep.subway.fixture.StationFixture;
-import nextstep.subway.station.dto.request.SaveStationRequestDto;
+import nextstep.subway.station.dto.request.SaveStationRequest;
 import nextstep.subway.support.AcceptanceTest;
 import nextstep.subway.support.AssertUtils;
 import nextstep.subway.support.DatabaseCleanup;
@@ -53,7 +53,7 @@ public class StationAcceptanceTest {
     @Test
     void createStation() {
         // when
-        SaveStationRequestDto 강남역 = StationFixture.강남역;
+        SaveStationRequest 강남역 = StationFixture.강남역;
         StationAcceptanceStep.지하철역_생성을_요청한다(강남역);
 
         // then
@@ -76,8 +76,8 @@ public class StationAcceptanceTest {
     @Test
     void readStations() {
         //given
-        SaveStationRequestDto 강남역 = StationFixture.강남역;
-        SaveStationRequestDto 광교역 = StationFixture.광교역;
+        SaveStationRequest 강남역 = StationFixture.강남역;
+        SaveStationRequest 광교역 = StationFixture.광교역;
 
         Stream.of(강남역, 광교역).forEach(StationAcceptanceStep::지하철역_생성을_요청한다);
 
@@ -99,7 +99,7 @@ public class StationAcceptanceTest {
     @Test
     void deleteStation() {
         // given
-        SaveStationRequestDto 강남역 = StationFixture.강남역;
+        SaveStationRequest 강남역 = StationFixture.강남역;
         Long 저장된_지하철역_아이디 = StationAcceptanceStep.지하철역_생성을_요청한다(강남역)
                 .jsonPath()
                 .getLong(STATION_ID_KEY);

--- a/src/test/java/nextstep/subway/acceptance/station/StationAcceptanceTest.java
+++ b/src/test/java/nextstep/subway/acceptance/station/StationAcceptanceTest.java
@@ -3,12 +3,12 @@ package nextstep.subway.acceptance.station;
 import io.restassured.RestAssured;
 import io.restassured.response.ExtractableResponse;
 import io.restassured.response.Response;
-import nextstep.subway.acceptance.constants.Endpoint;
+import nextstep.subway.acceptance.step.StationAcceptanceStep;
 import nextstep.subway.fixture.StationFixture;
 import nextstep.subway.station.dto.request.SaveStationRequestDto;
 import nextstep.subway.support.AcceptanceTest;
+import nextstep.subway.support.AssertUtils;
 import nextstep.subway.support.DatabaseCleanup;
-import nextstep.subway.support.RestAssuredClient;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -30,7 +30,6 @@ public class StationAcceptanceTest {
     @LocalServerPort
     private int port;
 
-    private static final String STATION_BASE_URL = Endpoint.STATION_BASE_URL.getUrl();
 
     private static final String STATION_ID_KEY = "id";
 
@@ -55,16 +54,16 @@ public class StationAcceptanceTest {
     void createStation() {
         // when
         SaveStationRequestDto 강남역 = StationFixture.강남역;
-        saveStation(강남역);
+        StationAcceptanceStep.지하철역_생성을_요청한다(강남역);
 
         // then
-        List<String> stationNames = findStationsAll()
+        List<String> 지하철역_이름_목록 = StationAcceptanceStep.지하철역_목록_조회를_요청한다()
                 .jsonPath()
                 .getList(STATION_NAME_KEY, String.class);
 
         assertAll(
-                () -> assertThat(stationNames.size()).isEqualTo(1),
-                () -> assertThat(stationNames).containsAnyOf(강남역.getName())
+                () -> assertThat(지하철역_이름_목록.size()).isEqualTo(1),
+                () -> assertThat(지하철역_이름_목록).containsAnyOf(강남역.getName())
         );
     }
 
@@ -80,18 +79,15 @@ public class StationAcceptanceTest {
         SaveStationRequestDto 강남역 = StationFixture.강남역;
         SaveStationRequestDto 광교역 = StationFixture.광교역;
 
-        Stream.of(강남역, 광교역)
-                .forEach(this::saveStation);
+        Stream.of(강남역, 광교역).forEach(StationAcceptanceStep::지하철역_생성을_요청한다);
 
         // when
-        ExtractableResponse<Response> findStationsAllResponse = findStationsAll();
-        List<String> stationNames = findStationsAllResponse
+        List<String> 지하철역_이름_목록 = StationAcceptanceStep.지하철역_목록_조회를_요청한다()
                 .jsonPath()
                 .getList(STATION_NAME_KEY, String.class);
 
         // then
-        assertThat(stationNames)
-                .containsOnly(강남역.getName(), 광교역.getName());
+        assertThat(지하철역_이름_목록).containsOnly(강남역.getName(), 광교역.getName());
     }
 
     /**
@@ -104,55 +100,23 @@ public class StationAcceptanceTest {
     void deleteStation() {
         // given
         SaveStationRequestDto 강남역 = StationFixture.강남역;
-        Long savedStationId = saveStation(강남역)
+        Long 저장된_지하철역_아이디 = StationAcceptanceStep.지하철역_생성을_요청한다(강남역)
                 .jsonPath()
                 .getLong(STATION_ID_KEY);
 
         // when
-        String path = String.format("%s/%d", STATION_BASE_URL, savedStationId);
-        ExtractableResponse<Response> deleteStationByIdResponse = RestAssuredClient.delete(path);
+        ExtractableResponse<Response> 지하철역_삭제_응답 = StationAcceptanceStep
+                .지하철역_삭제을_요청한다(저장된_지하철역_아이디);
 
         // then
+        List<String> 지하철역_이름_목록 = StationAcceptanceStep.지하철역_목록_조회를_요청한다()
+                .jsonPath()
+                .getList(STATION_NAME_KEY, String.class);
+
         assertAll(
-                () -> assertThat(deleteStationByIdResponse.statusCode()).isEqualTo(HttpStatus.NO_CONTENT.value()),
-                () -> {
-                    List<String> stationNames = RestAssuredClient.get(STATION_BASE_URL)
-                            .jsonPath()
-                            .getList(STATION_NAME_KEY, String.class);
-
-                    assertThat(stationNames).doesNotContain(강남역.getName());
-                }
+                () -> AssertUtils.assertThatStatusCode(지하철역_삭제_응답, HttpStatus.NO_CONTENT),
+                () -> assertThat(지하철역_이름_목록).doesNotContain(강남역.getName())
         );
-    }
-
-    /**
-     * <pre>
-     * 지하철역을 생성하는 API를 호출하는 함수
-     * </pre>
-     *
-     * @param station
-     * @return ExtractableResponse
-     */
-    private ExtractableResponse<Response> saveStation(SaveStationRequestDto station) {
-        ExtractableResponse<Response> saveStationResponse =
-                RestAssuredClient.post(STATION_BASE_URL, station);
-        assertThat(saveStationResponse.statusCode()).isEqualTo(HttpStatus.CREATED.value());
-
-        return saveStationResponse;
-    }
-
-    /**
-     * <pre>
-     * 모든 지하철역들을 조회하는 API를 호출하는 함수
-     * </pre>
-     *
-     * @return ExtractableResponse
-     */
-    private ExtractableResponse<Response> findStationsAll() {
-        ExtractableResponse<Response> findStationsAllResponse = RestAssuredClient.get(STATION_BASE_URL);
-        assertThat(findStationsAllResponse.statusCode()).isEqualTo(HttpStatus.OK.value());
-
-        return findStationsAllResponse;
     }
 
 }

--- a/src/test/java/nextstep/subway/acceptance/step/LineAcceptanceStep.java
+++ b/src/test/java/nextstep/subway/acceptance/step/LineAcceptanceStep.java
@@ -1,0 +1,78 @@
+package nextstep.subway.acceptance.step;
+
+import io.restassured.response.ExtractableResponse;
+import io.restassured.response.Response;
+import nextstep.subway.acceptance.constants.Endpoint;
+import nextstep.subway.line.dto.request.SaveLineRequestDto;
+import nextstep.subway.line.dto.request.UpdateLineRequestDto;
+import nextstep.subway.support.RestAssuredClient;
+
+public class LineAcceptanceStep {
+
+    private static final String LINE_BASE_URL = Endpoint.LINE_BASE_URL.getUrl();
+
+    /**
+     * <pre>
+     * 지하철 노선을 생성하는 API를 호출하는 함수
+     * </pre>
+     *
+     * @param line
+     * @return ExtractableResponse
+     */
+    public static ExtractableResponse<Response> 지하철_노선_생성을_요청한다(SaveLineRequestDto line) {
+        return RestAssuredClient.post(LINE_BASE_URL, line);
+    }
+
+    /**
+     * <pre>
+     * 모든 지하철 노선들을 조회하는 API를 호출하는 함수
+     * </pre>
+     *
+     * @return ExtractableResponse
+     */
+    public static ExtractableResponse<Response> 지하철_노선_목록_조회를_요청한다() {
+        ExtractableResponse<Response> findStationsAllResponse = RestAssuredClient.get(LINE_BASE_URL);
+        return findStationsAllResponse;
+    }
+
+    /**
+     * <pre>
+     * 지하철 노선을 id로 조회하는 API를 호출하는 함수
+     * </pre>
+     *
+     * @param id
+     * @return ExtractableResponse
+     */
+    public static ExtractableResponse<Response> 지하철_노선_상세_조회를_요청한다(Long id) {
+        String path = String.format("%s/%d", LINE_BASE_URL, id);
+        return RestAssuredClient.get(path);
+    }
+
+    /**
+     * <pre>
+     * 지하철 노선을 수정하는 API를 호출하는 함수
+     * </pre>
+     *
+     * @param line 수정할 정보가 담긴 노선
+     * @param id
+     * @return ExtractableResponse
+     */
+    public static ExtractableResponse<Response> 지하철_노선_수정을_요청한다(UpdateLineRequestDto line, Long id) {
+        String path = String.format("%s/%d", LINE_BASE_URL, id);
+        return RestAssuredClient.put(path, line);
+    }
+
+    /**
+     * <pre>
+     * 지하철 노선을 삭제하는 API를 호출하는 함수
+     * </pre>
+     *
+     * @param id
+     * @return ExtractableResponse
+     */
+    public static ExtractableResponse<Response> 지하철_노선_삭제를_요청한다(Long id) {
+        String path = String.format("%s/%d", LINE_BASE_URL, id);
+        return RestAssuredClient.delete(path);
+    }
+
+}

--- a/src/test/java/nextstep/subway/acceptance/step/LineAcceptanceStep.java
+++ b/src/test/java/nextstep/subway/acceptance/step/LineAcceptanceStep.java
@@ -3,8 +3,8 @@ package nextstep.subway.acceptance.step;
 import io.restassured.response.ExtractableResponse;
 import io.restassured.response.Response;
 import nextstep.subway.acceptance.constants.Endpoint;
-import nextstep.subway.line.dto.request.SaveLineRequestDto;
-import nextstep.subway.line.dto.request.UpdateLineRequestDto;
+import nextstep.subway.line.dto.request.SaveLineRequest;
+import nextstep.subway.line.dto.request.UpdateLineRequest;
 import nextstep.subway.support.RestAssuredClient;
 
 public class LineAcceptanceStep {
@@ -19,7 +19,7 @@ public class LineAcceptanceStep {
      * @param line
      * @return ExtractableResponse
      */
-    public static ExtractableResponse<Response> 지하철_노선_생성을_요청한다(SaveLineRequestDto line) {
+    public static ExtractableResponse<Response> 지하철_노선_생성을_요청한다(SaveLineRequest line) {
         return RestAssuredClient.post(LINE_BASE_URL, line);
     }
 
@@ -57,7 +57,7 @@ public class LineAcceptanceStep {
      * @param id
      * @return ExtractableResponse
      */
-    public static ExtractableResponse<Response> 지하철_노선_수정을_요청한다(UpdateLineRequestDto line, Long id) {
+    public static ExtractableResponse<Response> 지하철_노선_수정을_요청한다(UpdateLineRequest line, Long id) {
         String path = String.format("%s/%d", LINE_BASE_URL, id);
         return RestAssuredClient.put(path, line);
     }

--- a/src/test/java/nextstep/subway/acceptance/step/LineSectionAcceptanceStep.java
+++ b/src/test/java/nextstep/subway/acceptance/step/LineSectionAcceptanceStep.java
@@ -1,0 +1,44 @@
+package nextstep.subway.acceptance.step;
+
+import io.restassured.response.ExtractableResponse;
+import io.restassured.response.Response;
+import nextstep.subway.acceptance.constants.Endpoint;
+import nextstep.subway.line.dto.request.SaveLineSectionRequestDto;
+import nextstep.subway.support.RestAssuredClient;
+
+public class LineSectionAcceptanceStep {
+
+    private static final String LINE_BASE_URL = Endpoint.LINE_BASE_URL.getUrl();
+
+    /**
+     * <pre>
+     * 지하철 노선 구간을 생성하는 API를 호출하는 함수
+     * </pre>
+     *
+     * @param lineSection
+     * @param lineId
+     * @param
+     * @return ExtractableResponse
+     */
+    public static ExtractableResponse<Response> 지하철_구간_생성을_요청한다(SaveLineSectionRequestDto lineSection, Long lineId) {
+        String path = String.format("%s/%d/sections", LINE_BASE_URL, lineId);
+        return RestAssuredClient.post(path, lineSection);
+    }
+
+    /**
+     * <pre>
+     * 지하철역 id로
+     * 지하철 노선 구간을 삭제하는 API를 호출하는 함수
+     * </pre>
+     *
+     * @param lineId
+     * @param stationId
+     * @param
+     * @return ExtractableResponse
+     */
+    public static ExtractableResponse<Response> 지하철_구간_삭제을_요청한다(Long lineId, Long stationId) {
+        String path = String.format("%s/%d/sections?stationId=%d", LINE_BASE_URL, lineId, stationId);
+        return RestAssuredClient.delete(path);
+    }
+
+}

--- a/src/test/java/nextstep/subway/acceptance/step/LineSectionAcceptanceStep.java
+++ b/src/test/java/nextstep/subway/acceptance/step/LineSectionAcceptanceStep.java
@@ -3,7 +3,7 @@ package nextstep.subway.acceptance.step;
 import io.restassured.response.ExtractableResponse;
 import io.restassured.response.Response;
 import nextstep.subway.acceptance.constants.Endpoint;
-import nextstep.subway.line.dto.request.SaveLineSectionRequestDto;
+import nextstep.subway.line.dto.request.SaveLineSectionRequest;
 import nextstep.subway.support.RestAssuredClient;
 
 public class LineSectionAcceptanceStep {
@@ -20,7 +20,7 @@ public class LineSectionAcceptanceStep {
      * @param
      * @return ExtractableResponse
      */
-    public static ExtractableResponse<Response> 지하철_구간_생성을_요청한다(SaveLineSectionRequestDto lineSection, Long lineId) {
+    public static ExtractableResponse<Response> 지하철_구간_생성을_요청한다(SaveLineSectionRequest lineSection, Long lineId) {
         String path = String.format("%s/%d/sections", LINE_BASE_URL, lineId);
         return RestAssuredClient.post(path, lineSection);
     }

--- a/src/test/java/nextstep/subway/acceptance/step/PathAcceptanceStep.java
+++ b/src/test/java/nextstep/subway/acceptance/step/PathAcceptanceStep.java
@@ -1,0 +1,33 @@
+package nextstep.subway.acceptance.step;
+
+import io.restassured.response.ExtractableResponse;
+import io.restassured.response.Response;
+import nextstep.subway.acceptance.constants.Endpoint;
+import nextstep.subway.support.RestAssuredClient;
+
+import java.util.HashMap;
+import java.util.Map;
+
+public class PathAcceptanceStep {
+
+    private static final String PATH_BASE_URL = Endpoint.PATH_BASE_URL.getUrl();
+
+    /**
+     * <pre>
+     * 최단 거리 경로를 조회하는 API를 호출하는 함수
+     * </pre>
+     *
+     * @param source 출발역 ID
+     * @param target 도착역 ID
+     * @return ExtractableResponse
+     */
+    public static ExtractableResponse<Response> 최단_거리_경로_조회를_요청한다(Long source, Long target) {
+        Map<String, ?> queryParamMap = new HashMap<>(){{
+           put("source", source);
+           put("target", target);
+        }};
+        return RestAssuredClient.get(PATH_BASE_URL, queryParamMap);
+    }
+
+
+}

--- a/src/test/java/nextstep/subway/acceptance/step/StationAcceptanceStep.java
+++ b/src/test/java/nextstep/subway/acceptance/step/StationAcceptanceStep.java
@@ -1,0 +1,49 @@
+package nextstep.subway.acceptance.step;
+
+import io.restassured.response.ExtractableResponse;
+import io.restassured.response.Response;
+import nextstep.subway.acceptance.constants.Endpoint;
+import nextstep.subway.station.dto.request.SaveStationRequestDto;
+import nextstep.subway.support.RestAssuredClient;
+
+public class StationAcceptanceStep {
+
+    private static final String STATION_BASE_URL = Endpoint.STATION_BASE_URL.getUrl();
+
+    /**
+     * <pre>
+     * 지하철역을 생성하는 API를 호출하는 함수
+     * </pre>
+     *
+     * @param station
+     * @return ExtractableResponse
+     */
+    public static ExtractableResponse<Response> 지하철역_생성을_요청한다(SaveStationRequestDto station) {
+        return RestAssuredClient.post(STATION_BASE_URL, station);
+    }
+
+    /**
+     * <pre>
+     * 모든 지하철역들을 조회하는 API를 호출하는 함수
+     * </pre>
+     *
+     * @return ExtractableResponse
+     */
+    public static ExtractableResponse<Response> 지하철역_목록_조회를_요청한다() {
+        return RestAssuredClient.get(STATION_BASE_URL);
+    }
+
+    /**
+     * <pre>
+     * 지하철역을 삭제하는 API를 호출하는 함수
+     * </pre>
+     *
+     * @param stationId
+     * @return ExtractableResponse
+     */
+    public static ExtractableResponse<Response> 지하철역_삭제을_요청한다(Long stationId) {
+        String path = String.format("%s/%d", STATION_BASE_URL, stationId);
+        return  RestAssuredClient.delete(path);
+    }
+
+}

--- a/src/test/java/nextstep/subway/acceptance/step/StationAcceptanceStep.java
+++ b/src/test/java/nextstep/subway/acceptance/step/StationAcceptanceStep.java
@@ -3,7 +3,7 @@ package nextstep.subway.acceptance.step;
 import io.restassured.response.ExtractableResponse;
 import io.restassured.response.Response;
 import nextstep.subway.acceptance.constants.Endpoint;
-import nextstep.subway.station.dto.request.SaveStationRequestDto;
+import nextstep.subway.station.dto.request.SaveStationRequest;
 import nextstep.subway.support.RestAssuredClient;
 
 public class StationAcceptanceStep {
@@ -18,7 +18,7 @@ public class StationAcceptanceStep {
      * @param station
      * @return ExtractableResponse
      */
-    public static ExtractableResponse<Response> 지하철역_생성을_요청한다(SaveStationRequestDto station) {
+    public static ExtractableResponse<Response> 지하철역_생성을_요청한다(SaveStationRequest station) {
         return RestAssuredClient.post(STATION_BASE_URL, station);
     }
 

--- a/src/test/java/nextstep/subway/fixture/StationFixture.java
+++ b/src/test/java/nextstep/subway/fixture/StationFixture.java
@@ -1,38 +1,53 @@
 package nextstep.subway.fixture;
 
-import nextstep.subway.station.dto.request.SaveStationRequestDto;
+import nextstep.subway.station.dto.request.SaveStationRequest;
 import nextstep.subway.station.entity.Station;
 
 public class StationFixture {
 
-    public static final SaveStationRequestDto 신사역 =
-            SaveStationRequestDto.builder()
+    public static final SaveStationRequest 신사역 =
+            SaveStationRequest.builder()
                     .name("신사역")
                     .build();
 
-    public static final SaveStationRequestDto 강남역 =
-            SaveStationRequestDto.builder()
+    public static final SaveStationRequest 강남역 =
+            SaveStationRequest.builder()
                     .name("강남역")
                     .build();
 
-    public static final SaveStationRequestDto 판교역 =
-            SaveStationRequestDto.builder()
+    public static final SaveStationRequest 판교역 =
+            SaveStationRequest.builder()
                     .name("판교역")
                     .build();
 
-    public static final SaveStationRequestDto 광교역 =
-            SaveStationRequestDto.builder()
+    public static final SaveStationRequest 광교역 =
+            SaveStationRequest.builder()
                     .name("광교역")
                     .build();
 
-    public static final SaveStationRequestDto 청량리역 =
-            SaveStationRequestDto.builder()
+    public static final SaveStationRequest 청량리역 =
+            SaveStationRequest.builder()
                     .name("청량리역")
                     .build();
 
-    public static final SaveStationRequestDto 춘천역 =
-            SaveStationRequestDto.builder()
+    public static final SaveStationRequest 춘천역 =
+            SaveStationRequest.builder()
                     .name("춘천역")
+                    .build();
+
+    public static final SaveStationRequest 교대역 =
+            SaveStationRequest.builder()
+                    .name("교대역")
+                    .build();
+
+    public static final SaveStationRequest 양재역 =
+            SaveStationRequest.builder()
+                    .name("양재역")
+                    .build();
+
+    public static final SaveStationRequest 남부터미널역 =
+            SaveStationRequest.builder()
+                    .name("남부터미널역")
                     .build();
 
     public static final Station 까치산역 = new Station(1L, "까치산역");

--- a/src/test/java/nextstep/subway/fixture/StationFixture.java
+++ b/src/test/java/nextstep/subway/fixture/StationFixture.java
@@ -1,6 +1,7 @@
-package nextstep.subway.acceptance.station;
+package nextstep.subway.fixture;
 
 import nextstep.subway.station.dto.request.SaveStationRequestDto;
+import nextstep.subway.station.entity.Station;
 
 public class StationFixture {
 
@@ -33,4 +34,13 @@ public class StationFixture {
             SaveStationRequestDto.builder()
                     .name("춘천역")
                     .build();
+
+    public static final Station 까치산역 = new Station(1L, "까치산역");
+
+    public static final Station 신도림역 = new Station(2L, "신도림역");
+
+    public static final Station 신촌역 = new Station(3L, "신촌역");
+
+    public static final Station 잠실역 = new Station(4L, "잠실역");
+
 }

--- a/src/test/java/nextstep/subway/support/AcceptanceTest.java
+++ b/src/test/java/nextstep/subway/support/AcceptanceTest.java
@@ -25,7 +25,7 @@ public @interface AcceptanceTest {
     /**
      * <pre>
      * 설정할 웹 환경 유형
-     * {@link SpringBootTest.WebEnvironment#RANDOM_PORT
+     * {@link SpringBootTest.WebEnvironment#RANDOM_PORT}
      * </pre>
      *
      * @return the type of web environment

--- a/src/test/java/nextstep/subway/support/AssertUtils.java
+++ b/src/test/java/nextstep/subway/support/AssertUtils.java
@@ -1,0 +1,39 @@
+package nextstep.subway.support;
+
+import io.restassured.response.ExtractableResponse;
+import io.restassured.response.Response;
+import nextstep.subway.global.error.code.ErrorCode;
+import org.springframework.http.HttpStatus;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class AssertUtils {
+
+    private static final String ERROR_MESSAGES_KEY = "errorMessages";
+
+    /**
+     * <pre>
+     * 응답코드에 대한 검증
+     * </pre>
+     *
+     * @param response
+     * @param status
+     */
+    public static void assertThatStatusCode(ExtractableResponse<Response> response, HttpStatus status) {
+        assertThat(response.statusCode()).isEqualTo(status.value());
+    }
+
+    /**
+     * <pre>
+     * 에러메시지에 대한 검증
+     * </pre>
+     *
+     * @param response
+     * @param errorCode
+     */
+    public static void assertThatErrorMessage(ExtractableResponse<Response> response, ErrorCode errorCode) {
+        assertThat(response.jsonPath().getList(ERROR_MESSAGES_KEY, String.class))
+                .containsAnyOf(errorCode.getMessage());
+    }
+
+}

--- a/src/test/java/nextstep/subway/support/RestAssuredClient.java
+++ b/src/test/java/nextstep/subway/support/RestAssuredClient.java
@@ -5,6 +5,8 @@ import io.restassured.response.ExtractableResponse;
 import io.restassured.response.Response;
 import org.springframework.http.MediaType;
 
+import java.util.Map;
+
 /**
  * <pre>
  * RestAssured를 통한 HTTP Request를 도와주는 Wrapper 클래스입니다.
@@ -55,6 +57,31 @@ public class RestAssuredClient {
                     .log().all()
                 .when()
                     .get(path)
+                .then()
+                    .log().all()
+                    .extract();
+    }
+
+    /**
+     * <pre>
+     * path에
+     * GET 방식으로
+     * RestAssured를 통해
+     * query parameter와 함께
+     * HTTP 요청을 보낼 때 사용합니다.
+     * </pre>
+     *
+     * @param basePath
+     * @param queryParamMap
+     * @return ExtractableResponse
+     */
+    public static ExtractableResponse<Response> get(String basePath, Map<String, ?> queryParamMap) {
+        return RestAssured
+                .given()
+                    .log().all()
+                    .queryParams(queryParamMap)
+                .when()
+                    .get(basePath)
                 .then()
                     .log().all()
                     .extract();

--- a/src/test/java/nextstep/subway/unit/LineServiceMockTest.java
+++ b/src/test/java/nextstep/subway/unit/LineServiceMockTest.java
@@ -81,14 +81,10 @@ public class LineServiceMockTest {
                 .build();
 
         // when
-        LineResponseDto responseDto = lineService.saveLineSection(이호선.getId(), saveLineSectionRequestDto);
+        lineService.saveLineSection(이호선.getId(), saveLineSectionRequestDto);
 
         // then
-        List<Long> 등록된_지하철역_아이디_목록 = responseDto.getStations()
-                .stream()
-                .map(StationResponseDto::getId)
-                .collect(Collectors.toList());
-
+        List<Long> 등록된_지하철역_아이디_목록 = 노선에_등록된_역_아이디_목록을_가져온다(이호선);
         assertThat(등록된_지하철역_아이디_목록).containsExactly(신도림역_아이디, 까치산역_아이디, 신촌역_아이디);
     }
 
@@ -104,14 +100,10 @@ public class LineServiceMockTest {
                 이호선에_신도림이_하행역인_구간을_생성한다(까치산역_아이디, 5);
 
         // when
-        LineResponseDto responseDto = lineService.saveLineSection(이호선.getId(), saveLineSectionRequestDto);
+        lineService.saveLineSection(이호선.getId(), saveLineSectionRequestDto);
 
         // then
-        List<Long> 등록된_지하철역_아이디_목록 = responseDto.getStations()
-                .stream()
-                .map(StationResponseDto::getId)
-                .collect(Collectors.toList());
-
+        List<Long> 등록된_지하철역_아이디_목록 = 노선에_등록된_역_아이디_목록을_가져온다(이호선);
         assertThat(등록된_지하철역_아이디_목록).containsExactly(까치산역_아이디, 신도림역_아이디, 신촌역_아이디);
     }
 
@@ -126,14 +118,10 @@ public class LineServiceMockTest {
         SaveLineSectionRequestDto saveLineSectionRequestDto = 이호선에_잠실역이_하행_종점역인_구간을_생성한다(신촌역_아이디);
 
         // when
-        LineResponseDto responseDto = lineService.saveLineSection(이호선.getId(), saveLineSectionRequestDto);
+        lineService.saveLineSection(이호선.getId(), saveLineSectionRequestDto);
 
         // then
-        List<Long> 등록된_지하철역_아이디_목록 = responseDto.getStations()
-                .stream()
-                .map(StationResponseDto::getId)
-                .collect(Collectors.toList());
-
+        List<Long> 등록된_지하철역_아이디_목록 = 노선에_등록된_역_아이디_목록을_가져온다(이호선);
         assertThat(등록된_지하철역_아이디_목록).containsExactly(까치산역_아이디, 신촌역_아이디, 잠실역_아이디);
     }
 
@@ -222,12 +210,7 @@ public class LineServiceMockTest {
         lineService.deleteLineSectionByStationId(이호선.getId(), 노선의_상행_종점역_아이디);
 
         // then
-        List<Long> 노선에_등록된_역_아이디_목록 = 이호선.getSections()
-                .getAllStations()
-                .stream()
-                .map(Station::getId)
-                .collect(Collectors.toList());
-
+        List<Long> 노선에_등록된_역_아이디_목록 = 노선에_등록된_역_아이디_목록을_가져온다(이호선);
         assertThat(노선에_등록된_역_아이디_목록).doesNotContain(노선의_상행_종점역_아이디);
     }
 
@@ -246,12 +229,7 @@ public class LineServiceMockTest {
         lineService.deleteLineSectionByStationId(이호선.getId(), 노선의_중간역_아이디);
 
         // then
-        List<Long> 노선에_등록된_역_아이디_목록 = 이호선.getSections()
-                .getAllStations()
-                .stream()
-                .map(Station::getId)
-                .collect(Collectors.toList());
-
+        List<Long> 노선에_등록된_역_아이디_목록 = 노선에_등록된_역_아이디_목록을_가져온다(이호선);
         assertThat(노선에_등록된_역_아이디_목록).doesNotContain(노선의_중간역_아이디);
     }
 
@@ -270,12 +248,7 @@ public class LineServiceMockTest {
         lineService.deleteLineSectionByStationId(이호선.getId(), 노선의_하행_종점역_아이디);
 
         // then
-        List<Long> 노선에_등록된_역_아이디_목록 = 이호선.getSections()
-                .getAllStations()
-                .stream()
-                .map(Station::getId)
-                .collect(Collectors.toList());
-
+        List<Long> 노선에_등록된_역_아이디_목록 = 노선에_등록된_역_아이디_목록을_가져온다(이호선);
         assertThat(노선에_등록된_역_아이디_목록).doesNotContain(노선의_하행_종점역_아이디);
     }
 
@@ -303,6 +276,14 @@ public class LineServiceMockTest {
         assertThatThrownBy(() -> lineService.deleteLineSectionByStationId(이호선.getId(), 노선의_하행_종점역_아이디))
                 .isInstanceOf(InvalidLineSectionException.class)
                 .hasMessageContaining(ErrorCode.STAND_ALONE_LINE_SECTION.getMessage());
+    }
+
+    private List<Long> 노선에_등록된_역_아이디_목록을_가져온다(Line line) {
+        return line.getSections()
+                .getAllStations()
+                .stream()
+                .map(Station::getId)
+                .collect(Collectors.toList());
     }
 
     private SaveLineSectionRequestDto 이호선에_잠실역이_하행_종점역인_구간을_생성한다(Long upStationId) {

--- a/src/test/java/nextstep/subway/unit/LineServiceMockTest.java
+++ b/src/test/java/nextstep/subway/unit/LineServiceMockTest.java
@@ -1,5 +1,6 @@
 package nextstep.subway.unit;
 
+import nextstep.subway.fixture.StationFixture;
 import nextstep.subway.global.error.code.ErrorCode;
 import nextstep.subway.global.error.exception.InvalidLineSectionException;
 import nextstep.subway.global.error.exception.NotEntityFoundException;
@@ -39,13 +40,13 @@ public class LineServiceMockTest {
 
     private LineService lineService;
 
-    private Station 까치산역;
+    private static final Long 까치산역_아이디 = StationFixture.까치산역.getId();
 
-    private Station 신도림역;
+    private static final Long 신도림역_아이디 = StationFixture.신도림역.getId();
 
-    private Station 신촌역;
+    private static final Long 신촌역_아이디 = StationFixture.신촌역.getId();
 
-    private Station 강남역;
+    private static final Long 잠실역_아이디 = StationFixture.잠실역.getId();
 
     private Line 이호선;
 
@@ -56,16 +57,11 @@ public class LineServiceMockTest {
         lineService = new LineService(stationJpaAdapter, lineJpaAdapter);
 
         // given
-        this.까치산역 = new Station(1L, "까치산역");
-        this.신도림역 = new Station(2L, "신도림역");
-        this.신촌역 = new Station(3L, "신촌역");
-        this.강남역 = new Station(4L, "강남역");
-
         this.이호선 = Line.builder()
                 .name("2호선")
                 .color("#52c41a")
-                .upStation(까치산역)
-                .downStation(신촌역)
+                .upStation(StationFixture.까치산역)
+                .downStation(StationFixture.신촌역)
                 .distance(12)
                 .build();
     }
@@ -74,13 +70,13 @@ public class LineServiceMockTest {
     @DisplayName("지하철 노선의 상행 종점역이 하행역인 구간을 추가한다.")
     void addFirstLineSection() {
         // given
-        given(stationRepository.findById(신도림역.getId())).willReturn(Optional.of(신도림역));
-        given(stationRepository.findById(까치산역.getId())).willReturn(Optional.of(까치산역));
+        given(stationRepository.findById(신도림역_아이디)).willReturn(Optional.of(StationFixture.신도림역));
+        given(stationRepository.findById(까치산역_아이디)).willReturn(Optional.of(StationFixture.까치산역));
         given(lineRepository.findById(이호선.getId())).willReturn(Optional.of(이호선));
 
         SaveLineSectionRequestDto saveLineSectionRequestDto = SaveLineSectionRequestDto.builder()
-                .upStationId(신도림역.getId())
-                .downStationId(까치산역.getId())
+                .upStationId(신도림역_아이디)
+                .downStationId(까치산역_아이디)
                 .distance(5)
                 .build();
 
@@ -93,23 +89,19 @@ public class LineServiceMockTest {
                 .map(StationResponseDto::getId)
                 .collect(Collectors.toList());
 
-        assertThat(등록된_지하철역_아이디_목록).containsExactly(
-                신도림역.getId(),
-                까치산역.getId(),
-                신촌역.getId()
-        );
+        assertThat(등록된_지하철역_아이디_목록).containsExactly(신도림역_아이디, 까치산역_아이디, 신촌역_아이디);
     }
 
     @Test
     @DisplayName("지하철 노선의 상행 종점역과 하행 종점역 사이에 구간을 추가한다.")
     void addMiddleLineSection() {
         // given
-        given(stationRepository.findById(신도림역.getId())).willReturn(Optional.of(신도림역));
-        given(stationRepository.findById(까치산역.getId())).willReturn(Optional.of(까치산역));
+        given(stationRepository.findById(신도림역_아이디)).willReturn(Optional.of(StationFixture.신도림역));
+        given(stationRepository.findById(까치산역_아이디)).willReturn(Optional.of(StationFixture.까치산역));
         given(lineRepository.findById(이호선.getId())).willReturn(Optional.of(이호선));
 
         SaveLineSectionRequestDto saveLineSectionRequestDto =
-                이호선에_신도림이_하행역인_구간을_생성한다(까치산역.getId(), 5);
+                이호선에_신도림이_하행역인_구간을_생성한다(까치산역_아이디, 5);
 
         // when
         LineResponseDto responseDto = lineService.saveLineSection(이호선.getId(), saveLineSectionRequestDto);
@@ -120,22 +112,18 @@ public class LineServiceMockTest {
                 .map(StationResponseDto::getId)
                 .collect(Collectors.toList());
 
-        assertThat(등록된_지하철역_아이디_목록).containsExactly(
-                까치산역.getId(),
-                신도림역.getId(),
-                신촌역.getId()
-        );
+        assertThat(등록된_지하철역_아이디_목록).containsExactly(까치산역_아이디, 신도림역_아이디, 신촌역_아이디);
     }
 
     @Test
     @DisplayName("지하철 노선의 하행 종점역에 구간을 추가한다.")
     void addLastLineSection() {
         // given
-        given(stationRepository.findById(강남역.getId())).willReturn(Optional.of(강남역));
-        given(stationRepository.findById(신촌역.getId())).willReturn(Optional.of(신촌역));
+        given(stationRepository.findById(잠실역_아이디)).willReturn(Optional.of(StationFixture.잠실역));
+        given(stationRepository.findById(신촌역_아이디)).willReturn(Optional.of(StationFixture.신촌역));
         given(lineRepository.findById(이호선.getId())).willReturn(Optional.of(이호선));
 
-        SaveLineSectionRequestDto saveLineSectionRequestDto = 이호선에_강남역이_하행_종점역인_구간을_생성한다(신촌역.getId());
+        SaveLineSectionRequestDto saveLineSectionRequestDto = 이호선에_잠실역이_하행_종점역인_구간을_생성한다(신촌역_아이디);
 
         // when
         LineResponseDto responseDto = lineService.saveLineSection(이호선.getId(), saveLineSectionRequestDto);
@@ -146,21 +134,17 @@ public class LineServiceMockTest {
                 .map(StationResponseDto::getId)
                 .collect(Collectors.toList());
 
-        assertThat(등록된_지하철역_아이디_목록).containsExactly(
-                까치산역.getId(),
-                신촌역.getId(),
-                강남역.getId()
-        );
+        assertThat(등록된_지하철역_아이디_목록).containsExactly(까치산역_아이디, 신촌역_아이디, 잠실역_아이디);
     }
 
     @Test
     @DisplayName("존재하지 않는 역이 하행 종점역인 구간을 추가한다.")
     void addNotExistDownStation() {
         // given
-        given(stationRepository.findById(신촌역.getId())).willReturn(Optional.of(신촌역));
-        given(stationRepository.findById(강남역.getId())).willReturn(Optional.empty());
+        given(stationRepository.findById(신촌역_아이디)).willReturn(Optional.of(StationFixture.신촌역));
+        given(stationRepository.findById(잠실역_아이디)).willReturn(Optional.empty());
 
-        SaveLineSectionRequestDto 존재하지_않는_역이_하행_종점역인_구간 = 이호선에_강남역이_하행_종점역인_구간을_생성한다(
+        SaveLineSectionRequestDto 존재하지_않는_역이_하행_종점역인_구간 = 이호선에_잠실역이_하행_종점역인_구간을_생성한다(
                 지하철_노선의_하행_종점역_아이디를_찾는다(이호선)
         );
 
@@ -174,12 +158,12 @@ public class LineServiceMockTest {
     @DisplayName("역 사이에 기존 역 사이 길이보다 크거나 같은 노선을 등록한다.")
     void addInvalidDistanceLineSection() {
         // given
-        given(stationRepository.findById(신도림역.getId())).willReturn(Optional.of(신도림역));
-        given(stationRepository.findById(까치산역.getId())).willReturn(Optional.of(까치산역));
+        given(stationRepository.findById(신도림역_아이디)).willReturn(Optional.of(StationFixture.신도림역));
+        given(stationRepository.findById(까치산역_아이디)).willReturn(Optional.of(StationFixture.까치산역));
         given(lineRepository.findById(이호선.getId())).willReturn(Optional.of(이호선));
 
         SaveLineSectionRequestDto saveLineSectionRequestDto =
-                이호선에_신도림이_하행역인_구간을_생성한다(까치산역.getId(), 15);
+                이호선에_신도림이_하행역인_구간을_생성한다(까치산역_아이디, 15);
 
         // when & then
         assertThatThrownBy(() -> lineService.saveLineSection(이호선.getId(), saveLineSectionRequestDto))
@@ -191,13 +175,13 @@ public class LineServiceMockTest {
     @DisplayName("이미 등록되어 있는 노선을 등록한다.")
     void addAlreadyRegisteredLineSection() {
         // given
-        given(stationRepository.findById(신촌역.getId())).willReturn(Optional.of(신촌역));
-        given(stationRepository.findById(까치산역.getId())).willReturn(Optional.of(까치산역));
+        given(stationRepository.findById(신촌역_아이디)).willReturn(Optional.of(StationFixture.신촌역));
+        given(stationRepository.findById(까치산역_아이디)).willReturn(Optional.of(StationFixture.까치산역));
         given(lineRepository.findById(이호선.getId())).willReturn(Optional.of(이호선));
 
         SaveLineSectionRequestDto saveLineSectionRequestDto = SaveLineSectionRequestDto.builder()
-                .upStationId(까치산역.getId())
-                .downStationId(신촌역.getId())
+                .upStationId(까치산역_아이디)
+                .downStationId(신촌역_아이디)
                 .distance(12)
                 .build();
 
@@ -211,11 +195,11 @@ public class LineServiceMockTest {
     @DisplayName("상행역과 하행역 둘 중 하나도 포함되어있지 않은 노선을 등록한다.")
     void addLineSectionWithUnregisteredStation() {
         // given
-        given(stationRepository.findById(신도림역.getId())).willReturn(Optional.of(신도림역));
-        given(stationRepository.findById(강남역.getId())).willReturn(Optional.of(강남역));
+        given(stationRepository.findById(신도림역_아이디)).willReturn(Optional.of(StationFixture.신도림역));
+        given(stationRepository.findById(잠실역_아이디)).willReturn(Optional.of(StationFixture.잠실역));
         given(lineRepository.findById(이호선.getId())).willReturn(Optional.of(이호선));
 
-        SaveLineSectionRequestDto saveLineSectionRequestDto = 이호선에_강남역이_하행_종점역인_구간을_생성한다(신도림역.getId());
+        SaveLineSectionRequestDto saveLineSectionRequestDto = 이호선에_잠실역이_하행_종점역인_구간을_생성한다(신도림역_아이디);
 
         // when & then
         assertThatThrownBy(() -> lineService.saveLineSection(이호선.getId(), saveLineSectionRequestDto))
@@ -227,10 +211,10 @@ public class LineServiceMockTest {
     @DisplayName("노선의 상행 종점역을 삭제한다.")
     void deleteUpStation() {
         // given
-        given(stationRepository.findById(강남역.getId())).willReturn(Optional.of(강남역));
-        given(stationRepository.findById(신촌역.getId())).willReturn(Optional.of(신촌역));
+        given(stationRepository.findById(잠실역_아이디)).willReturn(Optional.of(StationFixture.잠실역));
+        given(stationRepository.findById(신촌역_아이디)).willReturn(Optional.of(StationFixture.신촌역));
         given(lineRepository.findById(이호선.getId())).willReturn(Optional.of(이호선));
-        SaveLineSectionRequestDto saveLineSectionRequestDto = 이호선에_강남역이_하행_종점역인_구간을_생성한다(신촌역.getId());
+        SaveLineSectionRequestDto saveLineSectionRequestDto = 이호선에_잠실역이_하행_종점역인_구간을_생성한다(신촌역_아이디);
         LineResponseDto responseDto = lineService.saveLineSection(이호선.getId(), saveLineSectionRequestDto);
 
         // when
@@ -251,10 +235,10 @@ public class LineServiceMockTest {
     @DisplayName("노선의 중간역을 삭제한다.")
     void deleteMiddleStation() {
         // given
-        given(stationRepository.findById(강남역.getId())).willReturn(Optional.of(강남역));
-        given(stationRepository.findById(신촌역.getId())).willReturn(Optional.of(신촌역));
+        given(stationRepository.findById(잠실역_아이디)).willReturn(Optional.of(StationFixture.잠실역));
+        given(stationRepository.findById(신촌역_아이디)).willReturn(Optional.of(StationFixture.신촌역));
         given(lineRepository.findById(이호선.getId())).willReturn(Optional.of(이호선));
-        SaveLineSectionRequestDto saveLineSectionRequestDto = 이호선에_강남역이_하행_종점역인_구간을_생성한다(신촌역.getId());
+        SaveLineSectionRequestDto saveLineSectionRequestDto = 이호선에_잠실역이_하행_종점역인_구간을_생성한다(신촌역_아이디);
         lineService.saveLineSection(이호선.getId(), saveLineSectionRequestDto);
 
         // when
@@ -275,10 +259,10 @@ public class LineServiceMockTest {
     @DisplayName("노선의 하행 종점역을 삭제한다.")
     void deleteDownStation() {
         // given
-        given(stationRepository.findById(강남역.getId())).willReturn(Optional.of(강남역));
-        given(stationRepository.findById(신촌역.getId())).willReturn(Optional.of(신촌역));
+        given(stationRepository.findById(잠실역_아이디)).willReturn(Optional.of(StationFixture.잠실역));
+        given(stationRepository.findById(신촌역_아이디)).willReturn(Optional.of(StationFixture.신촌역));
         given(lineRepository.findById(이호선.getId())).willReturn(Optional.of(이호선));
-        SaveLineSectionRequestDto saveLineSectionRequestDto = 이호선에_강남역이_하행_종점역인_구간을_생성한다(신촌역.getId());
+        SaveLineSectionRequestDto saveLineSectionRequestDto = 이호선에_잠실역이_하행_종점역인_구간을_생성한다(신촌역_아이디);
         LineResponseDto responseDto = lineService.saveLineSection(이호선.getId(), saveLineSectionRequestDto);
 
         // when
@@ -302,7 +286,7 @@ public class LineServiceMockTest {
         given(lineRepository.findById(이호선.getId())).willReturn(Optional.of(이호선));
 
         // when & then
-        assertThatThrownBy(() -> lineService.deleteLineSectionByStationId(이호선.getId(), 강남역.getId()))
+        assertThatThrownBy(() -> lineService.deleteLineSectionByStationId(이호선.getId(), 잠실역_아이디))
                 .isInstanceOf(InvalidLineSectionException.class)
                 .hasMessageContaining(ErrorCode.UNREGISTERED_STATION.getMessage());
     }
@@ -321,10 +305,10 @@ public class LineServiceMockTest {
                 .hasMessageContaining(ErrorCode.STAND_ALONE_LINE_SECTION.getMessage());
     }
 
-    private SaveLineSectionRequestDto 이호선에_강남역이_하행_종점역인_구간을_생성한다(Long upStationId) {
+    private SaveLineSectionRequestDto 이호선에_잠실역이_하행_종점역인_구간을_생성한다(Long upStationId) {
         return SaveLineSectionRequestDto.builder()
                 .upStationId(upStationId)
-                .downStationId(강남역.getId())
+                .downStationId(잠실역_아이디)
                 .distance(12)
                 .build();
     }
@@ -332,7 +316,7 @@ public class LineServiceMockTest {
     private SaveLineSectionRequestDto 이호선에_신도림이_하행역인_구간을_생성한다(Long upStationId, Integer distance) {
         return SaveLineSectionRequestDto.builder()
                 .upStationId(upStationId)
-                .downStationId(신도림역.getId())
+                .downStationId(신도림역_아이디)
                 .distance(distance)
                 .build();
     }

--- a/src/test/java/nextstep/subway/unit/LineServiceMockTest.java
+++ b/src/test/java/nextstep/subway/unit/LineServiceMockTest.java
@@ -5,13 +5,13 @@ import nextstep.subway.global.error.code.ErrorCode;
 import nextstep.subway.global.error.exception.InvalidLineSectionException;
 import nextstep.subway.global.error.exception.NotEntityFoundException;
 import nextstep.subway.line.adapters.persistence.LineJpaAdapter;
-import nextstep.subway.line.dto.request.SaveLineSectionRequestDto;
-import nextstep.subway.line.dto.response.LineResponseDto;
+import nextstep.subway.line.dto.request.SaveLineSectionRequest;
+import nextstep.subway.line.dto.response.LineResponse;
 import nextstep.subway.line.entity.Line;
 import nextstep.subway.line.repository.LineRepository;
 import nextstep.subway.line.service.LineService;
 import nextstep.subway.station.adapters.persistence.StationJpaAdapter;
-import nextstep.subway.station.dto.response.StationResponseDto;
+import nextstep.subway.station.dto.response.StationResponse;
 import nextstep.subway.station.entity.Station;
 import nextstep.subway.station.repository.StationRepository;
 import org.junit.jupiter.api.BeforeEach;
@@ -74,14 +74,14 @@ public class LineServiceMockTest {
         given(stationRepository.findById(까치산역_아이디)).willReturn(Optional.of(StationFixture.까치산역));
         given(lineRepository.findById(이호선.getId())).willReturn(Optional.of(이호선));
 
-        SaveLineSectionRequestDto saveLineSectionRequestDto = SaveLineSectionRequestDto.builder()
+        SaveLineSectionRequest 신도림역_까치산역_구간_생성_요청 = SaveLineSectionRequest.builder()
                 .upStationId(신도림역_아이디)
                 .downStationId(까치산역_아이디)
                 .distance(5)
                 .build();
 
         // when
-        lineService.saveLineSection(이호선.getId(), saveLineSectionRequestDto);
+        lineService.saveLineSection(이호선.getId(), 신도림역_까치산역_구간_생성_요청);
 
         // then
         List<Long> 등록된_지하철역_아이디_목록 = 노선에_등록된_역_아이디_목록을_가져온다(이호선);
@@ -96,11 +96,11 @@ public class LineServiceMockTest {
         given(stationRepository.findById(까치산역_아이디)).willReturn(Optional.of(StationFixture.까치산역));
         given(lineRepository.findById(이호선.getId())).willReturn(Optional.of(이호선));
 
-        SaveLineSectionRequestDto saveLineSectionRequestDto =
+        SaveLineSectionRequest 까치산역_신도림역_구간_생성_요청 =
                 이호선에_신도림이_하행역인_구간을_생성한다(까치산역_아이디, 5);
 
         // when
-        lineService.saveLineSection(이호선.getId(), saveLineSectionRequestDto);
+        lineService.saveLineSection(이호선.getId(), 까치산역_신도림역_구간_생성_요청);
 
         // then
         List<Long> 등록된_지하철역_아이디_목록 = 노선에_등록된_역_아이디_목록을_가져온다(이호선);
@@ -115,10 +115,10 @@ public class LineServiceMockTest {
         given(stationRepository.findById(신촌역_아이디)).willReturn(Optional.of(StationFixture.신촌역));
         given(lineRepository.findById(이호선.getId())).willReturn(Optional.of(이호선));
 
-        SaveLineSectionRequestDto saveLineSectionRequestDto = 이호선에_잠실역이_하행_종점역인_구간을_생성한다(신촌역_아이디);
+        SaveLineSectionRequest 신촌역_잠실역_구간_생성_요청 = 이호선에_잠실역이_하행_종점역인_구간을_생성한다(신촌역_아이디);
 
         // when
-        lineService.saveLineSection(이호선.getId(), saveLineSectionRequestDto);
+        lineService.saveLineSection(이호선.getId(), 신촌역_잠실역_구간_생성_요청);
 
         // then
         List<Long> 등록된_지하철역_아이디_목록 = 노선에_등록된_역_아이디_목록을_가져온다(이호선);
@@ -132,12 +132,12 @@ public class LineServiceMockTest {
         given(stationRepository.findById(신촌역_아이디)).willReturn(Optional.of(StationFixture.신촌역));
         given(stationRepository.findById(잠실역_아이디)).willReturn(Optional.empty());
 
-        SaveLineSectionRequestDto 존재하지_않는_역이_하행_종점역인_구간 = 이호선에_잠실역이_하행_종점역인_구간을_생성한다(
+        SaveLineSectionRequest 존재하지_않는_역이_하행_종점역인_구간_생성_요청 = 이호선에_잠실역이_하행_종점역인_구간을_생성한다(
                 지하철_노선의_하행_종점역_아이디를_찾는다(이호선)
         );
 
         // when & then
-        assertThatThrownBy(() -> lineService.saveLineSection(이호선.getId(), 존재하지_않는_역이_하행_종점역인_구간))
+        assertThatThrownBy(() -> lineService.saveLineSection(이호선.getId(), 존재하지_않는_역이_하행_종점역인_구간_생성_요청))
                 .isInstanceOf(NotEntityFoundException.class)
                 .hasMessageContaining(ErrorCode.NOT_EXIST_STATION.getMessage());
     }
@@ -150,11 +150,11 @@ public class LineServiceMockTest {
         given(stationRepository.findById(까치산역_아이디)).willReturn(Optional.of(StationFixture.까치산역));
         given(lineRepository.findById(이호선.getId())).willReturn(Optional.of(이호선));
 
-        SaveLineSectionRequestDto saveLineSectionRequestDto =
+        SaveLineSectionRequest 까치산역_신도림역_구간_생성_요청 =
                 이호선에_신도림이_하행역인_구간을_생성한다(까치산역_아이디, 15);
 
         // when & then
-        assertThatThrownBy(() -> lineService.saveLineSection(이호선.getId(), saveLineSectionRequestDto))
+        assertThatThrownBy(() -> lineService.saveLineSection(이호선.getId(), 까치산역_신도림역_구간_생성_요청))
                 .isInstanceOf(InvalidLineSectionException.class)
                 .hasMessageContaining(ErrorCode.INVALID_DISTANCE.getMessage());
     }
@@ -167,14 +167,14 @@ public class LineServiceMockTest {
         given(stationRepository.findById(까치산역_아이디)).willReturn(Optional.of(StationFixture.까치산역));
         given(lineRepository.findById(이호선.getId())).willReturn(Optional.of(이호선));
 
-        SaveLineSectionRequestDto saveLineSectionRequestDto = SaveLineSectionRequestDto.builder()
+        SaveLineSectionRequest 까치산역_신촌역_구간_생성_요청 = SaveLineSectionRequest.builder()
                 .upStationId(까치산역_아이디)
                 .downStationId(신촌역_아이디)
                 .distance(12)
                 .build();
 
         // when & then
-        assertThatThrownBy(() -> lineService.saveLineSection(이호선.getId(), saveLineSectionRequestDto))
+        assertThatThrownBy(() -> lineService.saveLineSection(이호선.getId(), 까치산역_신촌역_구간_생성_요청))
                 .isInstanceOf(InvalidLineSectionException.class)
                 .hasMessageContaining(ErrorCode.ALREADY_REGISTERED_SECTION.getMessage());
     }
@@ -187,10 +187,10 @@ public class LineServiceMockTest {
         given(stationRepository.findById(잠실역_아이디)).willReturn(Optional.of(StationFixture.잠실역));
         given(lineRepository.findById(이호선.getId())).willReturn(Optional.of(이호선));
 
-        SaveLineSectionRequestDto saveLineSectionRequestDto = 이호선에_잠실역이_하행_종점역인_구간을_생성한다(신도림역_아이디);
+        SaveLineSectionRequest 신도림역_잠실역_구간_생성_요청 = 이호선에_잠실역이_하행_종점역인_구간을_생성한다(신도림역_아이디);
 
         // when & then
-        assertThatThrownBy(() -> lineService.saveLineSection(이호선.getId(), saveLineSectionRequestDto))
+        assertThatThrownBy(() -> lineService.saveLineSection(이호선.getId(), 신도림역_잠실역_구간_생성_요청))
                 .isInstanceOf(InvalidLineSectionException.class)
                 .hasMessageContaining(ErrorCode.UNREGISTERED_STATION.getMessage());
     }
@@ -202,11 +202,11 @@ public class LineServiceMockTest {
         given(stationRepository.findById(잠실역_아이디)).willReturn(Optional.of(StationFixture.잠실역));
         given(stationRepository.findById(신촌역_아이디)).willReturn(Optional.of(StationFixture.신촌역));
         given(lineRepository.findById(이호선.getId())).willReturn(Optional.of(이호선));
-        SaveLineSectionRequestDto saveLineSectionRequestDto = 이호선에_잠실역이_하행_종점역인_구간을_생성한다(신촌역_아이디);
-        LineResponseDto responseDto = lineService.saveLineSection(이호선.getId(), saveLineSectionRequestDto);
+        SaveLineSectionRequest 신촌역_잠실역_구간_생성_요청 = 이호선에_잠실역이_하행_종점역인_구간을_생성한다(신촌역_아이디);
+        LineResponse 신촌역_잠실역_구간_생성_응답 = lineService.saveLineSection(이호선.getId(), 신촌역_잠실역_구간_생성_요청);
 
         // when
-        Long 노선의_상행_종점역_아이디 = 지하철_노선의_성행_종점역_아이디를_찾는다(responseDto);
+        Long 노선의_상행_종점역_아이디 = 지하철_노선의_성행_종점역_아이디를_찾는다(신촌역_잠실역_구간_생성_응답);
         lineService.deleteLineSectionByStationId(이호선.getId(), 노선의_상행_종점역_아이디);
 
         // then
@@ -221,11 +221,11 @@ public class LineServiceMockTest {
         given(stationRepository.findById(잠실역_아이디)).willReturn(Optional.of(StationFixture.잠실역));
         given(stationRepository.findById(신촌역_아이디)).willReturn(Optional.of(StationFixture.신촌역));
         given(lineRepository.findById(이호선.getId())).willReturn(Optional.of(이호선));
-        SaveLineSectionRequestDto saveLineSectionRequestDto = 이호선에_잠실역이_하행_종점역인_구간을_생성한다(신촌역_아이디);
-        lineService.saveLineSection(이호선.getId(), saveLineSectionRequestDto);
+        SaveLineSectionRequest 신촌역_잠실역_구간_생성_요청 = 이호선에_잠실역이_하행_종점역인_구간을_생성한다(신촌역_아이디);
+        lineService.saveLineSection(이호선.getId(), 신촌역_잠실역_구간_생성_요청);
 
         // when
-        Long 노선의_중간역_아이디 = saveLineSectionRequestDto.getUpStationId();
+        Long 노선의_중간역_아이디 = 신촌역_잠실역_구간_생성_요청.getUpStationId();
         lineService.deleteLineSectionByStationId(이호선.getId(), 노선의_중간역_아이디);
 
         // then
@@ -240,11 +240,11 @@ public class LineServiceMockTest {
         given(stationRepository.findById(잠실역_아이디)).willReturn(Optional.of(StationFixture.잠실역));
         given(stationRepository.findById(신촌역_아이디)).willReturn(Optional.of(StationFixture.신촌역));
         given(lineRepository.findById(이호선.getId())).willReturn(Optional.of(이호선));
-        SaveLineSectionRequestDto saveLineSectionRequestDto = 이호선에_잠실역이_하행_종점역인_구간을_생성한다(신촌역_아이디);
-        LineResponseDto responseDto = lineService.saveLineSection(이호선.getId(), saveLineSectionRequestDto);
+        SaveLineSectionRequest 신촌역_잠실역_구간_생성_요청 = 이호선에_잠실역이_하행_종점역인_구간을_생성한다(신촌역_아이디);
+        LineResponse 신촌역_잠실역_구간_생성_응답 = lineService.saveLineSection(이호선.getId(), 신촌역_잠실역_구간_생성_요청);
 
         // when
-        Long 노선의_하행_종점역_아이디 = 지하철_노선의_하행_종점역_아이디를_찾는다(responseDto);
+        Long 노선의_하행_종점역_아이디 = 지하철_노선의_하행_종점역_아이디를_찾는다(신촌역_잠실역_구간_생성_응답);
         lineService.deleteLineSectionByStationId(이호선.getId(), 노선의_하행_종점역_아이디);
 
         // then
@@ -286,23 +286,23 @@ public class LineServiceMockTest {
                 .collect(Collectors.toList());
     }
 
-    private SaveLineSectionRequestDto 이호선에_잠실역이_하행_종점역인_구간을_생성한다(Long upStationId) {
-        return SaveLineSectionRequestDto.builder()
+    private SaveLineSectionRequest 이호선에_잠실역이_하행_종점역인_구간을_생성한다(Long upStationId) {
+        return SaveLineSectionRequest.builder()
                 .upStationId(upStationId)
                 .downStationId(잠실역_아이디)
                 .distance(12)
                 .build();
     }
 
-    private SaveLineSectionRequestDto 이호선에_신도림이_하행역인_구간을_생성한다(Long upStationId, Integer distance) {
-        return SaveLineSectionRequestDto.builder()
+    private SaveLineSectionRequest 이호선에_신도림이_하행역인_구간을_생성한다(Long upStationId, Integer distance) {
+        return SaveLineSectionRequest.builder()
                 .upStationId(upStationId)
                 .downStationId(신도림역_아이디)
                 .distance(distance)
                 .build();
     }
 
-    private Long 지하철_노선의_성행_종점역_아이디를_찾는다(LineResponseDto lineResponseDto) {
+    private Long 지하철_노선의_성행_종점역_아이디를_찾는다(LineResponse lineResponseDto) {
         return lineResponseDto.getStations()
                 .get(0)
                 .getId();
@@ -315,8 +315,8 @@ public class LineServiceMockTest {
         return stations.get(lastIndex).getId();
     }
 
-    private Long 지하철_노선의_하행_종점역_아이디를_찾는다(LineResponseDto lineResponseDto) {
-        List<StationResponseDto> 노선에_등록된_역_목록 = lineResponseDto.getStations();
+    private Long 지하철_노선의_하행_종점역_아이디를_찾는다(LineResponse lineResponseDto) {
+        List<StationResponse> 노선에_등록된_역_목록 = lineResponseDto.getStations();
         int lastIndex = 노선에_등록된_역_목록.size() - 1;
 
         return 노선에_등록된_역_목록

--- a/src/test/java/nextstep/subway/unit/LineServiceTest.java
+++ b/src/test/java/nextstep/subway/unit/LineServiceTest.java
@@ -37,23 +37,31 @@ public class LineServiceTest {
     @Autowired
     private LineService lineService;
 
-    private Station 신사역;
+    private Long 신사역_아이디;
 
-    private Station 강남역;
+    private Long 강남역_아이디;
 
-    private Station 판교역;
+    private Long 판교역_아이디;
 
-    private Station 광교역;
+    private Long 광교역_아이디;
 
     private Line 신분당선;
 
     @BeforeEach
     void setUp() {
         // given
-        신사역 = stationRepository.save(new Station("신사역"));
-        강남역 = stationRepository.save(new Station("강남역"));
-        판교역 = stationRepository.save(new Station("판교역"));
-        광교역 = stationRepository.save(new Station("광교역"));
+        Station 신사역 = stationRepository.save(new Station("신사역"));
+        신사역_아이디 = 신사역.getId();
+
+        Station 강남역 = stationRepository.save(new Station("강남역"));
+        강남역_아이디 = 강남역.getId();
+
+        Station 판교역 = stationRepository.save(new Station("판교역"));
+        판교역_아이디 = 판교역.getId();
+
+        Station 광교역 = stationRepository.save(new Station("광교역"));
+        광교역_아이디 = 광교역.getId();
+
         신분당선 = lineRepository.save(
                 Line.builder()
                         .name("신분당선")
@@ -68,76 +76,52 @@ public class LineServiceTest {
     @Test
     @DisplayName("지하철 노선의 상행 종점역이 하행역인 구간을 추가한다.")
     void addFirstLineSection() {
-        // when: 신사역 - 판교역 노선에 강남역 - 신사역 노선을 추가
+        // when
         SaveLineSectionRequestDto 강남역_신사역_노선 = SaveLineSectionRequestDto.builder()
-                .upStationId(강남역.getId())
-                .downStationId(신사역.getId())
+                .upStationId(강남역_아이디)
+                .downStationId(신사역_아이디)
                 .distance(15)
                 .build();
 
         LineResponseDto lineResponseDto = lineService.saveLineSection(신분당선.getId(), 강남역_신사역_노선);
 
-        // then: 강남역 - 신사역 - 판교역이 조회
-        List<Long> 등록된_지하철역_아이디_목록 = lineResponseDto.getStations()
-                .stream()
-                .map(StationResponseDto::getId)
-                .collect(Collectors.toList());
-
-        assertThat(등록된_지하철역_아이디_목록).containsExactly(
-                강남역.getId(),
-                신사역.getId(),
-                판교역.getId()
-        );
+        // then
+        List<Long> 등록된_지하철역_아이디_목록 = 노선에_등록된_역_아이디_목록을_가져온다(lineResponseDto);
+        assertThat(등록된_지하철역_아이디_목록).containsExactly(강남역_아이디, 신사역_아이디, 판교역_아이디);
     }
 
     @Test
     @DisplayName("지하철 노선의 상행 종점역과 하행 종점역 사이에 구간을 추가한다.")
     void addMiddleLineSection() {
-        // when: 신사역 - 판교역 노선에 신사역 - 강남역 노선을 추가
+        // when
         SaveLineSectionRequestDto 신사역_강남역_노선 = SaveLineSectionRequestDto.builder()
-                .upStationId(신사역.getId())
-                .downStationId(강남역.getId())
+                .upStationId(신사역_아이디)
+                .downStationId(강남역_아이디)
                 .distance(15)
                 .build();
 
         LineResponseDto lineResponseDto = lineService.saveLineSection(신분당선.getId(), 신사역_강남역_노선);
 
-        // then: 신사역 - 강남역 - 판교역이 조회
-        List<Long> 등록된_지하철역_아이디_목록 = lineResponseDto.getStations()
-                .stream()
-                .map(StationResponseDto::getId)
-                .collect(Collectors.toList());
-
-        assertThat(등록된_지하철역_아이디_목록).containsExactly(
-                신사역.getId(),
-                강남역.getId(),
-                판교역.getId()
-        );
+        // then
+        List<Long> 등록된_지하철역_아이디_목록 = 노선에_등록된_역_아이디_목록을_가져온다(lineResponseDto);
+        assertThat(등록된_지하철역_아이디_목록).containsExactly(신사역_아이디, 강남역_아이디, 판교역_아이디);
     }
 
     @Test
     @DisplayName("지하철 노선의 하행 종점역에 구간을 추가한다.")
     void addLastLineSection() {
-        // when: 신사역 - 판교역 노선에 판교역 - 광교역 노선을 추가
+        // when
         SaveLineSectionRequestDto 판교역_광교역_노선 = SaveLineSectionRequestDto.builder()
-                .upStationId(판교역.getId())
-                .downStationId(광교역.getId())
+                .upStationId(판교역_아이디)
+                .downStationId(광교역_아이디)
                 .distance(5)
                 .build();
 
         LineResponseDto lineResponseDto = lineService.saveLineSection(신분당선.getId(), 판교역_광교역_노선);
 
-        // then: 신사역 - 판교역 - 광교역이 조회
-        List<Long> 등록된_지하철역_아이디_목록 = lineResponseDto.getStations()
-                .stream()
-                .map(StationResponseDto::getId)
-                .collect(Collectors.toList());
-
-        assertThat(등록된_지하철역_아이디_목록).containsExactly(
-                        신사역.getId(),
-                        판교역.getId(),
-                        광교역.getId()
-                );
+        // then
+        List<Long> 등록된_지하철역_아이디_목록 = 노선에_등록된_역_아이디_목록을_가져온다(lineResponseDto);
+        assertThat(등록된_지하철역_아이디_목록).containsExactly(신사역_아이디, 판교역_아이디, 광교역_아이디);
     }
 
     @Test
@@ -159,10 +143,10 @@ public class LineServiceTest {
     @Test
     @DisplayName("역 사이에 기존 역 사이 길이보다 크거나 같은 노선을 등록한다.")
     void addInvalidDistanceLineSection() {
-        // given: 신사역 - 강남역 노선(23m)
+        // given
         SaveLineSectionRequestDto 신사역_강남역_노선 = SaveLineSectionRequestDto.builder()
-                .upStationId(신사역.getId())
-                .downStationId(강남역.getId())
+                .upStationId(신사역_아이디)
+                .downStationId(강남역_아이디)
                 .distance(23)
                 .build();
 
@@ -177,8 +161,8 @@ public class LineServiceTest {
     void addAlreadyRegisteredLineSection() {
         // given
         SaveLineSectionRequestDto 신사역_판교역_노선 = SaveLineSectionRequestDto.builder()
-                .upStationId(신사역.getId())
-                .downStationId(판교역.getId())
+                .upStationId(신사역_아이디)
+                .downStationId(판교역_아이디)
                 .distance(24)
                 .build();
 
@@ -193,8 +177,8 @@ public class LineServiceTest {
     void addLineSectionWithUnregisteredStation() {
         // given
         SaveLineSectionRequestDto 강남역_광교역_노선 = SaveLineSectionRequestDto.builder()
-                .upStationId(강남역.getId())
-                .downStationId(광교역.getId())
+                .upStationId(강남역_아이디)
+                .downStationId(광교역_아이디)
                 .distance(13)
                 .build();
 
@@ -210,23 +194,19 @@ public class LineServiceTest {
         // given
         SaveLineSectionRequestDto 광교역이_하행_종점역인_구간 = SaveLineSectionRequestDto.builder()
                 .upStationId(노선의_하행_종점역_아이디를_찾는다(신분당선))
-                .downStationId(광교역.getId())
+                .downStationId(광교역_아이디)
                 .distance(13)
                 .build();
 
-        LineResponseDto lineResponseDto = lineService.saveLineSection(신분당선.getId(), 광교역이_하행_종점역인_구간);
+        LineResponseDto saveLineResponseDto = lineService.saveLineSection(신분당선.getId(), 광교역이_하행_종점역인_구간);
 
         // when
-        Long 노선의_상행_종점역_아이디 = 노선의_상행_종점역_아이디를_찾는다(lineResponseDto);
+        Long 노선의_상행_종점역_아이디 = 노선의_상행_종점역_아이디를_찾는다(saveLineResponseDto);
         lineService.deleteLineSectionByStationId(신분당선.getId(), 노선의_상행_종점역_아이디);
 
         // then
-        List<Long> 노선에_등록된_역_아이디_목록 = lineService.findLineById(lineResponseDto.getId())
-                .getStations()
-                .stream()
-                .map(StationResponseDto::getId)
-                .collect(Collectors.toList());
-
+        LineResponseDto findLineResponseDto = lineService.findLineById(saveLineResponseDto.getId());
+        List<Long> 노선에_등록된_역_아이디_목록 = 노선에_등록된_역_아이디_목록을_가져온다(findLineResponseDto);
         assertThat(노선에_등록된_역_아이디_목록).doesNotContain(노선의_상행_종점역_아이디);
     }
 
@@ -236,23 +216,19 @@ public class LineServiceTest {
         // given
         SaveLineSectionRequestDto 광교역이_하행_종점역인_구간 = SaveLineSectionRequestDto.builder()
                 .upStationId(노선의_하행_종점역_아이디를_찾는다(신분당선))
-                .downStationId(광교역.getId())
+                .downStationId(광교역_아이디)
                 .distance(13)
                 .build();
 
-        LineResponseDto lineResponseDto = lineService.saveLineSection(신분당선.getId(), 광교역이_하행_종점역인_구간);
+        LineResponseDto saveLineResponseDto = lineService.saveLineSection(신분당선.getId(), 광교역이_하행_종점역인_구간);
 
         // when
         Long 노선의_중간역_아이디 = 광교역이_하행_종점역인_구간.getUpStationId();
         lineService.deleteLineSectionByStationId(신분당선.getId(), 노선의_중간역_아이디);
 
         // then
-        List<Long> 노선에_등록된_역_아이디_목록 = lineService.findLineById(lineResponseDto.getId())
-                .getStations()
-                .stream()
-                .map(StationResponseDto::getId)
-                .collect(Collectors.toList());
-
+        LineResponseDto findLineResponseDto = lineService.findLineById(saveLineResponseDto.getId());
+        List<Long> 노선에_등록된_역_아이디_목록 = 노선에_등록된_역_아이디_목록을_가져온다(findLineResponseDto);
         assertThat(노선에_등록된_역_아이디_목록).doesNotContain(노선의_중간역_아이디);
     }
 
@@ -262,23 +238,19 @@ public class LineServiceTest {
         // given
         SaveLineSectionRequestDto 광교역이_하행_종점역인_구간 = SaveLineSectionRequestDto.builder()
                 .upStationId(노선의_하행_종점역_아이디를_찾는다(신분당선))
-                .downStationId(광교역.getId())
+                .downStationId(광교역_아이디)
                 .distance(13)
                 .build();
 
-        LineResponseDto lineResponseDto = lineService.saveLineSection(신분당선.getId(), 광교역이_하행_종점역인_구간);
+        LineResponseDto saveLineResponseDto = lineService.saveLineSection(신분당선.getId(), 광교역이_하행_종점역인_구간);
 
         // when
-        Long 노선의_하행_종점역_아이디 = 노선의_하행_종점역_아이디를_찾는다(lineResponseDto);
+        Long 노선의_하행_종점역_아이디 = 노선의_하행_종점역_아이디를_찾는다(saveLineResponseDto);
         lineService.deleteLineSectionByStationId(신분당선.getId(), 노선의_하행_종점역_아이디);
 
         // then
-        List<Long> 노선에_등록된_역_아이디_목록 = lineService.findLineById(lineResponseDto.getId())
-                .getStations()
-                .stream()
-                .map(StationResponseDto::getId)
-                .collect(Collectors.toList());
-
+        LineResponseDto findLineResponseDto = lineService.findLineById(saveLineResponseDto.getId());
+        List<Long> 노선에_등록된_역_아이디_목록 = 노선에_등록된_역_아이디_목록을_가져온다(findLineResponseDto);
         assertThat(노선에_등록된_역_아이디_목록).doesNotContain(노선의_하행_종점역_아이디);
     }
 
@@ -286,7 +258,7 @@ public class LineServiceTest {
     @DisplayName("등록되어 있지 않은 구간을 삭제한다.")
     void deleteNotExistSection() {
         // when & then
-        assertThatThrownBy(() -> lineService.deleteLineSectionByStationId(신분당선.getId(), 강남역.getId()))
+        assertThatThrownBy(() -> lineService.deleteLineSectionByStationId(신분당선.getId(), 강남역_아이디))
                 .isInstanceOf(InvalidLineSectionException.class)
                 .hasMessageContaining(ErrorCode.UNREGISTERED_STATION.getMessage());
     }
@@ -295,9 +267,17 @@ public class LineServiceTest {
     @DisplayName("구간이 1개일 때 삭제한다.")
     void deleteStandaloneSection() {
         // when & then
-        assertThatThrownBy(() -> lineService.deleteLineSectionByStationId(신분당선.getId(), 판교역.getId()))
+        assertThatThrownBy(() -> lineService.deleteLineSectionByStationId(신분당선.getId(), 판교역_아이디))
                 .isInstanceOf(InvalidLineSectionException.class)
                 .hasMessageContaining(ErrorCode.STAND_ALONE_LINE_SECTION.getMessage());
+    }
+
+    private List<Long> 노선에_등록된_역_아이디_목록을_가져온다(LineResponseDto lineResponseDto) {
+        return lineResponseDto
+                .getStations()
+                .stream()
+                .map(StationResponseDto::getId)
+                .collect(Collectors.toList());
     }
 
     private long 노선의_상행_종점역_아이디를_찾는다(LineResponseDto lineResponseDto) {

--- a/src/test/java/nextstep/subway/unit/LineServiceTest.java
+++ b/src/test/java/nextstep/subway/unit/LineServiceTest.java
@@ -3,12 +3,12 @@ package nextstep.subway.unit;
 import nextstep.subway.global.error.code.ErrorCode;
 import nextstep.subway.global.error.exception.InvalidLineSectionException;
 import nextstep.subway.global.error.exception.NotEntityFoundException;
-import nextstep.subway.line.dto.request.SaveLineSectionRequestDto;
-import nextstep.subway.line.dto.response.LineResponseDto;
+import nextstep.subway.line.dto.request.SaveLineSectionRequest;
+import nextstep.subway.line.dto.response.LineResponse;
 import nextstep.subway.line.entity.Line;
 import nextstep.subway.line.repository.LineRepository;
 import nextstep.subway.line.service.LineService;
-import nextstep.subway.station.dto.response.StationResponseDto;
+import nextstep.subway.station.dto.response.StationResponse;
 import nextstep.subway.station.entity.Station;
 import nextstep.subway.station.repository.StationRepository;
 import org.junit.jupiter.api.BeforeEach;
@@ -77,16 +77,16 @@ public class LineServiceTest {
     @DisplayName("지하철 노선의 상행 종점역이 하행역인 구간을 추가한다.")
     void addFirstLineSection() {
         // when
-        SaveLineSectionRequestDto 강남역_신사역_노선 = SaveLineSectionRequestDto.builder()
+        SaveLineSectionRequest 강남역_신사역_노선_요청 = SaveLineSectionRequest.builder()
                 .upStationId(강남역_아이디)
                 .downStationId(신사역_아이디)
                 .distance(15)
                 .build();
 
-        LineResponseDto lineResponseDto = lineService.saveLineSection(신분당선.getId(), 강남역_신사역_노선);
+        LineResponse 강남역_신사역_노선_응답 = lineService.saveLineSection(신분당선.getId(), 강남역_신사역_노선_요청);
 
         // then
-        List<Long> 등록된_지하철역_아이디_목록 = 노선에_등록된_역_아이디_목록을_가져온다(lineResponseDto);
+        List<Long> 등록된_지하철역_아이디_목록 = 노선에_등록된_역_아이디_목록을_가져온다(강남역_신사역_노선_응답);
         assertThat(등록된_지하철역_아이디_목록).containsExactly(강남역_아이디, 신사역_아이디, 판교역_아이디);
     }
 
@@ -94,16 +94,16 @@ public class LineServiceTest {
     @DisplayName("지하철 노선의 상행 종점역과 하행 종점역 사이에 구간을 추가한다.")
     void addMiddleLineSection() {
         // when
-        SaveLineSectionRequestDto 신사역_강남역_노선 = SaveLineSectionRequestDto.builder()
+        SaveLineSectionRequest 신사역_강남역_노선_생성_요청 = SaveLineSectionRequest.builder()
                 .upStationId(신사역_아이디)
                 .downStationId(강남역_아이디)
                 .distance(15)
                 .build();
 
-        LineResponseDto lineResponseDto = lineService.saveLineSection(신분당선.getId(), 신사역_강남역_노선);
+        LineResponse 신사역_강남역_노선_생성_응답 = lineService.saveLineSection(신분당선.getId(), 신사역_강남역_노선_생성_요청);
 
         // then
-        List<Long> 등록된_지하철역_아이디_목록 = 노선에_등록된_역_아이디_목록을_가져온다(lineResponseDto);
+        List<Long> 등록된_지하철역_아이디_목록 = 노선에_등록된_역_아이디_목록을_가져온다(신사역_강남역_노선_생성_응답);
         assertThat(등록된_지하철역_아이디_목록).containsExactly(신사역_아이디, 강남역_아이디, 판교역_아이디);
     }
 
@@ -111,16 +111,16 @@ public class LineServiceTest {
     @DisplayName("지하철 노선의 하행 종점역에 구간을 추가한다.")
     void addLastLineSection() {
         // when
-        SaveLineSectionRequestDto 판교역_광교역_노선 = SaveLineSectionRequestDto.builder()
+        SaveLineSectionRequest 판교역_광교역_노선_생성_요청 = SaveLineSectionRequest.builder()
                 .upStationId(판교역_아이디)
                 .downStationId(광교역_아이디)
                 .distance(5)
                 .build();
 
-        LineResponseDto lineResponseDto = lineService.saveLineSection(신분당선.getId(), 판교역_광교역_노선);
+        LineResponse 판교역_광교역_노선_생성_응답 = lineService.saveLineSection(신분당선.getId(), 판교역_광교역_노선_생성_요청);
 
         // then
-        List<Long> 등록된_지하철역_아이디_목록 = 노선에_등록된_역_아이디_목록을_가져온다(lineResponseDto);
+        List<Long> 등록된_지하철역_아이디_목록 = 노선에_등록된_역_아이디_목록을_가져온다(판교역_광교역_노선_생성_응답);
         assertThat(등록된_지하철역_아이디_목록).containsExactly(신사역_아이디, 판교역_아이디, 광교역_아이디);
     }
 
@@ -128,14 +128,14 @@ public class LineServiceTest {
     @DisplayName("존재하지 않는 역이 하행 종점역인 구간을 추가한다.")
     void addNotExistDownStation() {
         // given
-        SaveLineSectionRequestDto 존재하지_않는_역이_하행_종점역인_구간 = SaveLineSectionRequestDto.builder()
+        SaveLineSectionRequest 존재하지_않는_역이_하행_종점역인_구간_생성_요청 = SaveLineSectionRequest.builder()
                 .upStationId(노선의_하행_종점역_아이디를_찾는다(신분당선))
                 .downStationId(0L)
                 .distance(8)
                 .build();
 
         // when & then
-        assertThatThrownBy(() -> lineService.saveLineSection(신분당선.getId(), 존재하지_않는_역이_하행_종점역인_구간))
+        assertThatThrownBy(() -> lineService.saveLineSection(신분당선.getId(), 존재하지_않는_역이_하행_종점역인_구간_생성_요청))
                 .isInstanceOf(NotEntityFoundException.class)
                 .hasMessageContaining(ErrorCode.NOT_EXIST_STATION.getMessage());
     }
@@ -144,14 +144,14 @@ public class LineServiceTest {
     @DisplayName("역 사이에 기존 역 사이 길이보다 크거나 같은 노선을 등록한다.")
     void addInvalidDistanceLineSection() {
         // given
-        SaveLineSectionRequestDto 신사역_강남역_노선 = SaveLineSectionRequestDto.builder()
+        SaveLineSectionRequest 신사역_강남역_노선_생성_요청 = SaveLineSectionRequest.builder()
                 .upStationId(신사역_아이디)
                 .downStationId(강남역_아이디)
                 .distance(23)
                 .build();
 
         // when & then
-        assertThatThrownBy(() -> lineService.saveLineSection(신분당선.getId(), 신사역_강남역_노선))
+        assertThatThrownBy(() -> lineService.saveLineSection(신분당선.getId(), 신사역_강남역_노선_생성_요청))
                 .isInstanceOf(InvalidLineSectionException.class)
                 .hasMessageContaining(ErrorCode.INVALID_DISTANCE.getMessage());
     }
@@ -160,14 +160,14 @@ public class LineServiceTest {
     @DisplayName("이미 등록되어 있는 노선을 등록한다.")
     void addAlreadyRegisteredLineSection() {
         // given
-        SaveLineSectionRequestDto 신사역_판교역_노선 = SaveLineSectionRequestDto.builder()
+        SaveLineSectionRequest 신사역_판교역_노선_생성_요청 = SaveLineSectionRequest.builder()
                 .upStationId(신사역_아이디)
                 .downStationId(판교역_아이디)
                 .distance(24)
                 .build();
 
         // when & then
-        assertThatThrownBy(() -> lineService.saveLineSection(신분당선.getId(), 신사역_판교역_노선))
+        assertThatThrownBy(() -> lineService.saveLineSection(신분당선.getId(), 신사역_판교역_노선_생성_요청))
                 .isInstanceOf(InvalidLineSectionException.class)
                 .hasMessageContaining(ErrorCode.ALREADY_REGISTERED_SECTION.getMessage());
     }
@@ -176,14 +176,14 @@ public class LineServiceTest {
     @DisplayName("상행역과 하행역 둘 중 하나도 포함되어있지 않은 노선을 등록한다.")
     void addLineSectionWithUnregisteredStation() {
         // given
-        SaveLineSectionRequestDto 강남역_광교역_노선 = SaveLineSectionRequestDto.builder()
+        SaveLineSectionRequest 강남역_광교역_노선_생성_요청 = SaveLineSectionRequest.builder()
                 .upStationId(강남역_아이디)
                 .downStationId(광교역_아이디)
                 .distance(13)
                 .build();
 
         // when & then
-        assertThatThrownBy(() -> lineService.saveLineSection(신분당선.getId(), 강남역_광교역_노선))
+        assertThatThrownBy(() -> lineService.saveLineSection(신분당선.getId(), 강남역_광교역_노선_생성_요청))
                 .isInstanceOf(InvalidLineSectionException.class)
                 .hasMessageContaining(ErrorCode.UNREGISTERED_STATION.getMessage());
     }
@@ -192,20 +192,20 @@ public class LineServiceTest {
     @DisplayName("노선의 상행 종점역을 삭제한다.")
     void deleteUpStation() {
         // given
-        SaveLineSectionRequestDto 광교역이_하행_종점역인_구간 = SaveLineSectionRequestDto.builder()
+        SaveLineSectionRequest 광교역이_하행_종점역인_구간_생성_요청 = SaveLineSectionRequest.builder()
                 .upStationId(노선의_하행_종점역_아이디를_찾는다(신분당선))
                 .downStationId(광교역_아이디)
                 .distance(13)
                 .build();
 
-        LineResponseDto saveLineResponseDto = lineService.saveLineSection(신분당선.getId(), 광교역이_하행_종점역인_구간);
+        LineResponse 강남역_광교역_노선_생성_응답 = lineService.saveLineSection(신분당선.getId(), 광교역이_하행_종점역인_구간_생성_요청);
 
         // when
-        Long 노선의_상행_종점역_아이디 = 노선의_상행_종점역_아이디를_찾는다(saveLineResponseDto);
+        Long 노선의_상행_종점역_아이디 = 노선의_상행_종점역_아이디를_찾는다(강남역_광교역_노선_생성_응답);
         lineService.deleteLineSectionByStationId(신분당선.getId(), 노선의_상행_종점역_아이디);
 
         // then
-        LineResponseDto findLineResponseDto = lineService.findLineById(saveLineResponseDto.getId());
+        LineResponse findLineResponseDto = lineService.findLineById(강남역_광교역_노선_생성_응답.getId());
         List<Long> 노선에_등록된_역_아이디_목록 = 노선에_등록된_역_아이디_목록을_가져온다(findLineResponseDto);
         assertThat(노선에_등록된_역_아이디_목록).doesNotContain(노선의_상행_종점역_아이디);
     }
@@ -214,20 +214,21 @@ public class LineServiceTest {
     @DisplayName("노선의 중간역을 삭제한다.")
     void deleteMiddleStation() {
         // given
-        SaveLineSectionRequestDto 광교역이_하행_종점역인_구간 = SaveLineSectionRequestDto.builder()
+        SaveLineSectionRequest 광교역이_하행_종점역인_구간_생성_요청 = SaveLineSectionRequest.builder()
                 .upStationId(노선의_하행_종점역_아이디를_찾는다(신분당선))
                 .downStationId(광교역_아이디)
                 .distance(13)
                 .build();
 
-        LineResponseDto saveLineResponseDto = lineService.saveLineSection(신분당선.getId(), 광교역이_하행_종점역인_구간);
+        LineResponse 광교역이_하행_종점역인_구간_생성_응답 =
+                lineService.saveLineSection(신분당선.getId(), 광교역이_하행_종점역인_구간_생성_요청);
 
         // when
-        Long 노선의_중간역_아이디 = 광교역이_하행_종점역인_구간.getUpStationId();
+        Long 노선의_중간역_아이디 = 광교역이_하행_종점역인_구간_생성_요청.getUpStationId();
         lineService.deleteLineSectionByStationId(신분당선.getId(), 노선의_중간역_아이디);
 
         // then
-        LineResponseDto findLineResponseDto = lineService.findLineById(saveLineResponseDto.getId());
+        LineResponse findLineResponseDto = lineService.findLineById(광교역이_하행_종점역인_구간_생성_응답.getId());
         List<Long> 노선에_등록된_역_아이디_목록 = 노선에_등록된_역_아이디_목록을_가져온다(findLineResponseDto);
         assertThat(노선에_등록된_역_아이디_목록).doesNotContain(노선의_중간역_아이디);
     }
@@ -236,22 +237,22 @@ public class LineServiceTest {
     @DisplayName("노선의 하행 종점역을 삭제한다.")
     void deleteDownStation() {
         // given
-        SaveLineSectionRequestDto 광교역이_하행_종점역인_구간 = SaveLineSectionRequestDto.builder()
+        SaveLineSectionRequest 광교역이_하행_종점역인_구간_생성_요청 = SaveLineSectionRequest.builder()
                 .upStationId(노선의_하행_종점역_아이디를_찾는다(신분당선))
                 .downStationId(광교역_아이디)
                 .distance(13)
                 .build();
 
-        LineResponseDto saveLineResponseDto = lineService.saveLineSection(신분당선.getId(), 광교역이_하행_종점역인_구간);
+        LineResponse saveLineResponseDto = lineService.saveLineSection(신분당선.getId(), 광교역이_하행_종점역인_구간_생성_요청);
 
         // when
-        Long 노선의_하행_종점역_아이디 = 노선의_하행_종점역_아이디를_찾는다(saveLineResponseDto);
-        lineService.deleteLineSectionByStationId(신분당선.getId(), 노선의_하행_종점역_아이디);
+        Long 광교역이_하행_종점역인_구간_생성_응답 = 노선의_하행_종점역_아이디를_찾는다(saveLineResponseDto);
+        lineService.deleteLineSectionByStationId(신분당선.getId(), 광교역이_하행_종점역인_구간_생성_응답);
 
         // then
-        LineResponseDto findLineResponseDto = lineService.findLineById(saveLineResponseDto.getId());
-        List<Long> 노선에_등록된_역_아이디_목록 = 노선에_등록된_역_아이디_목록을_가져온다(findLineResponseDto);
-        assertThat(노선에_등록된_역_아이디_목록).doesNotContain(노선의_하행_종점역_아이디);
+        LineResponse 신분당선_조회_응답 = lineService.findLineById(신분당선.getId());
+        List<Long> 노선에_등록된_역_아이디_목록 = 노선에_등록된_역_아이디_목록을_가져온다(신분당선_조회_응답);
+        assertThat(노선에_등록된_역_아이디_목록).doesNotContain(광교역이_하행_종점역인_구간_생성_응답);
     }
 
     @Test
@@ -272,15 +273,15 @@ public class LineServiceTest {
                 .hasMessageContaining(ErrorCode.STAND_ALONE_LINE_SECTION.getMessage());
     }
 
-    private List<Long> 노선에_등록된_역_아이디_목록을_가져온다(LineResponseDto lineResponseDto) {
+    private List<Long> 노선에_등록된_역_아이디_목록을_가져온다(LineResponse lineResponseDto) {
         return lineResponseDto
                 .getStations()
                 .stream()
-                .map(StationResponseDto::getId)
+                .map(StationResponse::getId)
                 .collect(Collectors.toList());
     }
 
-    private long 노선의_상행_종점역_아이디를_찾는다(LineResponseDto lineResponseDto) {
+    private long 노선의_상행_종점역_아이디를_찾는다(LineResponse lineResponseDto) {
         return lineResponseDto.getStations()
                 .get(0)
                 .getId();
@@ -294,8 +295,8 @@ public class LineServiceTest {
                 .getId();
     }
 
-    private Long 노선의_하행_종점역_아이디를_찾는다(LineResponseDto lineResponseDto) {
-        List<StationResponseDto> 노선에_등록된_역_목록 = lineResponseDto.getStations();
+    private Long 노선의_하행_종점역_아이디를_찾는다(LineResponse lineResponseDto) {
+        List<StationResponse> 노선에_등록된_역_목록 = lineResponseDto.getStations();
         int lastIndex = 노선에_등록된_역_목록.size() - 1;
         return 노선에_등록된_역_목록
                 .get(lastIndex)

--- a/src/test/java/nextstep/subway/unit/LineTest.java
+++ b/src/test/java/nextstep/subway/unit/LineTest.java
@@ -1,5 +1,6 @@
 package nextstep.subway.unit;
 
+import nextstep.subway.fixture.StationFixture;
 import nextstep.subway.global.error.code.ErrorCode;
 import nextstep.subway.global.error.exception.InvalidLineSectionException;
 import nextstep.subway.section.entity.Section;
@@ -18,46 +19,37 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 @DisplayName("지하철 구간 단위 테스트")
 class LineTest {
 
-    private Station 신사역;
+    private static final Station 까치산역 = StationFixture.까치산역;
 
-    private Station 강남역;
+    private static final Station 신도림역 = StationFixture.신도림역;
 
-    private Station 판교역;
+    private static final Station 신촌역 = StationFixture.신촌역;
 
-    private Station 광교역;
+    private static final Station 잠실역 = StationFixture.잠실역;
 
     private Sections sections;
 
     @BeforeEach
     void setUp() {
         // given
-        Long 신사역_아이디 = 1L;
-        Long 강남역_아이디 = 2L;
-        Long 판교역_아이디 = 3L;
-        Long 광교역_아이디 = 4L;
-        신사역 = new Station(신사역_아이디, "신사역");
-        강남역 = new Station(강남역_아이디, "강남역");
-        판교역 = new Station(판교역_아이디, "판교역");
-        광교역 = new Station(광교역_아이디, "광교역");
-
-        Section 신사역_강남역_구간 = new Section(신사역, 판교역, 23);
+        Section 까치산역_신촌역_구간 = new Section(까치산역, 신촌역, 23);
         sections = new Sections();
-        sections.addSection(신사역_강남역_구간);
+        sections.addSection(까치산역_신촌역_구간);
     }
 
     @Test
     @DisplayName("지하철 노선의 하행 종점역에 구간을 추가한다.")
     void addLastLineSection() {
-        // when: 신사역 - 판교역 노선에 판교역 - 광교역 노선을 추가
-        Section 판교역_광교역_노선 = new Section(판교역, 광교역, 5);
-        sections.addSection(판교역_광교역_노선);
+        // when: 까치산역 - 신촌역 노선에 신촌역 - 잠실역 노선을 추가
+        Section 신촌역_잠실역_노선 = new Section(신촌역, 잠실역, 5);
+        sections.addSection(신촌역_잠실역_노선);
 
-        // then: 신사역 - 판교역 - 광교역이 조회
+        // then: 까치산역 - 신촌역 - 잠실역이 조회
         // then: 23 + 5 = 28m의 길이가 조회
         List<Station> 노선에_등록된_역_목록 = sections.getAllStations();
 
         assertAll(
-                () -> assertThat(노선에_등록된_역_목록).containsExactly(신사역, 판교역, 광교역),
+                () -> assertThat(노선에_등록된_역_목록).containsExactly(까치산역, 신촌역, 잠실역),
                 () -> assertThat(sections.getTotalDistance()).isEqualTo(28)
         );
     }
@@ -65,16 +57,16 @@ class LineTest {
     @Test
     @DisplayName("지하철 노선의 상행 종점역과 하행 종점역 사이에 구간을 추가한다.")
     void addMiddleLineSection() {
-        // when: 신사역 - 판교역 노선에 신사역 - 강남역 노선을 추가
-        Section 신사역_강남역_노선 = new Section(신사역, 강남역, 15);
-        sections.addSection(신사역_강남역_노선);
+        // when: 까치산역 - 신촌역 노선에 까치산역 - 신도림역 노선을 추가
+        Section 까치산역_신도림역_노선 = new Section(까치산역, 신도림역, 15);
+        sections.addSection(까치산역_신도림역_노선);
 
-        // then: 신사역 - 강남역 - 판교역이 조회
+        // then: 까치산역 - 신도림역 - 신촌역이 조회
         // then: 23m 길이가 조회
         List<Station> 노선에_등록된_역_목록 = sections.getAllStations();
 
         assertAll(
-                () -> assertThat(노선에_등록된_역_목록).containsExactly(신사역, 강남역, 판교역),
+                () -> assertThat(노선에_등록된_역_목록).containsExactly(까치산역, 신도림역, 신촌역),
                 () -> assertThat(sections.getTotalDistance()).isEqualTo(23)
         );
     }
@@ -82,16 +74,16 @@ class LineTest {
     @Test
     @DisplayName("지하철 노선의 상행 종점역이 하행역인 구간을 추가한다.")
     void addFirstLineSection() {
-        // when: 신사역 - 판교역 노선에 강남역 - 신사역 노선을 추가
-        Section 강남역_신사역_노선 = new Section(강남역, 신사역, 15);
-        sections.addSection(강남역_신사역_노선);
+        // when: 까치산역 - 신촌역 노선에 신도림역 - 까치산역 노선을 추가
+        Section 신도림역_까치산역_노선 = new Section(신도림역, 까치산역, 15);
+        sections.addSection(신도림역_까치산역_노선);
 
-        // then:  강남역 - 신사역 - 판교역이 조회
+        // then:  신도림역 - 까치산역 - 신촌역이 조회
         // then: 15 + 23 = 38m 길이가 조회
         List<Station> 노선에_등록된_역_목록 = sections.getAllStations();
 
         assertAll(
-                () -> assertThat(노선에_등록된_역_목록).containsExactly(강남역, 신사역, 판교역),
+                () -> assertThat(노선에_등록된_역_목록).containsExactly(신도림역, 까치산역, 신촌역),
                 () -> assertThat(sections.getTotalDistance()).isEqualTo(38)
         );
     }
@@ -99,11 +91,11 @@ class LineTest {
     @Test
     @DisplayName("역 사이에 기존 역 사이 길이보다 크거나 같은 노선을 등록한다.")
     void addInvalidDistanceLineSection() {
-        // when: 신사역 - 판교역 노선(23m)에 신사역 - 강남역 노선(23m)을 추가한다.
-        Section 신사역_강남역_노선 = new Section(신사역, 강남역, 23);
+        // when: 까치산역 - 신촌역 노선(23m)에 까치산역 - 신도림역 노선(23m)을 추가한다.
+        Section 까치산역_신도림역_노선 = new Section(까치산역, 신도림역, 23);
 
         // when & then
-        assertThatThrownBy(() -> sections.addSection(신사역_강남역_노선))
+        assertThatThrownBy(() -> sections.addSection(까치산역_신도림역_노선))
                 .isInstanceOf(InvalidLineSectionException.class)
                 .hasMessageContaining(ErrorCode.INVALID_DISTANCE.getMessage());
     }
@@ -111,11 +103,11 @@ class LineTest {
     @Test
     @DisplayName("이미 등록되어 있는 노선을 등록한다.")
     void addAlreadyRegisteredLineSection() {
-        // when: 신사역 - 판교역 노선에 동일한 노선인 신사역 - 판교역 노선을 추가한다.
-        Section 신사역_판교역_노선 = new Section(신사역, 판교역, 23);
+        // when: 까치산역 - 신촌역 노선에 동일한 노선인 까치산역 - 신촌역 노선을 추가한다.
+        Section 까치산역_신촌역_노선 = new Section(까치산역, 신촌역, 23);
 
         // when & then
-        assertThatThrownBy(() -> sections.addSection(신사역_판교역_노선))
+        assertThatThrownBy(() -> sections.addSection(까치산역_신촌역_노선))
                 .isInstanceOf(InvalidLineSectionException.class)
                 .hasMessageContaining(ErrorCode.ALREADY_REGISTERED_SECTION.getMessage());
     }
@@ -123,11 +115,11 @@ class LineTest {
     @Test
     @DisplayName("상행역과 하행역 둘 중 하나도 포함되어있지 않은 노선을 등록한다.")
     void addLineSectionWithUnregisteredStation() {
-        // when: 신사역 - 판교역 노선에 강남역 - 광교역 노선을 추가한다.
-        Section 강남역_광교역_노선 = new Section(강남역, 광교역, 13);
+        // when: 까치산역 - 신촌역 노선에 신도림역 - 잠실역 노선을 추가한다.
+        Section 신도림역_잠실역_노선 = new Section(신도림역, 잠실역, 13);
 
         // when &  then
-        assertThatThrownBy(() -> sections.addSection(강남역_광교역_노선))
+        assertThatThrownBy(() -> sections.addSection(신도림역_잠실역_노선))
                 .isInstanceOf(InvalidLineSectionException.class)
                 .hasMessageContaining(ErrorCode.UNREGISTERED_STATION.getMessage());
     }
@@ -139,24 +131,24 @@ class LineTest {
         List<Station> 노선에_등록된_역_목록 = sections.getAllStations();
 
         // then
-        assertThat(노선에_등록된_역_목록).containsExactly(신사역, 판교역);
+        assertThat(노선에_등록된_역_목록).containsExactly(까치산역, 신촌역);
     }
 
     @Test
     @DisplayName("지하철 노선의 첫번째 구간을 삭제한다.")
     void removeFirstSection() {
         // given
-        Section 판교역_광교역_구간 = new Section(판교역, 광교역, 5);
-        sections.addSection(판교역_광교역_구간);
+        Section 신촌역_잠실역_구간 = new Section(신촌역, 잠실역, 5);
+        sections.addSection(신촌역_잠실역_구간);
 
         // when
-        sections.deleteSectionByStationId(신사역.getId());
+        sections.deleteSectionByStationId(까치산역.getId());
 
         // then
         List<Station> 노선에_등록된_역_목록 = sections.getAllStations();
 
         assertAll(
-                () -> assertThat(노선에_등록된_역_목록).doesNotContain(신사역),
+                () -> assertThat(노선에_등록된_역_목록).doesNotContain(까치산역),
                 () -> assertThat(sections.getTotalDistance()).isEqualTo(5)
         );
     }
@@ -165,17 +157,17 @@ class LineTest {
     @DisplayName("지하철 노선의 중간 구간을 삭제한다.")
     void removeMiddleSection() {
         // given
-        Section 판교역_광교역_구간 = new Section(판교역, 광교역, 5);
-        sections.addSection(판교역_광교역_구간);
+        Section 신촌역_잠실역_구간 = new Section(신촌역, 잠실역, 5);
+        sections.addSection(신촌역_잠실역_구간);
 
         // when
-        sections.deleteSectionByStationId(판교역.getId());
+        sections.deleteSectionByStationId(신촌역.getId());
 
         // then
         List<Station> 노선에_등록된_역_목록 = sections.getAllStations();
 
         assertAll(
-                () -> assertThat(노선에_등록된_역_목록).doesNotContain(판교역),
+                () -> assertThat(노선에_등록된_역_목록).doesNotContain(신촌역),
                 () -> assertThat(sections.getTotalDistance()).isEqualTo(28)
         );
     }
@@ -184,17 +176,17 @@ class LineTest {
     @DisplayName("지하철의 노선의 마지막 구간을 삭제한다.")
     void removeSection() {
         // given
-        Section 판교역_광교역_구간 = new Section(판교역, 광교역, 5);
-        sections.addSection(판교역_광교역_구간);
+        Section 신촌역_잠실역_구간 = new Section(신촌역, 잠실역, 5);
+        sections.addSection(신촌역_잠실역_구간);
 
         // when
-        sections.deleteSectionByStationId(광교역.getId());
+        sections.deleteSectionByStationId(잠실역.getId());
 
         // then
         List<Station> 노선에_등록된_역_목록 = sections.getAllStations();
 
         assertAll(
-                () -> assertThat(노선에_등록된_역_목록).doesNotContain(광교역),
+                () -> assertThat(노선에_등록된_역_목록).doesNotContain(잠실역),
                 () -> assertThat(sections.getTotalDistance()).isEqualTo(23)
         );
     }
@@ -203,7 +195,7 @@ class LineTest {
     @DisplayName("등록되어 있지 않은 구간을 삭제한다.")
     void removeNotExistSection() {
         // when & then
-        assertThatThrownBy(() -> sections.deleteSectionByStationId(강남역.getId()))
+        assertThatThrownBy(() -> sections.deleteSectionByStationId(신도림역.getId()))
                 .isInstanceOf(InvalidLineSectionException.class)
                 .hasMessageContaining(ErrorCode.UNREGISTERED_STATION.getMessage());
     }
@@ -212,7 +204,7 @@ class LineTest {
     @DisplayName("구간이 1개일 때 삭제한다.")
     void removeStandaloneSection() {
         // when & then
-        assertThatThrownBy((() -> sections.deleteSectionByStationId(판교역.getId())))
+        assertThatThrownBy((() -> sections.deleteSectionByStationId(신촌역.getId())))
                 .isInstanceOf(InvalidLineSectionException.class)
                 .hasMessageContaining(ErrorCode.STAND_ALONE_LINE_SECTION.getMessage());
     }

--- a/src/test/java/nextstep/subway/unit/line/LineServiceMockTest.java
+++ b/src/test/java/nextstep/subway/unit/line/LineServiceMockTest.java
@@ -1,4 +1,4 @@
-package nextstep.subway.unit;
+package nextstep.subway.unit.line;
 
 import nextstep.subway.fixture.StationFixture;
 import nextstep.subway.global.error.code.ErrorCode;
@@ -57,7 +57,7 @@ public class LineServiceMockTest {
         lineService = new LineService(stationJpaAdapter, lineJpaAdapter);
 
         // given
-        this.이호선 = Line.builder()
+        이호선 = Line.builder()
                 .name("2호선")
                 .color("#52c41a")
                 .upStation(StationFixture.까치산역)

--- a/src/test/java/nextstep/subway/unit/line/LineServiceTest.java
+++ b/src/test/java/nextstep/subway/unit/line/LineServiceTest.java
@@ -1,4 +1,4 @@
-package nextstep.subway.unit;
+package nextstep.subway.unit.line;
 
 import nextstep.subway.global.error.code.ErrorCode;
 import nextstep.subway.global.error.exception.InvalidLineSectionException;

--- a/src/test/java/nextstep/subway/unit/line/LineTest.java
+++ b/src/test/java/nextstep/subway/unit/line/LineTest.java
@@ -1,4 +1,4 @@
-package nextstep.subway.unit;
+package nextstep.subway.unit.line;
 
 import nextstep.subway.fixture.StationFixture;
 import nextstep.subway.global.error.code.ErrorCode;

--- a/src/test/java/nextstep/subway/unit/path/PathServiceMockTest.java
+++ b/src/test/java/nextstep/subway/unit/path/PathServiceMockTest.java
@@ -1,0 +1,197 @@
+package nextstep.subway.unit.path;
+
+import nextstep.subway.fixture.StationFixture;
+import nextstep.subway.global.error.code.ErrorCode;
+import nextstep.subway.global.error.exception.InvalidPathException;
+import nextstep.subway.global.error.exception.NotEntityFoundException;
+import nextstep.subway.line.adapters.persistence.LineJpaAdapter;
+import nextstep.subway.line.entity.Line;
+import nextstep.subway.line.repository.LineRepository;
+import nextstep.subway.path.dto.request.PathRequest;
+import nextstep.subway.path.dto.response.PathResponse;
+import nextstep.subway.path.service.PathService;
+import nextstep.subway.section.entity.Section;
+import nextstep.subway.station.adapters.persistence.StationJpaAdapter;
+import nextstep.subway.station.dto.response.StationResponse;
+import nextstep.subway.station.repository.StationRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.List;
+import java.util.Optional;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.junit.jupiter.api.Assertions.assertAll;
+import static org.mockito.BDDMockito.given;
+
+@ExtendWith(MockitoExtension.class)
+public class PathServiceMockTest {
+
+    @Mock
+    LineRepository lineRepository;
+
+    @Mock
+    StationRepository stationRepository;
+
+    private PathService pathService;
+
+    private static final Long 까치산역_아이디 = StationFixture.까치산역.getId();
+
+    private static final Long 신도림역_아이디 = StationFixture.신도림역.getId();
+
+    private static final Long 신촌역_아이디 = StationFixture.신촌역.getId();
+
+    private static final Long 잠실역_아이디 = StationFixture.잠실역.getId();
+
+    private Line 이호선;
+
+    /**
+     * <pre>
+     *            신촌역    -------------------   *2호선(19)*
+     *            |                               |
+     *            *2호선(6)*                      |
+     *            |                              |
+     * 까치산역    신도림역  --- *2호선(18)* --- 잠실역
+     * </pre>
+     */
+    @BeforeEach
+    void setUp() {
+        LineJpaAdapter lineJpaAdapter = new LineJpaAdapter(lineRepository);
+        StationJpaAdapter stationJpaAdapter = new StationJpaAdapter(stationRepository);
+        pathService = new PathService(stationJpaAdapter, lineJpaAdapter);
+
+        // given
+        이호선 = Line.builder()
+                .name("2호선")
+                .color("#52c41a")
+                .upStation(StationFixture.신도림역)
+                .downStation(StationFixture.신촌역)
+                .distance(6)
+                .build();
+
+        Section 신촌역_잠실역_구간 = Section.builder()
+                .upStation(StationFixture.신촌역)
+                .downStation(StationFixture.잠실역)
+                .distance(19)
+                .build();
+        Section 잠실역_신도림역_구간 = Section.builder()
+                .upStation(StationFixture.잠실역)
+                .downStation(StationFixture.신도림역)
+                .distance(18)
+                .build();
+
+        Stream.of(신촌역_잠실역_구간, 잠실역_신도림역_구간).forEach(이호선::addSection);
+    }
+
+    @Test
+    @DisplayName("최단 거리 경로를 조회한다.")
+    void getShortestDistance() {
+        // given
+        given(stationRepository.findById(신도림역_아이디)).willReturn(Optional.of(StationFixture.신도림역));
+        given(stationRepository.findById(잠실역_아이디)).willReturn(Optional.of(StationFixture.잠실역));
+        given(stationRepository.findAll()).willReturn(
+                List.of(StationFixture.까치산역, StationFixture.신도림역, StationFixture.신촌역, StationFixture.잠실역)
+        );
+        given(lineRepository.findAll()).willReturn(List.of(이호선));
+
+        PathRequest 출발역_신도림역_도착역_잠실역_요청 = PathRequest.builder()
+                .source(신도림역_아이디)
+                .target(잠실역_아이디)
+                .build();
+
+        // when
+        PathResponse 최단_거리_경로_조회_응답 = pathService.getShortestDistance(출발역_신도림역_도착역_잠실역_요청);
+
+        // then
+        List<Long> 최단_거리_경로에_존재하는_역_아이디_목록 = 최단_거리_경로_조회_응답.getStations()
+                .stream()
+                .map(StationResponse::getId)
+                .collect(Collectors.toList());
+
+        Integer 최단_거리 = 최단_거리_경로_조회_응답.getDistance();
+
+        assertAll(
+                () -> assertThat(최단_거리_경로에_존재하는_역_아이디_목록).containsExactly(신도림역_아이디, 잠실역_아이디),
+                () -> assertThat(최단_거리).isEqualTo(18)
+        );
+    }
+
+    @Test
+    @DisplayName("출발역과 도착역이 같은 경로를 조회한다.")
+    void getSameDepartureAndArrivalStations() {
+        // given
+        PathRequest 출발역_신촌역_도착역_신촌역_요청 = PathRequest.builder()
+                .source(신촌역_아이디)
+                .target(신촌역_아이디)
+                .build();
+
+        // when & then
+        assertThatThrownBy(() -> pathService.getShortestDistance(출발역_신촌역_도착역_신촌역_요청))
+                .isInstanceOf(InvalidPathException.class)
+                .hasMessageContaining(ErrorCode.SAME_DEPARTURE_AND_ARRIVAL_STATIONS.getMessage());
+    }
+
+    @Test
+    @DisplayName("출발역과 도착역이 연결이 되어 있지 않은 경우에 경로를 조회한다.")
+    void getUnlinkedDepartureAndArrivalStations() {
+        // given
+        given(stationRepository.findById(신촌역_아이디)).willReturn(Optional.of(StationFixture.신촌역));
+        given(stationRepository.findById(까치산역_아이디)).willReturn(Optional.of(StationFixture.까치산역));
+        given(stationRepository.findAll()).willReturn(
+                List.of(StationFixture.까치산역, StationFixture.신도림역, StationFixture.신촌역, StationFixture.잠실역)
+        );
+        given(lineRepository.findAll()).willReturn(List.of(이호선));
+
+        PathRequest 출발역_신촌역_도착역_까치산역_요청 = PathRequest.builder()
+                .source(신촌역_아이디)
+                .target(까치산역_아이디)
+                .build();
+
+        // when & then
+        assertThatThrownBy(() -> pathService.getShortestDistance(출발역_신촌역_도착역_까치산역_요청))
+                .isInstanceOf(InvalidPathException.class)
+                .hasMessageContaining(ErrorCode.UNLINKED_DEPARTURE_AND_ARRIVAL_STATIONS.getMessage());
+    }
+
+    @Test
+    @DisplayName("등록되어 있지 않은 역이 출발역인 최단 경로를 조회한다.")
+    void getShortestDistanceWhenNotExistDepartureStation() {
+        // given
+        given(stationRepository.findById(신도림역_아이디)).willReturn(Optional.empty());
+
+        PathRequest 출발역_신도림역_도착역_잠실역_요청 = PathRequest.builder()
+                .source(신도림역_아이디)
+                .target(잠실역_아이디)
+                .build();
+
+        // when & then
+        assertThatThrownBy(() -> pathService.getShortestDistance(출발역_신도림역_도착역_잠실역_요청))
+                .isInstanceOf(NotEntityFoundException.class)
+                .hasMessageContaining(ErrorCode.NOT_EXIST_STATION.getMessage());
+    }
+
+    @Test
+    @DisplayName("등록되어 있지 않은 역이 도착역인 최단 경로를 조회한다.")
+    void getShortestDistanceWhenNotExistArrivalStation() {
+        // given
+        given(stationRepository.findById(신촌역_아이디)).willReturn(Optional.of(StationFixture.신촌역));
+        given(stationRepository.findById(신도림역_아이디)).willReturn(Optional.empty());
+
+        PathRequest 출발역_신촌역_도착역_신도림역_요청 = PathRequest.builder()
+                .source(신촌역_아이디)
+                .target(신도림역_아이디)
+                .build();
+
+        // when & then
+        assertThatThrownBy(() -> pathService.getShortestDistance(출발역_신촌역_도착역_신도림역_요청))
+                .isInstanceOf(NotEntityFoundException.class)
+                .hasMessageContaining(ErrorCode.NOT_EXIST_STATION.getMessage());
+    }
+}


### PR DESCRIPTION
안녕하세요!
개인적인 일이 생겨서 일주일 가까이 미션을 진행하지 못했었네요. 🥲
코드 리팩토링을 좀 많이 해서 변경사항이 좀 많습니다.
리뷰 부탁드립니다 🙏

# 2단계 코멘트에 따른 개선 사항
- [x] 공통으로 검증하는 부분(응답코드, 에러 메시지)에 대해 유틸성 메서드로 분리
- [x] 지하철 노선을 조회하는 부분을 assertAll 전에 먼저 호출하여 가독성 높임

# 기능 요구사항
### Request
- source: 출발역 id
- target: 도착역 id

```
HTTP/1.1 200 
Request method:	GET
Request URI:	http://localhost:55494/paths?source=1&target=3
Headers: 	Accept=application/json
		Content-Type=application/json; charset=UTF-8
```

### Response
- stations: 출발역으로부터 도착역까지의 경로에 있는 역 목록
- distance: 조회한 경로 구간의 거리

```
HTTP/1.1 200 
Content-Type: application/json
Transfer-Encoding: chunked
Date: Sat, 09 May 2020 14:54:11 GMT
Keep-Alive: timeout=60
Connection: keep-alive

{
    "stations": [
        {
            "id": 1,
            "name": "교대역"
        },
        {
            "id": 4,
            "name": "남부터미널역"
        },
        {
            "id": 3,
            "name": "양재역"
        }
    ],
    "distance": 5
}
```

# 요구사항 설명

- [x] 구간 삭제에 대한 제약 사항 변경 구현
  - [x] 기존에는 마지막 역 삭제만 가능했는데 위치에 상관 없이 삭제가 가능하도록 수정
  - [x] 종점이 제거될 경우 다음으로 오던 역이 종점이 됨
  - [x] 중간역이 제거될 경우 재배치를 함
    - [x] 노선에 A - B - C 역이 연결되어 있을 때 B역을 제거할 경우 A - C로 재배치 됨
    - [x] 거리는 두 구간의 거리의 합으로 정함

## 예외케이스
- [x] 출발역과 도착역이 같은 경우 최단 경로를 조회할 수 없음
- [x] 출발역과 도착역이 연결이 되어 있지 않은 경우 최단 경로를 조회할 수 없음
- [x] 존재하지 않은 출발역이나 도착역을 조회 할 경우 최단 경로를 조회할 수 없음