### PR TITLE
🚀 2단계 - 구간 제거 요구사항 반영

### DIFF
--- a/src/main/java/nextstep/subway/applicaion/LineService.java
+++ b/src/main/java/nextstep/subway/applicaion/LineService.java
@@ -12,7 +12,6 @@ import nextstep.subway.domain.Line;
 import nextstep.subway.domain.LineRepository;
 import nextstep.subway.domain.Section;
 import nextstep.subway.domain.Station;
-import nextstep.subway.domain.exception.LineException;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -48,12 +47,14 @@ public class LineService {
 
     public LineResponse findById(Long id) {
         return createLineResponse(
-            lineRepository.findById(id).orElseThrow(() -> new BadRequestException(BadRequestException.LINE_NOT_FOUND)));
+            lineRepository.findById(id)
+                .orElseThrow(() -> new BadRequestException(BadRequestException.LINE_NOT_FOUND)));
     }
 
     @Transactional
     public void updateLine(Long id, LineRequest lineRequest) {
-        Line line = lineRepository.findById(id).orElseThrow(() -> new BadRequestException(BadRequestException.LINE_NOT_FOUND));
+        Line line = lineRepository.findById(id)
+            .orElseThrow(() -> new BadRequestException(BadRequestException.LINE_NOT_FOUND));
 
         if (lineRequest.getName() != null) {
             line.setName(lineRequest.getName());
@@ -72,7 +73,8 @@ public class LineService {
     public void addSection(Long lineId, SectionRequest sectionRequest) {
         Station upStation = stationService.findById(sectionRequest.getUpStationId());
         Station downStation = stationService.findById(sectionRequest.getDownStationId());
-        Line line = lineRepository.findById(lineId).orElseThrow(() -> new BadRequestException(BadRequestException.LINE_NOT_FOUND));
+        Line line = lineRepository.findById(lineId)
+            .orElseThrow(() -> new BadRequestException(BadRequestException.LINE_NOT_FOUND));
 
         line.addSection(upStation, downStation, sectionRequest.getDistance());
     }
@@ -104,14 +106,9 @@ public class LineService {
 
     @Transactional
     public void deleteSection(Long lineId, Long stationId) {
-        Line line = lineRepository.findById(lineId).orElseThrow(() -> new BadRequestException(BadRequestException.LINE_NOT_FOUND));
+        Line line = lineRepository.findById(lineId)
+            .orElseThrow(() -> new BadRequestException(BadRequestException.LINE_NOT_FOUND));
         Station station = stationService.findById(stationId);
-
-        if (!line.getSections().get(line.getSections().size() - 1).getDownStation()
-            .equals(station)) {
-            throw new IllegalArgumentException();
-        }
-
-        line.removeSection(line.getSections().size() - 1);
+        line.removeSection(station);
     }
 }

--- a/src/main/java/nextstep/subway/domain/exception/LineException.java
+++ b/src/main/java/nextstep/subway/domain/exception/LineException.java
@@ -5,6 +5,7 @@ public class LineException extends DomainException {
     public static final String ALREADY_REGISTERED_STATION_EXCEPTION = "이미 해당 노선에 등록되어있는 역은 새로운 구간의 하행역이 될 수 없습니다.";
     public static final String NOT_EXIST_SECTION = "노선에 등록된 구간이 없습니다.";
     public static final String NOT_ADDABLE_SECTION = "노선에 등록할 수 없는 구간입니다.";
+    public static final String NOT_REMOVE_EXCEPTION = "노선을 삭제할 수 없습니다.";
 
     public LineException(String message) {
         super(message);

--- a/src/main/java/nextstep/subway/domain/exception/LineException.java
+++ b/src/main/java/nextstep/subway/domain/exception/LineException.java
@@ -6,6 +6,7 @@ public class LineException extends DomainException {
     public static final String NOT_EXIST_SECTION = "노선에 등록된 구간이 없습니다.";
     public static final String NOT_ADDABLE_SECTION = "노선에 등록할 수 없는 구간입니다.";
     public static final String NOT_REMOVE_EXCEPTION = "노선을 삭제할 수 없습니다.";
+    public static final String NOT_EXIST_STATION = "노선에 등록되지 않은 역입니다.";
 
     public LineException(String message) {
         super(message);

--- a/src/test/java/nextstep/subway/acceptance/LineSectionAcceptanceTest.java
+++ b/src/test/java/nextstep/subway/acceptance/LineSectionAcceptanceTest.java
@@ -224,13 +224,13 @@ class LineSectionAcceptanceTest extends AcceptanceTest {
         지하철_노선에_지하철_구간_생성_요청(신분당선, createSectionCreateParams(양재역, 판교역));
 
         // when
-        지하철_노선에_지하철_구간_제거_요청(신분당선, 정자역);
+        지하철_노선에_지하철_구간_제거_요청(신분당선, 판교역);
 
         // then
         ExtractableResponse<Response> response = 지하철_노선_조회_요청(신분당선);
         assertThat(response.statusCode()).isEqualTo(HttpStatus.OK.value());
-        assertThat(response.jsonPath().getList("stations.id", Long.class)).containsExactly(강남역,
-            양재역, 판교역);
+        assertThat(response.jsonPath().getList("stations.id", Long.class)).containsExactly(강남역, 양재역,
+            정자역);
     }
 
     private Map<String, String> createLineCreateParams(Long upStationId, Long downStationId) {

--- a/src/test/java/nextstep/subway/acceptance/LineSectionAcceptanceTest.java
+++ b/src/test/java/nextstep/subway/acceptance/LineSectionAcceptanceTest.java
@@ -208,6 +208,31 @@ class LineSectionAcceptanceTest extends AcceptanceTest {
             양재역);
     }
 
+
+    /**
+     * Given 지하철 노선에 새로운 구간 추가를 요청 하고
+     * When 지하철 노선의 중간 구간 제거를 요청 하면
+     * Then 노선에 구간이 제거된다
+     */
+    @DisplayName("지하철 노선에 중간에 구간을 제거")
+    @Test
+    void removeLineSectionInMiddle() {
+        // given
+        Long 정자역 = 지하철역_생성_요청("정자역").jsonPath().getLong("id");
+        Long 판교역 = 지하철역_생성_요청("판교역").jsonPath().getLong("id");
+        지하철_노선에_지하철_구간_생성_요청(신분당선, createSectionCreateParams(양재역, 정자역));
+        지하철_노선에_지하철_구간_생성_요청(신분당선, createSectionCreateParams(양재역, 판교역));
+
+        // when
+        지하철_노선에_지하철_구간_제거_요청(신분당선, 정자역);
+
+        // then
+        ExtractableResponse<Response> response = 지하철_노선_조회_요청(신분당선);
+        assertThat(response.statusCode()).isEqualTo(HttpStatus.OK.value());
+        assertThat(response.jsonPath().getList("stations.id", Long.class)).containsExactly(강남역,
+            양재역, 판교역);
+    }
+
     private Map<String, String> createLineCreateParams(Long upStationId, Long downStationId) {
         Map<String, String> lineCreateParams;
         lineCreateParams = new HashMap<>();

--- a/src/test/java/nextstep/subway/unit/LineTest.java
+++ b/src/test/java/nextstep/subway/unit/LineTest.java
@@ -156,4 +156,36 @@ class LineTest {
         assertThat(sections.get(2).getDownStation()).isEqualTo(downStation);
     }
 
+    /***
+     * Given 지하철 노선을 생성하고
+     * Given 지하철역 두 개를 생성하고
+     * Given 지하철 구간을 생성한다
+     * Given 지하철 노선에 지하철 구간을 추가한다
+     * Given 지하철역 한 개를 생성하고
+     * Given 지하철 노선에 지하철 구간을 추가한다
+     * When 지하철 노선을 삭제하면
+     * Then 지하철 노선이 삭제된다
+     */
+    @Test
+    void removeSectionInMiddle() {
+        // given
+        Line line = LineFixture.line(1L, "2호선", "green");
+        Station 강남역 = StationFixture.station(1L, "강남역");
+        Station 양재역 = StationFixture.station(2L, "양재역");
+        line.addSection(강남역, 양재역, 10);
+        Station 정자역 = StationFixture.station(3L, "정자역");
+        line.addSection(강남역, 정자역, 4);
+        Station 판교역 = StationFixture.station(4L, "판교역");
+        line.addSection(정자역, 판교역, 4);
+        // when
+        line.removeSection(정자역);
+        // then
+        List<Section> result = line.getSections();
+        assertThat(result.size()).isEqualTo(2);
+        assertThat(result.get(0).getUpStation()).isEqualTo(정자역);
+        assertThat(result.get(0).getDownStation()).isEqualTo(판교역);
+        assertThat(result.get(1).getUpStation()).isEqualTo(판교역);
+        assertThat(result.get(1).getDownStation()).isEqualTo(양재역);
+    }
+
 }

--- a/src/test/java/nextstep/subway/unit/LineTest.java
+++ b/src/test/java/nextstep/subway/unit/LineTest.java
@@ -72,9 +72,9 @@ class LineTest {
         Station upStation = StationFixture.station(1L, "강남역");
         Station downStation = StationFixture.station(2L, "양재역");
         line.addSection(upStation, downStation, 10);
-
+        List<Section> sections = line.getSections();
         // when
-        line.removeSection(line.getSections().size() - 1);
+        line.removeSection(sections.get(0).getUpStation());
         // then
         assertThat(line.getSections()).isEmpty();
     }
@@ -193,4 +193,42 @@ class LineTest {
         assertThat(result.get(1).getDownStation()).isEqualTo(양재역);
     }
 
+
+    /***
+     * Given 지하철 노선을 생성하고
+     * Given 지하철역 두 개를 생성하고
+     * Given 지하철 구간을 생성한다
+     * Given 지하철 노선에 지하철 구간을 추가한다
+     * Given 지하철역 한 개를 생성하고
+     * Given 지하철 노선에 지하철 구간을 추가한다
+     * When 지하철 노선을 삭제하면
+     * Then 지하철 노선이 삭제된다
+     */
+    @Test
+    void removeSectionInMiddleByUpStation() {
+        // given
+        Line line = LineFixture.line(1L, "2호선", "green");
+        Station 강남역 = StationFixture.station(1L, "강남역");
+        Station 양재역 = StationFixture.station(2L, "양재역");
+        line.addSection(강남역, 양재역, 10);
+        Station 정자역 = StationFixture.station(3L, "정자역");
+        line.addSection(강남역, 정자역, 4);
+        assertThat(line.getSections().get(0).getDistance()).isEqualTo(4);
+        assertThat(line.getSections().get(1).getDistance()).isEqualTo(6);
+        Station 판교역 = StationFixture.station(4L, "판교역");
+        line.addSection(정자역, 판교역, 4);
+        assertThat(line.getSections().get(0).getDistance()).isEqualTo(4);
+        assertThat(line.getSections().get(1).getDistance()).isEqualTo(4);
+        assertThat(line.getSections().get(2).getDistance()).isEqualTo(2);
+
+        // when
+        line.removeSection(강남역);
+        // then
+        List<Section> result = line.getSections();
+        assertThat(result.size()).isEqualTo(2);
+        assertThat(result.get(0).getUpStation()).isEqualTo(정자역);
+        assertThat(result.get(0).getDownStation()).isEqualTo(판교역);
+        assertThat(result.get(1).getUpStation()).isEqualTo(판교역);
+        assertThat(result.get(1).getDownStation()).isEqualTo(양재역);
+    }
 }

--- a/src/test/java/nextstep/subway/unit/LineTest.java
+++ b/src/test/java/nextstep/subway/unit/LineTest.java
@@ -175,8 +175,13 @@ class LineTest {
         line.addSection(강남역, 양재역, 10);
         Station 정자역 = StationFixture.station(3L, "정자역");
         line.addSection(강남역, 정자역, 4);
+        assertThat(line.getSections().get(0).getDistance()).isEqualTo(4);
+        assertThat(line.getSections().get(1).getDistance()).isEqualTo(6);
         Station 판교역 = StationFixture.station(4L, "판교역");
         line.addSection(정자역, 판교역, 4);
+        assertThat(line.getSections().get(0).getDistance()).isEqualTo(4);
+        assertThat(line.getSections().get(1).getDistance()).isEqualTo(4);
+        assertThat(line.getSections().get(2).getDistance()).isEqualTo(2);
         // when
         line.removeSection(정자역);
         // then


### PR DESCRIPTION
2단계 구간 제거 요구사항 반영합니다!

삭제할 지하철역에 따라서 로직이 달라진다고 생각해서 
1. `UpStation`을 삭제하는 경우
2. `DownStation`을 삭제하는 경우
로 나누어 보았습니다.

`UpStation`을 삭제하는 경우에는 로직을 보면 항상 구간들은 `DownStation`을 가지고 있습니다.
그래서 `DownStation` 을 먼저 찾는데,  `DownStation`으로 구간을 찾았지만 없으면 `UpStation`으로 찾는데, 이 경우에는 항상 상행종점역이 되므로 상행종점역을 삭제하는 로직을 작성하였습니다.
