### PR TITLE
🚀 1단계 - 구간 추가 요구사항 반영

### DIFF
--- a/src/main/java/nextstep/subway/applicaion/LineService.java
+++ b/src/main/java/nextstep/subway/applicaion/LineService.java
@@ -7,10 +7,12 @@ import nextstep.subway.applicaion.dto.LineRequest;
 import nextstep.subway.applicaion.dto.LineResponse;
 import nextstep.subway.applicaion.dto.SectionRequest;
 import nextstep.subway.applicaion.dto.StationResponse;
+import nextstep.subway.applicaion.exception.BadRequestException;
 import nextstep.subway.domain.Line;
 import nextstep.subway.domain.LineRepository;
 import nextstep.subway.domain.Section;
 import nextstep.subway.domain.Station;
+import nextstep.subway.domain.exception.LineException;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -46,12 +48,12 @@ public class LineService {
 
     public LineResponse findById(Long id) {
         return createLineResponse(
-            lineRepository.findById(id).orElseThrow(IllegalArgumentException::new));
+            lineRepository.findById(id).orElseThrow(() -> new BadRequestException(BadRequestException.LINE_NOT_FOUND)));
     }
 
     @Transactional
     public void updateLine(Long id, LineRequest lineRequest) {
-        Line line = lineRepository.findById(id).orElseThrow(IllegalArgumentException::new);
+        Line line = lineRepository.findById(id).orElseThrow(() -> new BadRequestException(BadRequestException.LINE_NOT_FOUND));
 
         if (lineRequest.getName() != null) {
             line.setName(lineRequest.getName());
@@ -70,7 +72,7 @@ public class LineService {
     public void addSection(Long lineId, SectionRequest sectionRequest) {
         Station upStation = stationService.findById(sectionRequest.getUpStationId());
         Station downStation = stationService.findById(sectionRequest.getDownStationId());
-        Line line = lineRepository.findById(lineId).orElseThrow(IllegalArgumentException::new);
+        Line line = lineRepository.findById(lineId).orElseThrow(() -> new BadRequestException(BadRequestException.LINE_NOT_FOUND));
 
         line.addSection(upStation, downStation, sectionRequest.getDistance());
     }
@@ -102,7 +104,7 @@ public class LineService {
 
     @Transactional
     public void deleteSection(Long lineId, Long stationId) {
-        Line line = lineRepository.findById(lineId).orElseThrow(IllegalArgumentException::new);
+        Line line = lineRepository.findById(lineId).orElseThrow(() -> new BadRequestException(BadRequestException.LINE_NOT_FOUND));
         Station station = stationService.findById(stationId);
 
         if (!line.getSections().get(line.getSections().size() - 1).getDownStation()
@@ -111,9 +113,5 @@ public class LineService {
         }
 
         line.removeSection(line.getSections().size() - 1);
-    }
-
-    public Line findLineById(Long id) {
-        return lineRepository.findById(id).orElseThrow(IllegalArgumentException::new);
     }
 }

--- a/src/main/java/nextstep/subway/applicaion/LineService.java
+++ b/src/main/java/nextstep/subway/applicaion/LineService.java
@@ -33,7 +33,7 @@ public class LineService {
             && request.getDistance() != 0) {
             Station upStation = stationService.findById(request.getUpStationId());
             Station downStation = stationService.findById(request.getDownStationId());
-            line.addSection(new Section(line, upStation, downStation, request.getDistance()));
+            line.addSection(upStation, downStation, request.getDistance());
         }
         return createLineResponse(line);
     }
@@ -72,7 +72,7 @@ public class LineService {
         Station downStation = stationService.findById(sectionRequest.getDownStationId());
         Line line = lineRepository.findById(lineId).orElseThrow(IllegalArgumentException::new);
 
-        line.addSection(new Section(line, upStation, downStation, sectionRequest.getDistance()));
+        line.addSection(upStation, downStation, sectionRequest.getDistance());
     }
 
     private LineResponse createLineResponse(Line line) {

--- a/src/main/java/nextstep/subway/applicaion/LineService.java
+++ b/src/main/java/nextstep/subway/applicaion/LineService.java
@@ -18,8 +18,8 @@ import org.springframework.transaction.annotation.Transactional;
 @Transactional(readOnly = true)
 public class LineService {
 
-    private LineRepository lineRepository;
-    private StationService stationService;
+    private final LineRepository lineRepository;
+    private final StationService stationService;
 
     public LineService(LineRepository lineRepository, StationService stationService) {
         this.lineRepository = lineRepository;

--- a/src/main/java/nextstep/subway/applicaion/LineService.java
+++ b/src/main/java/nextstep/subway/applicaion/LineService.java
@@ -1,5 +1,8 @@
 package nextstep.subway.applicaion;
 
+import java.util.Collections;
+import java.util.List;
+import java.util.stream.Collectors;
 import nextstep.subway.applicaion.dto.LineRequest;
 import nextstep.subway.applicaion.dto.LineResponse;
 import nextstep.subway.applicaion.dto.SectionRequest;
@@ -11,13 +14,10 @@ import nextstep.subway.domain.Station;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
-import java.util.Collections;
-import java.util.List;
-import java.util.stream.Collectors;
-
 @Service
 @Transactional(readOnly = true)
 public class LineService {
+
     private LineRepository lineRepository;
     private StationService stationService;
 
@@ -29,22 +29,24 @@ public class LineService {
     @Transactional
     public LineResponse saveLine(LineRequest request) {
         Line line = lineRepository.save(new Line(request.getName(), request.getColor()));
-        if (request.getUpStationId() != null && request.getDownStationId() != null && request.getDistance() != 0) {
+        if (request.getUpStationId() != null && request.getDownStationId() != null
+            && request.getDistance() != 0) {
             Station upStation = stationService.findById(request.getUpStationId());
             Station downStation = stationService.findById(request.getDownStationId());
-            line.getSections().add(new Section(line, upStation, downStation, request.getDistance()));
+            line.addSection(new Section(line, upStation, downStation, request.getDistance()));
         }
         return createLineResponse(line);
     }
 
     public List<LineResponse> showLines() {
         return lineRepository.findAll().stream()
-                .map(this::createLineResponse)
-                .collect(Collectors.toList());
+            .map(this::createLineResponse)
+            .collect(Collectors.toList());
     }
 
     public LineResponse findById(Long id) {
-        return createLineResponse(lineRepository.findById(id).orElseThrow(IllegalArgumentException::new));
+        return createLineResponse(
+            lineRepository.findById(id).orElseThrow(IllegalArgumentException::new));
     }
 
     @Transactional
@@ -70,15 +72,15 @@ public class LineService {
         Station downStation = stationService.findById(sectionRequest.getDownStationId());
         Line line = lineRepository.findById(lineId).orElseThrow(IllegalArgumentException::new);
 
-        line.getSections().add(new Section(line, upStation, downStation, sectionRequest.getDistance()));
+        line.addSection(new Section(line, upStation, downStation, sectionRequest.getDistance()));
     }
 
     private LineResponse createLineResponse(Line line) {
         return new LineResponse(
-                line.getId(),
-                line.getName(),
-                line.getColor(),
-                createStationResponses(line)
+            line.getId(),
+            line.getName(),
+            line.getColor(),
+            createStationResponses(line)
         );
     }
 
@@ -88,14 +90,14 @@ public class LineService {
         }
 
         List<Station> stations = line.getSections().stream()
-                .map(Section::getDownStation)
-                .collect(Collectors.toList());
+            .map(Section::getDownStation)
+            .collect(Collectors.toList());
 
         stations.add(0, line.getSections().get(0).getUpStation());
 
         return stations.stream()
-                .map(it -> stationService.createStationResponse(it))
-                .collect(Collectors.toList());
+            .map(it -> stationService.createStationResponse(it))
+            .collect(Collectors.toList());
     }
 
     @Transactional
@@ -103,11 +105,12 @@ public class LineService {
         Line line = lineRepository.findById(lineId).orElseThrow(IllegalArgumentException::new);
         Station station = stationService.findById(stationId);
 
-        if (!line.getSections().get(line.getSections().size() - 1).getDownStation().equals(station)) {
+        if (!line.getSections().get(line.getSections().size() - 1).getDownStation()
+            .equals(station)) {
             throw new IllegalArgumentException();
         }
 
-        line.getSections().remove(line.getSections().size() - 1);
+        line.removeSection(line.getSections().size() - 1);
     }
 
     public Line findLineById(Long id) {

--- a/src/main/java/nextstep/subway/applicaion/StationService.java
+++ b/src/main/java/nextstep/subway/applicaion/StationService.java
@@ -13,7 +13,7 @@ import java.util.stream.Collectors;
 @Service
 @Transactional(readOnly = true)
 public class StationService {
-    private StationRepository stationRepository;
+    private final StationRepository stationRepository;
 
     public StationService(StationRepository stationRepository) {
         this.stationRepository = stationRepository;

--- a/src/main/java/nextstep/subway/applicaion/StationService.java
+++ b/src/main/java/nextstep/subway/applicaion/StationService.java
@@ -2,6 +2,7 @@ package nextstep.subway.applicaion;
 
 import nextstep.subway.applicaion.dto.StationRequest;
 import nextstep.subway.applicaion.dto.StationResponse;
+import nextstep.subway.applicaion.exception.BadRequestException;
 import nextstep.subway.domain.Station;
 import nextstep.subway.domain.StationRepository;
 import org.springframework.stereotype.Service;
@@ -44,6 +45,6 @@ public class StationService {
     }
 
     public Station findById(Long id) {
-        return stationRepository.findById(id).orElseThrow(IllegalArgumentException::new);
+        return stationRepository.findById(id).orElseThrow(() -> new BadRequestException(BadRequestException.STATION_NOT_FOUND));
     }
 }

--- a/src/main/java/nextstep/subway/applicaion/exception/ApplicationException.java
+++ b/src/main/java/nextstep/subway/applicaion/exception/ApplicationException.java
@@ -1,0 +1,17 @@
+package nextstep.subway.applicaion.exception;
+
+import org.springframework.http.HttpStatus;
+
+public class ApplicationException extends RuntimeException {
+
+    private final HttpStatus status;
+
+    public ApplicationException(HttpStatus status, String message) {
+        super(message);
+        this.status = status;
+    }
+
+    public HttpStatus getStatus() {
+        return status;
+    }
+}

--- a/src/main/java/nextstep/subway/applicaion/exception/BadRequestException.java
+++ b/src/main/java/nextstep/subway/applicaion/exception/BadRequestException.java
@@ -1,0 +1,15 @@
+package nextstep.subway.applicaion.exception;
+
+
+import org.springframework.http.HttpStatus;
+
+public class BadRequestException extends ApplicationException {
+
+    public final static String MESSAGE = "잘못된 요청입니다.";
+    public final static String STATION_NOT_FOUND = "존재하지 않는 역입니다.";
+    public final static String LINE_NOT_FOUND = "존재하지 않는 노선입니다.";
+
+    public BadRequestException(String message) {
+        super(HttpStatus.BAD_REQUEST, message);
+    }
+}

--- a/src/main/java/nextstep/subway/applicaion/exception/InternalServerException.java
+++ b/src/main/java/nextstep/subway/applicaion/exception/InternalServerException.java
@@ -1,0 +1,9 @@
+package nextstep.subway.applicaion.exception;
+
+import org.springframework.http.HttpStatus;
+
+public class InternalServerException extends ApplicationException {
+    public InternalServerException(String message) {
+        super(HttpStatus.INTERNAL_SERVER_ERROR, message);
+    }
+}

--- a/src/main/java/nextstep/subway/domain/Line.java
+++ b/src/main/java/nextstep/subway/domain/Line.java
@@ -1,9 +1,11 @@
 package nextstep.subway.domain;
 
 import java.util.ArrayList;
+import java.util.Comparator;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
+import java.util.stream.Collectors;
 import javax.persistence.CascadeType;
 import javax.persistence.Entity;
 import javax.persistence.GeneratedValue;
@@ -63,10 +65,12 @@ public class Line {
     }
 
     public List<Section> getSections() {
-        return sections;
+        return sections.stream().sorted(Comparator.comparing(Section::getOrderNo)).collect(
+            Collectors.toList());
     }
 
     public void addSection(Section section) {
+        // 모든 구간을 돌면서 하행선인지를 판단하여 있으면 넣고 없으면 에러를 띄워야한다.
         this.sections.add(section);
     }
 
@@ -81,5 +85,9 @@ public class Line {
 
     public void removeSection(Section section) {
         this.sections.remove(section);
+    }
+
+    public void removeSection(int index) {
+        this.sections.remove(index);
     }
 }

--- a/src/main/java/nextstep/subway/domain/Line.java
+++ b/src/main/java/nextstep/subway/domain/Line.java
@@ -69,9 +69,9 @@ public class Line {
             Collectors.toList());
     }
 
-    public void addSection(Section section) {
+    public void addSection(Station upStation, Station downStation, int distance) {
         // 모든 구간을 돌면서 하행선인지를 판단하여 있으면 넣고 없으면 에러를 띄워야한다.
-        this.sections.add(section);
+        this.sections.add(new Section(this, upStation, downStation, distance));
     }
 
     public Set<Station> getStations() {
@@ -90,4 +90,5 @@ public class Line {
     public void removeSection(int index) {
         this.sections.remove(index);
     }
+
 }

--- a/src/main/java/nextstep/subway/domain/Line.java
+++ b/src/main/java/nextstep/subway/domain/Line.java
@@ -1,17 +1,18 @@
 package nextstep.subway.domain;
 
 import java.util.ArrayList;
-import java.util.Comparator;
 import java.util.HashSet;
+import java.util.LinkedList;
 import java.util.List;
+import java.util.Optional;
 import java.util.Set;
-import java.util.stream.Collectors;
 import javax.persistence.CascadeType;
 import javax.persistence.Entity;
 import javax.persistence.GeneratedValue;
 import javax.persistence.GenerationType;
 import javax.persistence.Id;
 import javax.persistence.OneToMany;
+import nextstep.subway.domain.exception.LineException;
 
 @Entity
 public class Line {
@@ -65,71 +66,118 @@ public class Line {
     }
 
     public List<Section> getSections() {
-        return sections.stream().sorted(Comparator.comparing(Section::getOrderNo))
-            .collect(Collectors.toList());
+        if (sections.isEmpty()) {
+            return new ArrayList<>();
+        }
+        List<Section> result = new LinkedList<>();
+        Optional<Section> headSection = getHeadSection();
+        if (headSection.isEmpty()) {
+            return result;
+        }
+        result.add(headSection.get());
+        Section _headSection = getHeadSection().get();
+        while (!_headSection.isTail()) {
+            Station downStation = _headSection.getDownStation();
+            Section nextSection = searchSection(sections, downStation).orElseThrow(
+                () -> new LineException(LineException.NOT_EXIST_SECTION));
+            result.add(nextSection);
+            _headSection = nextSection;
+        }
+        return result;
+    }
+
+    private Optional<Section> searchSection(List<Section> sections, Station downStation) {
+        return sections.stream()
+            .filter(section -> section.getUpStation().equals(downStation))
+            .findFirst();
+    }
+
+    private Optional<Section> getHeadSection() {
+        return this.sections.stream().filter(Section::isHead).findFirst();
     }
 
     public void addSection(Station upStation, Station downStation, int distance) {
-        // 중간에 끼워 넣는 경우, 맨 끝에 넣는 경우
         if (sections.isEmpty()) {
-            Section newSection = Section.createFirstSection(this, upStation, downStation, distance);
-            this.sections.add(newSection);
+            sections.add(Section.createHeadAndTailSection(this, upStation, downStation, distance));
             return;
         }
-        Section tempSection = Section.createTempSection(this, upStation, downStation, distance);
-        if (isLastSectionAndNewSectionConnectionValid(tempSection)) {
-            addTailSection(tempSection);
+        Section headSection = getHeadSection().orElseThrow(
+            () -> new LineException(LineException.NOT_EXIST_SECTION));
+        Section tailSection = getTailSection();
+        if (tailSection.isSameDownStation(upStation)) {
+            addTail(upStation, downStation, distance, tailSection);
             return;
         }
-        addMiddleSection(tempSection);
-    }
-
-    private void addTailSection(Section tempSection) {
-        Section newSection = new Section(this, tempSection.getUpStation(),
-            tempSection.getDownStation(), tempSection.getDistance(),
-            getLastSection().getOrderNo() + 1);
-        this.sections.add(newSection);
-    }
-
-    private boolean isLastSectionAndNewSectionConnectionValid(Section tempSection) {
-        // 마지막 지하철 구간의 하행역과 추가할 구간의 상행역이 같고, 추가할 구간의 하행역이 없을 때
-        if (getLastSection().getDownStation().equals(tempSection.getUpStation())
-            && getSections().stream().noneMatch(section ->
-            section.getDownStation().equals(tempSection.getDownStation()))) {
-            return true;
+        if (headSection.isSameUpStation(downStation)) {
+            addHead(upStation, downStation, distance, headSection);
+            return;
         }
-        return false;
-    }
-
-    private void addMiddleSection(Section tempSection) {
-        Section foundSection = getSections().stream()
-            .filter(section -> section.getUpStation().equals(tempSection.getUpStation()))
+        if (isNotExistsUpStationInSections(upStation)) {
+            throw new LineException(LineException.NOT_ADDABLE_SECTION);
+        }
+        sections.stream().filter(section -> section.getUpStation().equals(upStation))
             .findFirst()
-            .orElseThrow(IllegalArgumentException::new);
-        validateMiddleSectionAndNewSectionConnectionValid(tempSection);
-        foundSection.changeUpStation(tempSection.getDownStation());
-        // 거리는 기존 FoundSection 거리 - 새로운 Section 거리의 나머지
-        foundSection.changeDistance(foundSection.getDistance() - tempSection.getDistance());
-        Section newSection = Section.createMiddleSection(this, tempSection.getUpStation(),
-            tempSection.getDownStation(), tempSection.getDistance(), foundSection.getOrderNo());
-        this.sections.add(foundSection.getOrderNo() - 1, newSection);
-        for (int i = foundSection.getOrderNo(); i < getSections().size(); i++) {
-            getSections().get(i).changeOrderNo(getSections().get(i).getOrderNo() + 1);
-        }
+            .ifPresent(section -> {
+                addMiddle(section, upStation, downStation, distance);
+            });
     }
 
-    private void validateMiddleSectionAndNewSectionConnectionValid(Section tempSection) {
-        // 같은 하행역이 하나도 없는지 확인
+    private void addTail(Station upStation, Station downStation, int distance,
+        Section tailSection) {
+        validateSameDownStationNotExists(downStation);
+        tailSection.changeTail(false);
+        sections.add(Section.createTailSection(this, upStation, downStation, distance));
+    }
+
+    private void addHead(Station upStation, Station downStation, int distance,
+        Section headSection) {
+        validateSameUpStationNotExists(upStation);
+        headSection.changeHead(false);
+        sections.add(Section.createHeadSection(this, upStation, downStation, distance));
+    }
+    
+    private boolean isNotExistsUpStationInSections(Station upStation) {
+        return sections.stream().noneMatch(section -> section.getUpStation().equals(upStation));
+    }
+
+    private void addMiddle(Section targetSection, Station upStation, Station downStation,
+        int distance) {
+        validateSameDownStationNotExists(downStation);
+        if (targetSection.isHead()) {
+            targetSection.changeHead(false);
+            addMiddleToSections(targetSection, downStation, distance,
+                Section.createHeadSection(this, upStation, downStation, distance));
+            return;
+        }
+        addMiddleToSections(targetSection, downStation, distance,
+            new Section(this, upStation, downStation, distance, false, false));
+    }
+
+    private void addMiddleToSections(Section targetSection, Station downStation, int distance,
+        Section upStation) {
+        targetSection.changeUpStation(downStation);
+        targetSection.changeDistance(targetSection.getDistance() - distance);
+        sections.add(sections.indexOf(targetSection),
+            upStation);
+    }
+
+    private void validateSameUpStationNotExists(Station upStation) {
         if (getSections().stream()
-            .anyMatch(section -> section.getDownStation().equals(tempSection.getDownStation()))) {
-            throw new IllegalArgumentException();
+            .anyMatch(section -> section.getUpStation().equals(upStation))) {
+            throw new LineException(LineException.ALREADY_REGISTERED_STATION_EXCEPTION);
         }
     }
 
-    // 맨 끝에 넣는 경우
+    private void validateSameDownStationNotExists(Station downStation) {
+        if (getSections().stream()
+            .anyMatch(section -> section.getDownStation().equals(downStation))) {
+            throw new LineException(LineException.ALREADY_REGISTERED_STATION_EXCEPTION);
+        }
+    }
 
-    private Section getLastSection() {
-        return getSections().get(getSections().size() - 1);
+    private Section getTailSection() {
+        return this.sections.stream().filter(Section::isTail).findFirst()
+            .orElseThrow(() -> new LineException(LineException.NOT_EXIST_SECTION));
     }
 
     public Set<Station> getStations() {
@@ -141,12 +189,11 @@ public class Line {
         return stations;
     }
 
-    public void removeSection(Section section) {
-        this.sections.remove(section);
-    }
-
     public void removeSection(int index) {
         this.sections.remove(index);
+        if (sections.size() == 1) {
+            sections.get(0).changeTail(true);
+        }
     }
 
 }

--- a/src/main/java/nextstep/subway/domain/Section.java
+++ b/src/main/java/nextstep/subway/domain/Section.java
@@ -16,8 +16,8 @@ public class Section {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
-    @Column
-    private int orderNo;
+    @Column(nullable = false)
+    private Integer orderNo;
 
     @ManyToOne(cascade = CascadeType.PERSIST)
     @JoinColumn(name = "line_id")
@@ -37,11 +37,18 @@ public class Section {
 
     }
 
-    public Section(Line line, Station upStation, Station downStation, int distance) {
+    public Section(Line line, Station upStation, Station downStation, int distance,
+        Integer orderNo) {
         this.line = line;
         this.upStation = upStation;
         this.downStation = downStation;
         this.distance = distance;
+        this.orderNo = orderNo;
+    }
+
+    public static Section createMiddleSection(Line line, Station upStation, Station downStation,
+        int distance, int orderNo) {
+        return new Section(line, upStation, downStation, distance, orderNo);
     }
 
     public Long getId() {
@@ -66,5 +73,30 @@ public class Section {
 
     public int getOrderNo() {
         return orderNo;
+    }
+
+    public static Section createFirstSection(Line line, Station upStation, Station downStation,
+        int distance) {
+        return new Section(line, upStation, downStation, distance, 1);
+    }
+
+    public static Section createTempSection(Line line, Station upStation, Station downStation,
+        int distance) {
+        return new Section(line, upStation, downStation, distance, null);
+    }
+
+    public void changeUpStation(Station downStation) {
+        this.upStation = downStation;
+    }
+
+    public void changeOrderNo(int orderNo) {
+        this.orderNo = orderNo;
+    }
+
+    public void changeDistance(int distance) {
+        if (distance == 0) {
+            throw new IllegalArgumentException();
+        }
+        this.distance = distance;
     }
 }

--- a/src/main/java/nextstep/subway/domain/Section.java
+++ b/src/main/java/nextstep/subway/domain/Section.java
@@ -1,12 +1,23 @@
 package nextstep.subway.domain;
 
-import javax.persistence.*;
+import javax.persistence.CascadeType;
+import javax.persistence.Column;
+import javax.persistence.Entity;
+import javax.persistence.GeneratedValue;
+import javax.persistence.GenerationType;
+import javax.persistence.Id;
+import javax.persistence.JoinColumn;
+import javax.persistence.ManyToOne;
 
 @Entity
 public class Section {
+
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
+
+    @Column
+    private int orderNo;
 
     @ManyToOne(cascade = CascadeType.PERSIST)
     @JoinColumn(name = "line_id")
@@ -51,5 +62,9 @@ public class Section {
 
     public int getDistance() {
         return distance;
+    }
+
+    public int getOrderNo() {
+        return orderNo;
     }
 }

--- a/src/main/java/nextstep/subway/domain/Section.java
+++ b/src/main/java/nextstep/subway/domain/Section.java
@@ -8,6 +8,7 @@ import javax.persistence.GenerationType;
 import javax.persistence.Id;
 import javax.persistence.JoinColumn;
 import javax.persistence.ManyToOne;
+import nextstep.subway.domain.exception.SectionException;
 
 @Entity
 public class Section {
@@ -105,7 +106,7 @@ public class Section {
 
     public void changeDistance(int distance) {
         if (distance == 0) {
-            throw new IllegalArgumentException();
+            throw new SectionException(SectionException.INVALID_DISTANCE);
         }
         this.distance = distance;
     }

--- a/src/main/java/nextstep/subway/domain/Section.java
+++ b/src/main/java/nextstep/subway/domain/Section.java
@@ -105,7 +105,7 @@ public class Section {
     }
 
     public void changeDistance(int distance) {
-        if (distance == 0) {
+        if (distance <= 0) {
             throw new SectionException(SectionException.INVALID_DISTANCE);
         }
         this.distance = distance;

--- a/src/main/java/nextstep/subway/domain/Section.java
+++ b/src/main/java/nextstep/subway/domain/Section.java
@@ -1,7 +1,7 @@
 package nextstep.subway.domain;
 
+import java.util.Objects;
 import javax.persistence.CascadeType;
-import javax.persistence.Column;
 import javax.persistence.Entity;
 import javax.persistence.GeneratedValue;
 import javax.persistence.GenerationType;
@@ -16,8 +16,6 @@ public class Section {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
-    @Column(nullable = false)
-    private Integer orderNo;
 
     @ManyToOne(cascade = CascadeType.PERSIST)
     @JoinColumn(name = "line_id")
@@ -33,22 +31,44 @@ public class Section {
 
     private int distance;
 
+    private boolean head;
+
+    private boolean tail;
+
     public Section() {
 
     }
 
-    public Section(Line line, Station upStation, Station downStation, int distance,
-        Integer orderNo) {
+
+    public Section(Line line, Station upStation, Station downStation, int distance, boolean head,
+        boolean tail) {
         this.line = line;
         this.upStation = upStation;
         this.downStation = downStation;
         this.distance = distance;
-        this.orderNo = orderNo;
+        this.head = head;
+        this.tail = tail;
+    }
+
+    public static Section createHeadAndTailSection(Line line, Station upStation,
+        Station downStation,
+        int distance) {
+        return new Section(line, upStation, downStation, distance, true, true);
+    }
+
+    public static Section createHeadSection(Line line, Station upStation, Station downStation,
+        int distance) {
+        return new Section(line, upStation, downStation, distance, true, false);
+    }
+
+    public static Section createTailSection(Line line, Station upStation, Station downStation,
+        int distance) {
+        return new Section(line, upStation, downStation, distance, false, true);
     }
 
     public static Section createMiddleSection(Line line, Station upStation, Station downStation,
-        int distance, int orderNo) {
-        return new Section(line, upStation, downStation, distance, orderNo);
+        int distance) {
+        return new Section(line, upStation, downStation, distance, false, false);
     }
 
     public Long getId() {
@@ -71,26 +91,16 @@ public class Section {
         return distance;
     }
 
-    public int getOrderNo() {
-        return orderNo;
+    public boolean isHead() {
+        return head;
     }
 
-    public static Section createFirstSection(Line line, Station upStation, Station downStation,
-        int distance) {
-        return new Section(line, upStation, downStation, distance, 1);
-    }
-
-    public static Section createTempSection(Line line, Station upStation, Station downStation,
-        int distance) {
-        return new Section(line, upStation, downStation, distance, null);
+    public boolean isTail() {
+        return tail;
     }
 
     public void changeUpStation(Station downStation) {
         this.upStation = downStation;
-    }
-
-    public void changeOrderNo(int orderNo) {
-        this.orderNo = orderNo;
     }
 
     public void changeDistance(int distance) {
@@ -98,5 +108,41 @@ public class Section {
             throw new IllegalArgumentException();
         }
         this.distance = distance;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        Section section = (Section) o;
+        return distance == section.distance && head == section.head && tail == section.tail
+            && Objects.equals(id, section.id) && Objects.equals(line, section.line)
+            && Objects.equals(upStation, section.upStation) && Objects.equals(
+            downStation, section.downStation);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(id, line, upStation, downStation, distance, head, tail);
+    }
+
+    public void changeTail(boolean tail) {
+        this.tail = tail;
+    }
+
+    public void changeHead(boolean head) {
+        this.head = head;
+    }
+
+    public boolean isSameDownStation(Station station) {
+        return this.downStation.equals(station);
+    }
+
+    public boolean isSameUpStation(Station station) {
+        return this.upStation.equals(station);
     }
 }

--- a/src/main/java/nextstep/subway/domain/Station.java
+++ b/src/main/java/nextstep/subway/domain/Station.java
@@ -1,5 +1,6 @@
 package nextstep.subway.domain;
 
+import java.util.Objects;
 import javax.persistence.Entity;
 import javax.persistence.GeneratedValue;
 import javax.persistence.GenerationType;
@@ -7,6 +8,7 @@ import javax.persistence.Id;
 
 @Entity
 public class Station {
+
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
@@ -30,5 +32,22 @@ public class Station {
 
     public String getName() {
         return name;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        Station station = (Station) o;
+        return Objects.equals(id, station.id) && Objects.equals(name, station.name);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(id, name);
     }
 }

--- a/src/main/java/nextstep/subway/domain/exception/DomainException.java
+++ b/src/main/java/nextstep/subway/domain/exception/DomainException.java
@@ -1,0 +1,8 @@
+package nextstep.subway.domain.exception;
+
+public class DomainException extends RuntimeException {
+
+    public DomainException(String message) {
+        super(message);
+    }
+}

--- a/src/main/java/nextstep/subway/domain/exception/LineException.java
+++ b/src/main/java/nextstep/subway/domain/exception/LineException.java
@@ -1,7 +1,13 @@
 package nextstep.subway.domain.exception;
 
 public class LineException extends DomainException {
+
+    public static final String ALREADY_REGISTERED_STATION_EXCEPTION = "이미 해당 노선에 등록되어있는 역은 새로운 구간의 하행역이 될 수 없습니다.";
+    public static final String NOT_EXIST_SECTION = "노선에 등록된 구간이 없습니다.";
+    public static final String NOT_ADDABLE_SECTION = "노선에 등록할 수 없는 구간입니다.";
+
     public LineException(String message) {
         super(message);
     }
+
 }

--- a/src/main/java/nextstep/subway/domain/exception/LineException.java
+++ b/src/main/java/nextstep/subway/domain/exception/LineException.java
@@ -1,0 +1,7 @@
+package nextstep.subway.domain.exception;
+
+public class LineException extends DomainException {
+    public LineException(String message) {
+        super(message);
+    }
+}

--- a/src/main/java/nextstep/subway/domain/exception/SectionException.java
+++ b/src/main/java/nextstep/subway/domain/exception/SectionException.java
@@ -1,0 +1,13 @@
+package nextstep.subway.domain.exception;
+
+public class SectionException extends DomainException {
+    public SectionException(String message) {
+        super(message);
+    }
+
+    public static class InvalidSectionException extends SectionException {
+        public InvalidSectionException() {
+            super("구간을 추가할 수 없습니다.");
+        }
+    }
+}

--- a/src/main/java/nextstep/subway/domain/exception/SectionException.java
+++ b/src/main/java/nextstep/subway/domain/exception/SectionException.java
@@ -1,11 +1,15 @@
 package nextstep.subway.domain.exception;
 
 public class SectionException extends DomainException {
+
+    public static final String INVALID_DISTANCE = "구간의 거리는 0보다 커야 합니다.";
+
     public SectionException(String message) {
         super(message);
     }
 
     public static class InvalidSectionException extends SectionException {
+
         public InvalidSectionException() {
             super("구간을 추가할 수 없습니다.");
         }

--- a/src/main/java/nextstep/subway/domain/exception/StationException.java
+++ b/src/main/java/nextstep/subway/domain/exception/StationException.java
@@ -1,0 +1,7 @@
+package nextstep.subway.domain.exception;
+
+public class StationException extends DomainException {
+    public StationException(String message) {
+        super(message);
+    }
+}

--- a/src/main/java/nextstep/subway/ui/ControllerExceptionHandler.java
+++ b/src/main/java/nextstep/subway/ui/ControllerExceptionHandler.java
@@ -1,5 +1,7 @@
 package nextstep.subway.ui;
 
+import nextstep.subway.applicaion.exception.ApplicationException;
+import nextstep.subway.domain.exception.DomainException;
 import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.ControllerAdvice;
@@ -10,5 +12,15 @@ public class ControllerExceptionHandler {
     @ExceptionHandler(DataIntegrityViolationException.class)
     public ResponseEntity<Void> handleIllegalArgsException(DataIntegrityViolationException e) {
         return ResponseEntity.badRequest().build();
+    }
+
+    @ExceptionHandler(ApplicationException.class)
+    public ResponseEntity<ApplicationException> handleApplicationException(ApplicationException e) {
+        return ResponseEntity.status(e.getStatus()).body(e);
+    }
+
+    @ExceptionHandler(DomainException.class)
+    public ResponseEntity<String> handleDomainException(DomainException e) {
+        return ResponseEntity.badRequest().body(e.getMessage());
     }
 }

--- a/src/main/java/nextstep/subway/ui/LineController.java
+++ b/src/main/java/nextstep/subway/ui/LineController.java
@@ -13,7 +13,7 @@ import java.util.List;
 @RestController
 @RequestMapping("/lines")
 public class LineController {
-    private LineService lineService;
+    private final LineService lineService;
 
     public LineController(LineService lineService) {
         this.lineService = lineService;

--- a/src/main/java/nextstep/subway/ui/StationController.java
+++ b/src/main/java/nextstep/subway/ui/StationController.java
@@ -11,7 +11,7 @@ import java.util.List;
 
 @RestController
 public class StationController {
-    private StationService stationService;
+    private final StationService stationService;
 
     public StationController(StationService stationService) {
         this.stationService = stationService;

--- a/src/test/java/nextstep/subway/acceptance/LineSectionAcceptanceTest.java
+++ b/src/test/java/nextstep/subway/acceptance/LineSectionAcceptanceTest.java
@@ -65,18 +65,12 @@ class LineSectionAcceptanceTest extends AcceptanceTest {
     @Test
     void addLineSectionInMiddle() {
         // given
-        // 강남역, 양재역
         Long 정자역 = 지하철역_생성_요청("정자역").jsonPath().getLong("id");
         Long 판교역 = 지하철역_생성_요청("판교역").jsonPath().getLong("id");
         지하철_노선에_지하철_구간_생성_요청(신분당선, createSectionCreateParams(양재역, 정자역));
-        // 양재역, 정자역
-        // 강남역, 양재역, 정자역
 
         // when
-        지하철_노선에_지하철_구간_생성_요청(신분당선, createSectionCreateParams(양재역, 판교역));
-        // 강남역, 양재역, 정자역
-        // 강남역, 양재역, 판교역, 정자역
-        // 강남역, 양재역, 정자역, 판교역
+        지하철_노선에_지하철_구간_생성_요청(신분당선, createSectionCreateParams(양재역, 판교역, 6));
 
         // then
         ExtractableResponse<Response> response = 지하철_노선_조회_요청(신분당선);
@@ -122,7 +116,20 @@ class LineSectionAcceptanceTest extends AcceptanceTest {
         Map<String, String> params = new HashMap<>();
         params.put("upStationId", upStationId + "");
         params.put("downStationId", downStationId + "");
-        params.put("distance", 6 + "");
+        params.put("distance", 10 + "");
         return params;
     }
+
+    private Map<String, String> createSectionCreateParams(Long upStationId, Long downStationId,
+        Integer distance) {
+        Map<String, String> params = new HashMap<>();
+        params.put("upStationId", upStationId + "");
+        params.put("downStationId", downStationId + "");
+        if (distance == null) {
+            distance = 10;
+        }
+        params.put("distance", distance + "");
+        return params;
+    }
+
 }

--- a/src/test/java/nextstep/subway/acceptance/LineSectionAcceptanceTest.java
+++ b/src/test/java/nextstep/subway/acceptance/LineSectionAcceptanceTest.java
@@ -80,6 +80,113 @@ class LineSectionAcceptanceTest extends AcceptanceTest {
     }
 
     /**
+     * When 기존에 같은 상행역으로 지하철 노선의 마지막이 아닌 중간에 구간 추가를 요청하면
+     * Then 에러가 발생한다
+     */
+    @DisplayName("지하철 노선에 중간에 같은 하행역 구간을 등록하면 에러가 발생한다")
+    @Test
+    void addLineSectionInMiddleWithSameUpStation() {
+        // when
+        ExtractableResponse<Response> response = 지하철_노선에_지하철_구간_생성_요청(신분당선,
+            createSectionCreateParams(강남역, 양재역));
+
+        // then
+        assertThat(response.statusCode()).isEqualTo(HttpStatus.BAD_REQUEST.value());
+    }
+
+    /**
+     * Given 지하철 역을 생성하고
+     * When 지하철 노선의 처음 구간 추가를 요청 하면
+     * Then 노선에 새로운 구간이 추가된다
+     */
+    @DisplayName("지하철 노선에 처음에 구간을 등록")
+    @Test
+    void addLineSectionAtFirst() {
+        // given
+        // 강남역 양재역
+        Long 정자역 = 지하철역_생성_요청("정자역").jsonPath().getLong("id");
+
+        // when
+        // 강남역 정자역 양재역
+        지하철_노선에_지하철_구간_생성_요청(신분당선, createSectionCreateParams(정자역, 강남역));
+
+        // then
+        ExtractableResponse<Response> response = 지하철_노선_조회_요청(신분당선);
+        assertThat(response.statusCode()).isEqualTo(HttpStatus.OK.value());
+        assertThat(response.jsonPath().getList("stations.id", Long.class)).containsExactly(정자역, 강남역,
+            양재역);
+    }
+
+    /**
+     * When 기존에 같은 상행역으로 지하철 노선의 처음 구간 추가를 요청하면
+     * Then 에러가 발생한다
+     */
+    @DisplayName("지하철 노선에 처음에 같은 상행역 구간을 등록하면 에러가 발생한다")
+    @Test
+    void addLineSectionAtFirstWithSameUpStation() {
+        // when
+        ExtractableResponse<Response> response = 지하철_노선에_지하철_구간_생성_요청(신분당선,
+            createSectionCreateParams(강남역, 강남역, 6));
+
+        // then
+        assertThat(response.statusCode()).isEqualTo(HttpStatus.BAD_REQUEST.value());
+    }
+
+    /**
+     * Give 지하철 역을 생성하고
+     * When 지하철 노선의 마지막 구간 추가를 요청 하면
+     * Then 노선에 새로운 구간이 추가된다
+     */
+    @DisplayName("지하철 노선에 마지막에 구간을 등록")
+    @Test
+    void addLineSectionAtLast() {
+        // given
+        Long 정자역 = 지하철역_생성_요청("정자역").jsonPath().getLong("id");
+
+        // when
+        지하철_노선에_지하철_구간_생성_요청(신분당선, createSectionCreateParams(양재역, 정자역));
+
+        // then
+        ExtractableResponse<Response> response = 지하철_노선_조회_요청(신분당선);
+        assertThat(response.statusCode()).isEqualTo(HttpStatus.OK.value());
+        assertThat(response.jsonPath().getList("stations.id", Long.class)).containsExactly(강남역, 양재역,
+            정자역);
+    }
+
+    /**
+     * When 기존에 같은 하행역으로 지하철 노선의 마지막 구간 추가를 요청하면
+     * Then 에러가 발생한다
+     */
+    @DisplayName("지하철 노선에 마지막에 같은 하행역 구간을 등록하면 에러가 발생한다")
+    @Test
+    void addLineSectionAtLastWithSameDownStation() {
+        // when
+        ExtractableResponse<Response> response = 지하철_노선에_지하철_구간_생성_요청(신분당선,
+            createSectionCreateParams(양재역, 양재역, 6));
+
+        // then
+        assertThat(response.statusCode()).isEqualTo(HttpStatus.BAD_REQUEST.value());
+    }
+
+    /**
+     * When 지하철 노선에 새로운 구간 추가를 요청 할 때 기존 구간의 거리보다 길거나 같으면
+     * Then 에러가 발생한다
+     */
+    @DisplayName("지하철 노선에 새로운 구간 추가 시 기존 구간의 거리보다 길거나 같으면 에러가 발생한다")
+    @Test
+    void addLineSectionWithSameOrLongerDistance() {
+        // given
+        Long 정자역 = 지하철역_생성_요청("정자역").jsonPath().getLong("id");
+
+        // when
+        ExtractableResponse<Response> response = 지하철_노선에_지하철_구간_생성_요청(신분당선,
+            createSectionCreateParams(강남역, 정자역));
+
+        // then
+        assertThat(response.statusCode()).isEqualTo(HttpStatus.BAD_REQUEST.value());
+    }
+
+    /**
      * Given 지하철 노선에 새로운 구간 추가를 요청 하고
      * When 지하철 노선의 마지막 구간 제거를 요청 하면
      * Then 노선에 구간이 제거된다

--- a/src/test/java/nextstep/subway/acceptance/LineSectionAcceptanceTest.java
+++ b/src/test/java/nextstep/subway/acceptance/LineSectionAcceptanceTest.java
@@ -1,21 +1,24 @@
 package nextstep.subway.acceptance;
 
+import static nextstep.subway.acceptance.LineSteps.지하철_노선_생성_요청;
+import static nextstep.subway.acceptance.LineSteps.지하철_노선_조회_요청;
+import static nextstep.subway.acceptance.LineSteps.지하철_노선에_지하철_구간_생성_요청;
+import static nextstep.subway.acceptance.LineSteps.지하철_노선에_지하철_구간_제거_요청;
+import static nextstep.subway.acceptance.StationSteps.지하철역_생성_요청;
+import static org.assertj.core.api.Assertions.assertThat;
+
 import io.restassured.response.ExtractableResponse;
 import io.restassured.response.Response;
+import java.util.HashMap;
+import java.util.Map;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.http.HttpStatus;
 
-import java.util.HashMap;
-import java.util.Map;
-
-import static nextstep.subway.acceptance.LineSteps.*;
-import static nextstep.subway.acceptance.StationSteps.지하철역_생성_요청;
-import static org.assertj.core.api.Assertions.assertThat;
-
 @DisplayName("지하철 구간 관리 기능")
 class LineSectionAcceptanceTest extends AcceptanceTest {
+
     private Long 신분당선;
 
     private Long 강남역;
@@ -44,12 +47,42 @@ class LineSectionAcceptanceTest extends AcceptanceTest {
     void addLineSection() {
         // when
         Long 정자역 = 지하철역_생성_요청("정자역").jsonPath().getLong("id");
-        지하철_노선에_지하철_구간_생성_요청(신분당선, createSectionCreateParams(양재역, 정자역));
+        ExtractableResponse<Response> test = 지하철_노선에_지하철_구간_생성_요청(신분당선,
+            createSectionCreateParams(양재역, 정자역));
 
         // then
         ExtractableResponse<Response> response = 지하철_노선_조회_요청(신분당선);
         assertThat(response.statusCode()).isEqualTo(HttpStatus.OK.value());
-        assertThat(response.jsonPath().getList("stations.id", Long.class)).containsExactly(강남역, 양재역, 정자역);
+        assertThat(response.jsonPath().getList("stations.id", Long.class)).containsExactly(강남역, 양재역,
+            정자역);
+    }
+
+    /**
+     * When 지하철 노선의 마지막이 아닌 중간에 구간 추가를 요청 하면
+     * Then 노선에 새로운 구간이 추가된다
+     */
+    @DisplayName("지하철 노선에 중간에 구간을 등록")
+    @Test
+    void addLineSectionInMiddle() {
+        // given
+        // 강남역, 양재역
+        Long 정자역 = 지하철역_생성_요청("정자역").jsonPath().getLong("id");
+        Long 판교역 = 지하철역_생성_요청("판교역").jsonPath().getLong("id");
+        지하철_노선에_지하철_구간_생성_요청(신분당선, createSectionCreateParams(양재역, 정자역));
+        // 양재역, 정자역
+        // 강남역, 양재역, 정자역
+
+        // when
+        지하철_노선에_지하철_구간_생성_요청(신분당선, createSectionCreateParams(양재역, 판교역));
+        // 강남역, 양재역, 정자역
+        // 강남역, 양재역, 판교역, 정자역
+        // 강남역, 양재역, 정자역, 판교역
+
+        // then
+        ExtractableResponse<Response> response = 지하철_노선_조회_요청(신분당선);
+        assertThat(response.statusCode()).isEqualTo(HttpStatus.OK.value());
+        assertThat(response.jsonPath().getList("stations.id", Long.class)).containsExactly(강남역, 양재역,
+            판교역, 정자역);
     }
 
     /**
@@ -70,7 +103,8 @@ class LineSectionAcceptanceTest extends AcceptanceTest {
         // then
         ExtractableResponse<Response> response = 지하철_노선_조회_요청(신분당선);
         assertThat(response.statusCode()).isEqualTo(HttpStatus.OK.value());
-        assertThat(response.jsonPath().getList("stations.id", Long.class)).containsExactly(강남역, 양재역);
+        assertThat(response.jsonPath().getList("stations.id", Long.class)).containsExactly(강남역,
+            양재역);
     }
 
     private Map<String, String> createLineCreateParams(Long upStationId, Long downStationId) {

--- a/src/test/java/nextstep/subway/unit/Fixtures.java
+++ b/src/test/java/nextstep/subway/unit/Fixtures.java
@@ -24,7 +24,8 @@ public class Fixtures {
 
     public static class SectionFixture {
 
-        public static Section section(Line line, Station upStation, Station downStation, int distance) {
+        public static Section section(Line line, Station upStation, Station downStation,
+            int distance, int orderNo) {
             if (upStation == null) {
                 upStation = StationFixture.station(1L, "강남역");
             }
@@ -37,8 +38,11 @@ public class Fixtures {
             if (distance == 0) {
                 distance = 10;
             }
+            if (orderNo == 0) {
+                orderNo = 1;
+            }
 
-            return new Section(line, upStation, downStation, distance);
+            return new Section(line, upStation, downStation, distance, orderNo);
         }
     }
 

--- a/src/test/java/nextstep/subway/unit/Fixtures.java
+++ b/src/test/java/nextstep/subway/unit/Fixtures.java
@@ -24,8 +24,7 @@ public class Fixtures {
 
     public static class SectionFixture {
 
-        public static Section section(Line line, Station upStation, Station downStation,
-            int distance, int orderNo) {
+        public static Section section(Line line, Station upStation, Station downStation, Integer distance, Boolean head, Boolean tail) {
             if (upStation == null) {
                 upStation = StationFixture.station(1L, "강남역");
             }
@@ -35,14 +34,20 @@ public class Fixtures {
             if (line == null) {
                 line = LineFixture.line(1L, "2호선", "green");
             }
-            if (distance == 0) {
+            if (distance == null) {
                 distance = 10;
             }
-            if (orderNo == 0) {
-                orderNo = 1;
+
+            if (head == null) {
+                head = false;
             }
 
-            return new Section(line, upStation, downStation, distance, orderNo);
+            if (tail == null) {
+                tail = false;
+            }
+
+
+            return new Section(line, upStation, downStation, distance, head, tail);
         }
     }
 

--- a/src/test/java/nextstep/subway/unit/LineServiceMockTest.java
+++ b/src/test/java/nextstep/subway/unit/LineServiceMockTest.java
@@ -51,6 +51,6 @@ public class LineServiceMockTest {
         verify(lineRepository).findById(1L);
         verify(stationService).findById(upStationId);
         verify(stationService).findById(downStationId);
-        assertThat(lineService.findLineById(1L)).isNotNull();
+        assertThat(lineService.findById(1L)).isNotNull();
     }
 }

--- a/src/test/java/nextstep/subway/unit/LineTest.java
+++ b/src/test/java/nextstep/subway/unit/LineTest.java
@@ -4,10 +4,8 @@ import static org.assertj.core.api.AssertionsForInterfaceTypes.assertThat;
 
 import java.util.Set;
 import nextstep.subway.domain.Line;
-import nextstep.subway.domain.Section;
 import nextstep.subway.domain.Station;
 import nextstep.subway.unit.Fixtures.LineFixture;
-import nextstep.subway.unit.Fixtures.SectionFixture;
 import nextstep.subway.unit.Fixtures.StationFixture;
 import org.junit.jupiter.api.Test;
 
@@ -26,10 +24,8 @@ class LineTest {
         Line line = LineFixture.line(1L, "2호선", "green");
         Station upStation = StationFixture.station(1L, "강남역");
         Station downStation = StationFixture.station(2L, "양재역");
-        Section section = SectionFixture.section(line, upStation, downStation, 10);
-
         // when
-        line.addSection(section);
+        line.addSection(upStation, downStation, 10);
         // then
         assertThat(line.getSections()).isNotEmpty();
     }
@@ -49,8 +45,7 @@ class LineTest {
         Line line = LineFixture.line(1L, "2호선", "green");
         Station upStation = StationFixture.station(1L, "강남역");
         Station downStation = StationFixture.station(2L, "양재역");
-        Section section = SectionFixture.section(line, upStation, downStation, 10);
-        line.addSection(section);
+        line.addSection(upStation, downStation, 10);
 
         // when
         Set<Station> stations = line.getStations();
@@ -74,11 +69,10 @@ class LineTest {
         Line line = LineFixture.line(1L, "2호선", "green");
         Station upStation = StationFixture.station(1L, "강남역");
         Station downStation = StationFixture.station(2L, "양재역");
-        Section section = SectionFixture.section(line, upStation, downStation, 10);
-        line.addSection(section);
+        line.addSection(upStation, downStation, 10);
 
         // when
-        line.removeSection(section);
+        line.removeSection(line.getSections().size() - 1);
         // then
         assertThat(line.getSections()).isEmpty();
     }

--- a/src/test/java/nextstep/subway/unit/LineTest.java
+++ b/src/test/java/nextstep/subway/unit/LineTest.java
@@ -2,6 +2,7 @@ package nextstep.subway.unit;
 
 import static org.assertj.core.api.AssertionsForInterfaceTypes.assertThat;
 
+import java.util.List;
 import java.util.Set;
 import nextstep.subway.domain.Line;
 import nextstep.subway.domain.Section;
@@ -114,4 +115,45 @@ class LineTest {
         assertThat(secondSection.getDistance()).isEqualTo(4);
         assertThat(thirdSection.getDistance()).isEqualTo(2);
     }
+
+
+    /***
+     * Given 지하철 노선을 생성하고
+     * Given 지하철역 두 개를 생성하고
+     * Given 지하철 구간을 생성한다
+     * Given 지하철 노선에 지하철 구간을 추가한다
+     * When 지하철 노선 중간에 지하철 구간이 2개 추가되면
+     * Then 지하철 노선에 지하철 구간이 2개 추가된다.
+     */
+    @Test
+    void getSections() {
+        // given
+        Line line = LineFixture.line(1L, "2호선", "green");
+        Station upStation = StationFixture.station(1L, "강남역");
+        Station downStation = StationFixture.station(2L, "양재역");
+        line.addSection(upStation, downStation, 10);
+        // 중간 추가
+        Station middleStation = StationFixture.station(3L, "정자역");
+        line.addSection(upStation, middleStation, 4);
+
+        // 맨 앞 추가
+        Station newUpStation = StationFixture.station(4L, "판교역");
+        line.addSection(newUpStation, upStation, 4);
+
+        // 맨 뒤 추가
+        Station newDownStation = StationFixture.station(5L, "신사역");
+        line.addSection(downStation, newDownStation, 4);
+
+        // when
+        List<Section> sections = line.getSections();
+        // then
+        assertThat(sections.size()).isEqualTo(4);
+        assertThat(sections.get(0).getUpStation()).isEqualTo(newUpStation);
+        assertThat(sections.get(0).getDownStation()).isEqualTo(upStation);
+        assertThat(sections.get(1).getUpStation()).isEqualTo(upStation);
+        assertThat(sections.get(1).getDownStation()).isEqualTo(middleStation);
+        assertThat(sections.get(2).getUpStation()).isEqualTo(middleStation);
+        assertThat(sections.get(2).getDownStation()).isEqualTo(downStation);
+    }
+
 }

--- a/src/test/java/nextstep/subway/unit/LineTest.java
+++ b/src/test/java/nextstep/subway/unit/LineTest.java
@@ -4,6 +4,7 @@ import static org.assertj.core.api.AssertionsForInterfaceTypes.assertThat;
 
 import java.util.Set;
 import nextstep.subway.domain.Line;
+import nextstep.subway.domain.Section;
 import nextstep.subway.domain.Station;
 import nextstep.subway.unit.Fixtures.LineFixture;
 import nextstep.subway.unit.Fixtures.StationFixture;
@@ -75,5 +76,42 @@ class LineTest {
         line.removeSection(line.getSections().size() - 1);
         // then
         assertThat(line.getSections()).isEmpty();
+    }
+
+    /***
+     * Given 지하철 노선을 생성하고
+     * Given 지하철역 두 개를 생성하고
+     * Given 지하철 구간을 생성한다
+     * Given 지하철 노선에 지하철 구간을 추가한다
+     * When 지하철 노선 중간에 지하철 구간이 2개 추가되면
+     * Then 지하철 노선에 지하철 구간이 2개 추가된다.
+     */
+    @Test
+    void addSectionInMiddle() {
+        // given
+        Line line = LineFixture.line(1L, "2호선", "green");
+        Station upStation = StationFixture.station(1L, "강남역");
+        Station downStation = StationFixture.station(2L, "양재역");
+        line.addSection(upStation, downStation, 10);
+        Station middleStation = StationFixture.station(3L, "정자역");
+
+        // when
+        line.addSection(upStation, middleStation, 4);
+
+        Station downStation2 = StationFixture.station(4L, "판교역");
+        line.addSection(middleStation, downStation2, 4);
+        // then
+        Section firstSection = line.getSections().get(0);
+        Section secondSection = line.getSections().get(1);
+        Section thirdSection = line.getSections().get(2);
+
+        assertThat(firstSection.getDownStation()).isEqualTo(middleStation);
+        assertThat(secondSection.getDownStation()).isEqualTo(downStation2);
+        assertThat(thirdSection.getDownStation()).isEqualTo(downStation);
+        assertThat(line.getSections().size()).isEqualTo(3);
+
+        assertThat(firstSection.getDistance()).isEqualTo(4);
+        assertThat(secondSection.getDistance()).isEqualTo(4);
+        assertThat(thirdSection.getDistance()).isEqualTo(2);
     }
 }


### PR DESCRIPTION
안녕하세요. 2주차 1단계 미션 PR 올립니다.

이 번 PR에서는 구간 추가(중간에 추가) 기능을 개발하면서 고려했던 지점을 적어보았습니다.
1. `Section` 에 `OrderNo` 이라는 컬럼을 추가하게 되었습니다.
  - `orderNo`을 추가하게 된 이유는, `Line`의 연관 관계인 `Sections`를 가져올 때 `Section`을 중간에 추가하게 되면 어떤 기준으로 정렬해야하는지 애매해서 입니다.
2. `Line`의 `getSections` 를 `orderNo` 기준으로 `ascending` 하여 리턴하도록 구현하였습니다
  - 이 때 `getSections.add()`(List의 add 메소드) 를 호출하고 있는 곳에서 Hibernate의 dirty checking 으로 `Section`이 `insert` 되지 않았습니다. 그래서 기존 인수 테스트가 실패했고 실패하지 않도록 `Line`의 `getSections.add()`(List의 add 메소드)를 호출하고 있는 부분을 `addSection` 메소드를 호출하도록 리팩토링 하였습니다.
3. 모든 외부 클라이언트 코드는 `Line` 의 `addSection`을 호출 하는 대신,  `addSection` 메소드의 내부에서 argument가 어떤 요구사항에 부합하는지에 따라 맨 끝에 추가 또는 중간에 추가 하도록 구현하였습니다.

피드백 주시면 감사드리겠습니다!